### PR TITLE
feat: add optional name filter to spaces list

### DIFF
--- a/docs/specifications/tools/space-management.md
+++ b/docs/specifications/tools/space-management.md
@@ -73,8 +73,13 @@ MCP tool: `wiki_spaces_list`
 
 ```
 llm-wiki spaces list
+             [<name>]             # omit for all, provide to filter
              [--format <fmt>]     # text | json (default: text)
 ```
+
+When `<name>` is omitted, lists all registered wikis.
+When `<name>` is provided, returns a list with only that wiki's info.
+If the name is not found, returns an empty list.
 
 Text (default):
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,6 +169,8 @@ pub enum SpacesAction {
     },
     /// List all registered wikis
     List {
+        /// Wiki name (omit for all)
+        name: Option<String>,
         /// Output format: text | json
         #[arg(long)]
         format: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,9 @@ fn main() -> Result<()> {
                     println!("Initial commit: create: {}", report.name);
                 }
             }
-            SpacesAction::List { format } => {
+            SpacesAction::List { name, format } => {
                 let global = config::load_global(&config_path)?;
-                let entries = ops::spaces_list(&global);
+                let entries = ops::spaces_list(&global, name.as_deref());
                 if is_json(&format) {
                     println!("{}", serde_json::to_string_pretty(&entries)?);
                 } else if entries.is_empty() {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -37,9 +37,10 @@ pub fn handle_spaces_create(server: &McpServer, args: &Map<String, Value>) -> To
     ok_text(json)
 }
 
-pub fn handle_spaces_list(server: &McpServer, _args: &Map<String, Value>) -> ToolHandlerResult {
+pub fn handle_spaces_list(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
-    let entries = ops::spaces_list(&engine.config);
+    let name = arg_str(args, "name");
+    let entries = ops::spaces_list(&engine.config, name.as_deref());
     let s = serde_json::to_string_pretty(&entries).map_err(|e| format!("{e}"))?;
     ok_text(s)
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -59,7 +59,12 @@ pub fn tool_list() -> Vec<Tool> {
         Tool::new(
             "wiki_spaces_list",
             "List all registered wiki spaces",
-            schema(json!({}), &[]),
+            schema(
+                json!({
+                    "name": opt_str("Wiki name (omit for all)"),
+                }),
+                &[],
+            ),
         ),
         Tool::new(
             "wiki_spaces_remove",

--- a/src/ops/spaces.rs
+++ b/src/ops/spaces.rs
@@ -16,8 +16,12 @@ pub fn spaces_create(
     spaces::create(path, name, description, force, set_default, config_path)
 }
 
-pub fn spaces_list(config: &GlobalConfig) -> Vec<config::WikiEntry> {
-    spaces::load_all(config)
+pub fn spaces_list(config: &GlobalConfig, name: Option<&str>) -> Vec<config::WikiEntry> {
+    let all = spaces::load_all(config);
+    match name {
+        Some(n) => all.into_iter().filter(|e| e.name == n).collect(),
+        None => all,
+    }
 }
 
 pub fn spaces_remove(name: &str, delete: bool, config_path: &Path) -> Result<()> {

--- a/tests/ops.rs
+++ b/tests/ops.rs
@@ -36,9 +36,32 @@ fn spaces_create_and_list() {
     let config_path = setup_wiki(dir.path(), "test");
 
     let global = llm_wiki::config::load_global(&config_path).unwrap();
-    let entries = ops::spaces_list(&global);
+    let entries = ops::spaces_list(&global, None);
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].name, "test");
+}
+
+#[test]
+fn spaces_list_filters_by_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "alpha");
+    let beta_path = dir.path().join("beta");
+    ops::spaces_create(&beta_path, "beta", None, false, false, &config_path).unwrap();
+
+    let global = llm_wiki::config::load_global(&config_path).unwrap();
+    let filtered = ops::spaces_list(&global, Some("beta"));
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].name, "beta");
+}
+
+#[test]
+fn spaces_list_unknown_name_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+
+    let global = llm_wiki::config::load_global(&config_path).unwrap();
+    let filtered = ops::spaces_list(&global, Some("nonexistent"));
+    assert!(filtered.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## What

add optional name filter to spaces list

## Why

With some skill we need detailled information about a space configuration (wiki root path)

## Changes
- CLI: spaces list [name]
- MCP: wiki_spaces_list { name? }
- ops::spaces_list takes Option<&str>

## Checklist

- [X] `cargo fmt && cargo clippy --all-targets`
- [X] `cargo test` — all pass
- [X] Docs updated (if applicable)
