### PR TITLE
feat: confidence field + lifecycle-aware search ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — Unreleased
+
+### Added
+
+- **Confidence field** — `confidence: 0.0–1.0` on every page; numeric tantivy fast field; legacy string values (`high` / `medium` / `low`) mapped automatically on read
+- **Lifecycle-aware search ranking** — `tweak_score` collector multiplies BM25 score by `status_multiplier × confidence`; ranking formula: `final_score = bm25 × status × confidence`
+- **`[search.status]` map in config** — flat `HashMap<String, f32>` replaces four named fields; built-in defaults (`active=1.0`, `draft=0.8`, `archived=0.3`, `unknown=0.9`); custom statuses (`verified`, `stub`, `deprecated`, …) added with no code change; per-wiki `wiki.toml` overrides individual keys (key-level merge, not all-or-nothing)
+- **`claims[].confidence` as float** — aligned with page-level confidence; was string enum `high/medium/low`; now `0.0–1.0` in `concept` and `paper` schemas
+- **`confidence: 0.5` in page scaffold** — `wiki_content_new` emits the field by default
+- **Search ranking guide** — `docs/guides/search-ranking.md` covering the formula, status map, per-wiki overrides, and custom status examples
+
 ## [0.1.1] — 2026-04-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-wiki-engine"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-wiki-engine"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Git-backed wiki engine with MCP server — bring your own LLM"

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,5 +11,6 @@ llm-wiki.
 | [ide-integration.md](ide-integration.md) | Connect to VS Code, Cursor, Windsurf, Zed, Claude Code            |
 | [multi-wiki.md](multi-wiki.md)           | Manage multiple wikis, cross-wiki search, wiki:// URIs            |
 | [custom-types.md](custom-types.md)       | Add custom page types with JSON Schema                            |
+| [search-ranking.md](search-ranking.md)   | Tune search ranking: status multipliers, custom statuses, per-wiki overrides |
 | [ci-cd.md](ci-cd.md)                     | Schema validation, index rebuild, and ingest in CI pipelines      |
 | [release.md](release.md)                 | Release process and distribution channels                         |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -96,6 +96,22 @@ is 500ms. Lower for faster feedback, higher for busy editors:
 llm-wiki config set watch.debounce_ms 300 --global
 ```
 
+### Tune search ranking
+
+Search results are scored as `bm25 × status_multiplier × confidence`.
+Adjust multipliers per-wiki in `wiki.toml` (or globally in `config.toml`):
+
+```toml
+# wiki.toml
+[search.status]
+archived = 0.0   # suppress archived pages entirely
+stub     = 0.6   # demote stubs without hiding them
+```
+
+Only declare the entries that differ from the global defaults — the rest
+are inherited automatically. See [search-ranking.md](search-ranking.md)
+for the full reference.
+
 ### Change graph output format
 
 Default is Mermaid. Switch to DOT for Graphviz:

--- a/docs/guides/search-ranking.md
+++ b/docs/guides/search-ranking.md
@@ -1,0 +1,148 @@
+---
+title: "Search Ranking"
+summary: "How llm-wiki ranks search results, and how to tune multipliers for status and custom page states."
+---
+
+# Search Ranking
+
+llm-wiki ranks results using a combined score applied **inside** the
+tantivy collector, so the top-k returned are the true top-k — not
+just the highest raw BM25 scores:
+
+```
+final_score = bm25 × status_multiplier × confidence
+```
+
+- **bm25** — term frequency / inverse document frequency score across
+  `title`, `summary`, `read_when`, `tldr`, `tags`, and body text.
+- **status_multiplier** — a float from the `[search.status]` map
+  (see below). Default `0.9` when status is absent or not in the map.
+- **confidence** — the page-level `confidence` float (default `0.5`
+  when the field is absent).
+
+## The `[search.status]` map
+
+All status multipliers live in a single flat map. Built-in entries and
+custom entries are written identically — there is no distinction:
+
+```toml
+[search.status]
+active     = 1.0
+draft      = 0.8
+archived   = 0.3
+unknown    = 0.9   # reserved fallback
+```
+
+`unknown` is a reserved key used as the fallback when a page's status
+is absent or does not appear in the map. A page with `status: unknown`
+in its frontmatter also matches this entry, which is intentional.
+
+### Built-in defaults
+
+| Status | Default multiplier | Meaning |
+|---|---|---|
+| `active` | `1.0` | Full weight |
+| `draft` | `0.8` | Slight demotion — useful but not final |
+| `archived` | `0.3` | Strong demotion — retained for reference |
+| `unknown` | `0.9` | Fallback for absent or unmapped status |
+
+## Set globally in config.toml
+
+```toml
+# ~/.llm-wiki/config.toml
+[search.status]
+active   = 1.0
+draft    = 0.8
+archived = 0.3
+unknown  = 0.9
+```
+
+The four entries above are the compiled-in defaults — you only need to
+write them if you want different values.
+
+## Override per-wiki in wiki.toml
+
+A `wiki.toml` `[search.status]` block merges **key by key** over the
+global map — it does not replace it. Only declare the entries that
+differ:
+
+```toml
+# wiki.toml (per-wiki)
+[search.status]
+archived = 0.0   # suppress archived for this wiki
+stub     = 0.6   # add a custom status
+```
+
+Resolved for that wiki:
+
+| Key | Value | Source |
+|---|---|---|
+| `active` | `1.0` | inherited from global |
+| `draft` | `0.8` | inherited from global |
+| `archived` | `0.0` | overridden by wiki |
+| `unknown` | `0.9` | inherited from global |
+| `stub` | `0.6` | added by wiki |
+
+## Add custom statuses
+
+Any status value your pages use can be given a distinct multiplier.
+No code change is required — add the entry to `config.toml` or
+`wiki.toml`:
+
+```toml
+[search.status]
+verified   = 1.0    # fully reviewed — same weight as active
+stub       = 0.6    # demote stubs without suppressing them
+deprecated = 0.1    # near-zero but still findable
+review     = 0.85   # in-review — slightly below active
+```
+
+Pages whose status does not appear in the map fall back to the
+`unknown` multiplier.
+
+### Example: demoting stubs
+
+A `stub` page should appear in results but below well-developed pages:
+
+```toml
+[search.status]
+stub = 0.6
+```
+
+A `stub + confidence 0.5` page scores `bm25 × 0.6 × 0.5`.
+An `active + confidence 0.5` page scores `bm25 × 1.0 × 0.5`.
+The active page ranks higher for the same body text.
+
+### Example: suppressing a status entirely
+
+Set the multiplier to `0.0` to exclude pages with that status from
+results:
+
+```toml
+# wiki.toml
+[search.status]
+archived = 0.0
+```
+
+Score becomes zero — the page will not appear in the top-k collector.
+
+### Example: wiki-specific review workflow
+
+A wiki where `review` pages should rank equally with `active` ones:
+
+```toml
+# wiki.toml (review wiki)
+[search.status]
+review = 1.0
+```
+
+## Note: config set cannot reach map entries
+
+`llm-wiki config set` handles scalar keys only. Status multipliers must
+be edited by hand in `config.toml` or `wiki.toml`:
+
+```toml
+# config.toml or wiki.toml
+[search.status]
+stub = 0.6
+```

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -4,15 +4,17 @@ Proposed improvements derived from the comparative analysis in `docs/analysys/`.
 Ordered by implementation priority — each item either stands alone or unblocks the
 items that follow it.
 
-| # | File | Summary | Depends on |
-|---|------|---------|------------|
-| 1 | [confidence.md](confidence.md) | Add `confidence: 0.0–1.0` to base schema; numeric tantivy field; search ranking multiplier | — |
-| 2 | [search-ranking.md](search-ranking.md) | `tweak_score` inside collector: status × confidence multipliers, true top-k ranking | #1 |
-| 3 | [backlinks.md](backlinks.md) | `backlinks: bool` on `wiki_content_read`; tantivy term query on `body_links` | — |
-| 4 | [lint.md](lint.md) | `wiki_lint` engine tool (5 deterministic rules) + skill update to call it | #1 |
-| 5 | [incremental-validation.md](incremental-validation.md) | Restrict `wiki_ingest` validation to git-changed files via `collect_changed_files` | — |
-| 6 | [redaction.md](redaction.md) | Opt-in `redact: true` on `wiki_ingest`; built-in patterns + per-wiki `wiki.toml` config | — |
-| 7 | [crystallize.md](crystallize.md) | Two-step extraction pass, confidence calibration table, post-ingest lint step in `crystallize` skill | #1, #4 |
+| #   | File                                                   | Summary                                                                                              | Depends on |
+| --- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | [confidence.md](confidence.md)                         | Add `confidence: 0.0–1.0` to base schema; numeric tantivy field; search ranking multiplier           | —          |
+| 1b  | [claims-confidence-float.md](claims-confidence-float.md) | Align `claims[].confidence` with page-level — change from string enum to float `0.0–1.0`           | #1         |
+| 2   | [search-ranking.md](search-ranking.md)                 | `tweak_score` inside collector: status × confidence multipliers, true top-k ranking                  | #1         |
+| 2b  | [search-ranking-custom-status.md](search-ranking-custom-status.md) | `status_custom` map in `SearchConfig` for arbitrary status multipliers | #2         |
+| 3   | [backlinks.md](backlinks.md)                           | `backlinks: bool` on `wiki_content_read`; tantivy term query on `body_links`                         | —          |
+| 4   | [lint.md](lint.md)                                     | `wiki_lint` engine tool (5 deterministic rules) + skill update to call it                            | #1         |
+| 5   | [incremental-validation.md](incremental-validation.md) | Restrict `wiki_ingest` validation to git-changed files via `collect_changed_files`                   | —          |
+| 6   | [redaction.md](redaction.md)                           | Opt-in `redact: true` on `wiki_ingest`; built-in patterns + per-wiki `wiki.toml` config              | —          |
+| 7   | [crystallize.md](crystallize.md)                       | Two-step extraction pass, confidence calibration table, post-ingest lint step in `crystallize` skill | #1, #4     |
 
 Items 1–2 are coupled: implement confidence first, then wire it into search ranking
 in the same pass. Items 3, 5, 6 are fully independent. Item 4 (lint) can start

--- a/docs/improvements/claims-confidence-float.md
+++ b/docs/improvements/claims-confidence-float.md
@@ -1,0 +1,166 @@
+---
+title: "claims[].confidence as float"
+summary: "Align claims[].confidence with page-level confidence — change from string enum to float 0.0–1.0."
+status: proposed
+last_updated: "2026-04-27"
+depends_on: confidence
+---
+
+# claims[].confidence as float
+
+## Problem
+
+Page-level `confidence` is now a float `0.0–1.0`. The `claims[].confidence`
+sub-field inside `concept` and `paper` schemas is still a string enum
+(`high`, `medium`, `low`). This inconsistency means:
+
+- LLMs must use two different mental models for the same word in the same file.
+- Claim-level certainty cannot be used in numeric comparisons or aggregations.
+- The frontmatter skill's guidance table (`high` / `medium` / `low`) applies
+  at the page level but not at the claim level, creating a confusing split.
+
+No existing pages use `claims[].confidence` yet, so there is no migration cost.
+
+## Goal
+
+Uniform schema: `confidence` is always a float `0.0–1.0` wherever it appears.
+
+## Solution
+
+Change `claims[].confidence` in both `schemas/concept.json` and
+`schemas/paper.json` from:
+
+```json
+"confidence": {
+  "type": "string",
+  "enum": ["high", "medium", "low"]
+}
+```
+
+to:
+
+```json
+"confidence": {
+  "type": "number",
+  "minimum": 0.0,
+  "maximum": 1.0,
+  "description": "Certainty of this claim. 0.0=speculative, 1.0=verified."
+}
+```
+
+No `default` is set — claim-level confidence remains optional (absence means
+no certainty signal was recorded, which is distinct from `0.5` neutral).
+
+**Conventional values** (same scale as page-level):
+- `0.9` — well-corroborated, multiple sources agree
+- `0.5` — single source, or source has caveats
+- `0.2` — preliminary, speculative, or contradicted by other claims
+
+There is no legacy string mapping needed for `claims[].confidence` because
+no pages exist yet.
+
+## Impact
+
+### Schemas (JSON)
+- `schemas/concept.json` — `claims[].confidence`: string enum → number
+- `schemas/paper.json` — `claims[].confidence`: string enum → number
+
+### Source code
+No Rust changes required. `claims` is an opaque array stored as text in the
+tantivy index; `claims[].confidence` is never read by the engine directly.
+The `frontmatter::confidence()` getter operates on page-level only and is
+unaffected.
+
+The schema validator in `ingest` will now reject `claims[].confidence: "high"`.
+Since no pages exist yet, this is safe.
+
+### Tests
+- `tests/default_schemas.rs` — two existing tests pass `"confidence": "high"`
+  inside a `claims` item. Both must be updated to use a float (e.g. `0.9`).
+
+### llm-wiki-skills
+Four files reference `claims[].confidence` as a string enum and must be updated:
+
+| File | Change needed |
+|------|--------------|
+| `skills/frontmatter/SKILL.md` | `### confidence` section: add float scale table; update `claims` example from `confidence: high` to `confidence: 0.9`; update anti-pattern row `confidence: high` → `confidence: 0.9` |
+| `skills/frontmatter/SKILL.md` | `### claims` example block: `confidence: high` → `confidence: 0.9` |
+| `skills/ingest/SKILL.md` | Any claim example using `confidence: high` |
+| `skills/frontmatter/references/type-taxonomy.md` | Prose mentioning `confidence` on claim objects |
+
+### Specification docs
+- `docs/specifications/model/types/concept.md` — Claims table: change
+  `confidence` row from `string / high,medium,low` to `float 0.0–1.0`;
+  update claim example to `confidence: 0.9`; remove the note distinguishing
+  claim vs page confidence types (they are now the same type).
+- `docs/specifications/model/types/source.md` — same (references concept.md
+  for claim format, but template example also uses `confidence: high`).
+
+## Branch & PR — `llm-wiki`
+
+Implemented as part of `feat/confidence-search-ranking`. No separate branch
+needed — schema and test changes ship in the same PR as imp-1.
+
+## Branch & PR — `llm-wiki-skills`
+
+Skills changes are pure Markdown and have no engine dependency — they can
+be developed in parallel with the engine branch and merged independently.
+
+```bash
+# in llm-wiki-skills repo
+git checkout -b feat/claims-confidence-float
+```
+
+When done:
+
+```bash
+git push -u origin feat/claims-confidence-float
+gh pr create \
+  --repo geronimo-iia/llm-wiki-skills \
+  --milestone "v0.4.0" \
+  --title "fix: align claims[].confidence to float 0.0–1.0" \
+  --body "$(cat <<'EOF'
+Aligns skill documentation with the schema change in llm-wiki imp-1b:
+`claims[].confidence` is now a float `0.0–1.0`, not a string enum.
+
+- `skills/frontmatter/SKILL.md`: rewrite confidence table to float scale;
+  update claims example and anti-pattern row
+- `skills/ingest/SKILL.md`: update any claim examples using string confidence
+- `skills/frontmatter/references/type-taxonomy.md`: update confidence prose
+
+Companion to llm-wiki feat/confidence-search-ranking (imp-1b).
+Closes geronimo-iia/llm-wiki-skills#1 (imp-1b)
+EOF
+)"
+```
+
+> Merge timing: can merge before or after the engine PR — no runtime
+> dependency. Merging before is fine since the skills just document what the
+> schema will enforce.
+
+## Tasks
+
+### Engine — `llm-wiki` (branch: `feat/confidence-search-ranking`)
+
+#### Schemas (JSON)
+- [ ] `schemas/concept.json`: change `claims[].confidence` from `type: string, enum: [...]` to `type: number, minimum: 0.0, maximum: 1.0`.
+- [ ] `schemas/paper.json`: same change.
+
+#### Tests
+- [ ] `tests/default_schemas.rs` `concept_accepts_full_template`: change `"confidence": "high"` inside claims item to `"confidence": 0.9`.
+- [ ] `tests/default_schemas.rs` `paper_accepts_source_template`: same.
+- [ ] Add test: `concept_rejects_string_confidence_in_claim` — assert `claims[].confidence: "high"` is now invalid.
+- [ ] Add test: `paper_rejects_string_confidence_in_claim` — same.
+
+#### Specification docs
+- [ ] `docs/specifications/model/types/concept.md`: update Claims table row and example; remove the `claims[].confidence` distinction note (types are now uniform).
+- [ ] `docs/specifications/model/types/source.md`: update template example `confidence: high` in claims → `confidence: 0.9`.
+
+### Skills — `llm-wiki-skills` (branch: `feat/claims-confidence-float`)
+
+- [ ] `skills/frontmatter/SKILL.md`: rewrite `### confidence` table from string enum to float scale; update anti-pattern row.
+- [ ] `skills/frontmatter/SKILL.md`: update `### claims` example: `confidence: high` → `confidence: 0.9`.
+- [ ] `skills/ingest/SKILL.md`: update any claim examples using string confidence.
+- [ ] `skills/frontmatter/references/type-taxonomy.md`: update confidence prose.
+</content>
+</invoke>

--- a/docs/improvements/claims-confidence-float.md
+++ b/docs/improvements/claims-confidence-float.md
@@ -1,7 +1,7 @@
 ---
 title: "claims[].confidence as float"
 summary: "Align claims[].confidence with page-level confidence — change from string enum to float 0.0–1.0."
-status: proposed
+status: implemented
 last_updated: "2026-04-27"
 depends_on: confidence
 ---
@@ -143,24 +143,24 @@ EOF
 ### Engine — `llm-wiki` (branch: `feat/confidence-search-ranking`)
 
 #### Schemas (JSON)
-- [ ] `schemas/concept.json`: change `claims[].confidence` from `type: string, enum: [...]` to `type: number, minimum: 0.0, maximum: 1.0`.
-- [ ] `schemas/paper.json`: same change.
+- [x] `schemas/concept.json`: change `claims[].confidence` from `type: string, enum: [...]` to `type: number, minimum: 0.0, maximum: 1.0`.
+- [x] `schemas/paper.json`: same change.
 
 #### Tests
-- [ ] `tests/default_schemas.rs` `concept_accepts_full_template`: change `"confidence": "high"` inside claims item to `"confidence": 0.9`.
-- [ ] `tests/default_schemas.rs` `paper_accepts_source_template`: same.
-- [ ] Add test: `concept_rejects_string_confidence_in_claim` — assert `claims[].confidence: "high"` is now invalid.
-- [ ] Add test: `paper_rejects_string_confidence_in_claim` — same.
+- [x] `tests/default_schemas.rs` `concept_accepts_full_template`: change `"confidence": "high"` inside claims item to `"confidence": 0.9`.
+- [x] `tests/default_schemas.rs` `paper_accepts_source_template`: same.
+- [x] Add test: `concept_rejects_string_confidence_in_claim` — assert `claims[].confidence: "high"` is now invalid.
+- [x] Add test: `paper_rejects_string_confidence_in_claim` — same.
 
 #### Specification docs
-- [ ] `docs/specifications/model/types/concept.md`: update Claims table row and example; remove the `claims[].confidence` distinction note (types are now uniform).
-- [ ] `docs/specifications/model/types/source.md`: update template example `confidence: high` in claims → `confidence: 0.9`.
+- [x] `docs/specifications/model/types/concept.md`: update Claims table row and example; remove the `claims[].confidence` distinction note (types are now uniform).
+- [x] `docs/specifications/model/types/source.md`: update template example `confidence: high` in claims → `confidence: 0.9`.
 
 ### Skills — `llm-wiki-skills` (branch: `feat/claims-confidence-float`)
 
-- [ ] `skills/frontmatter/SKILL.md`: rewrite `### confidence` table from string enum to float scale; update anti-pattern row.
-- [ ] `skills/frontmatter/SKILL.md`: update `### claims` example: `confidence: high` → `confidence: 0.9`.
-- [ ] `skills/ingest/SKILL.md`: update any claim examples using string confidence.
-- [ ] `skills/frontmatter/references/type-taxonomy.md`: update confidence prose.
+- [x] `skills/frontmatter/SKILL.md`: rewrite `### confidence` table from string enum to float scale; update anti-pattern row.
+- [x] `skills/frontmatter/SKILL.md`: update `### claims` example: `confidence: high` → `confidence: 0.9`.
+- [x] `skills/ingest/SKILL.md`: update any claim examples using string confidence.
+- [x] `skills/frontmatter/references/type-taxonomy.md`: update confidence prose.
 </content>
 </invoke>

--- a/docs/improvements/confidence.md
+++ b/docs/improvements/confidence.md
@@ -1,7 +1,7 @@
 ---
 title: "Confidence Field"
 summary: "Add confidence: 0.0–1.0 to the base page schema; index as a numeric field; use as a search ranking multiplier."
-status: proposed
+status: implemented
 last_updated: "2026-04-27"
 ---
 
@@ -100,31 +100,31 @@ with `confidence: high` should not crash on read. Map legacy strings on read:
 ## Tasks
 
 ### Schemas (JSON)
-- [ ] Add `confidence` float field to `schemas/base.json`: `type: number`, `minimum: 0.0`, `maximum: 1.0`, `default: 0.5`.
-- [ ] Change `confidence` in `schemas/concept.json` from string enum to `number` with same range and default; leave `claims[].confidence` string enum untouched (different scope).
-- [ ] Change `confidence` in `schemas/paper.json` from string enum to `number` with same range and default; same caveat for `claims[].confidence`.
+- [x] Add `confidence` float field to `schemas/base.json`: `type: number`, `minimum: 0.0`, `maximum: 1.0`, `default: 0.5`. *(done via concept.json + paper.json; base.json deferred — no base.json schema file)*
+- [x] Change `confidence` in `schemas/concept.json` from string enum to `number` with same range and default; leave `claims[].confidence` string enum untouched (different scope).
+- [x] Change `confidence` in `schemas/paper.json` from string enum to `number` with same range and default; same caveat for `claims[].confidence`.
 
 ### Source code
-- [ ] Add `fn confidence(fm: &BTreeMap<String, Value>) -> f32` to `src/frontmatter.rs`; return `0.5` when absent; map legacy strings (`"high" → 0.9`, `"medium" → 0.5`, `"low" → 0.2`); clamp result to `[0.0, 1.0]`.
-- [ ] Add `confidence` as a `f64 | FAST | STORED` numeric field in `src/index_schema.rs` via a new `add_numeric` method on `SchemaBuilder`; populate during index build via the `confidence()` getter. Tantivy 0.26 exposes numeric fast fields only as `f64` — store and read as `f64`, cast to `f32` at the `PageRef` boundary.
-- [ ] Add `confidence: f32` to `PageRef` struct in `src/search.rs`; populate from stored field (default `0.5`).
-- [ ] Add `confidence: f32` to `PageSummary` struct in `src/search.rs`; populate from stored field.
-- [ ] Update `src/ops/search.rs` to read `confidence` from the stored field and apply as score multiplier after the status multiplier (improvement #2 wires this in).
-- [ ] Add `confidence: 0.5` to `fn scaffold()` in `src/frontmatter.rs` so `wiki_content_new` emits it by default.
+- [x] Add `fn confidence(fm: &BTreeMap<String, Value>) -> f32` to `src/frontmatter.rs`; return `0.5` when absent; map legacy strings (`"high" → 0.9`, `"medium" → 0.5`, `"low" → 0.2`); clamp result to `[0.0, 1.0]`.
+- [x] Add `confidence` as a `f64 | FAST | STORED` numeric field in `src/index_schema.rs` via a new `add_numeric` method on `SchemaBuilder`; populate during index build via the `confidence()` getter. Tantivy 0.26 exposes numeric fast fields only as `f64` — store and read as `f64`, cast to `f32` at the `PageRef` boundary.
+- [x] Add `confidence: f32` to `PageRef` struct in `src/search.rs`; populate from stored field (default `0.5`).
+- [x] Add `confidence: f32` to `PageSummary` struct in `src/search.rs`; populate from stored field.
+- [x] Update `src/ops/search.rs` to read `confidence` from the stored field and apply as score multiplier after the status multiplier (improvement #2 wires this in).
+- [x] Add `confidence: 0.5` to `fn scaffold()` in `src/frontmatter.rs` so `wiki_content_new` emits it by default.
 
 ### Schema body templates
-- [ ] Add `confidence: 0.5` to `schemas/concept.md` frontmatter template if it contains a frontmatter block; otherwise leave (body template, not frontmatter).
-- [ ] Same for `schemas/paper.md`.
+- [x] Add `confidence: 0.5` to `schemas/concept.md` frontmatter template if it contains a frontmatter block; otherwise leave (body template, not frontmatter). *(body-only template — no frontmatter block, nothing to add)*
+- [x] Same for `schemas/paper.md`. *(body-only template — no frontmatter block, nothing to add)*
 
 ### Specification docs
-- [ ] `docs/specifications/model/types/base.md`: add `confidence` to optional fields table (`float 0.0–1.0`, default `0.5`).
-- [ ] `docs/specifications/model/types/concept.md`: change `confidence` field type from string enum to `float 0.0–1.0`; update all `confidence: high` examples to `confidence: 0.9`; note `claims[].confidence` remains a string enum.
-- [ ] `docs/specifications/model/types/source.md`: same — change table entry and examples.
-- [ ] `docs/specifications/engine/index-management.md`: note `confidence` is now a dedicated numeric FAST field, not an arbitrary text field.
-- [ ] `docs/specifications/tools/search.md`: document `confidence: float` in the `PageRef` result schema.
-- [ ] `docs/specifications/tools/list.md`: document `confidence: float` in the `PageSummary` result schema.
+- [x] `docs/specifications/model/types/base.md`: add `confidence` to optional fields table (`float 0.0–1.0`, default `0.5`).
+- [x] `docs/specifications/model/types/concept.md`: change `confidence` field type from string enum to `float 0.0–1.0`; update all `confidence: high` examples to `confidence: 0.9`; note `claims[].confidence` remains a string enum.
+- [x] `docs/specifications/model/types/source.md`: same — change table entry and examples.
+- [x] `docs/specifications/engine/index-management.md`: note `confidence` is now a dedicated numeric FAST field, not an arbitrary text field.
+- [x] `docs/specifications/tools/search.md`: document `confidence: float` in the `PageRef` result schema.
+- [x] `docs/specifications/tools/list.md`: document `confidence: float` in the `PageSummary` result schema.
 
 ### Tests
-- [ ] `fn scaffold()` emits `confidence: 0.5`.
-- [ ] `fn confidence()` maps `"high" → 0.9`, `"medium" → 0.5`, `"low" → 0.2`, absent → `0.5`, out-of-range float clamped.
-- [ ] Search ranks `confidence: 0.9` page above `confidence: 0.2` page with identical body text.
+- [x] `fn scaffold()` emits `confidence: 0.5`.
+- [x] `fn confidence()` maps `"high" → 0.9`, `"medium" → 0.5`, `"low" → 0.2`, absent → `0.5`, out-of-range float clamped.
+- [x] Search ranks `confidence: 0.9` page above `confidence: 0.2` page with identical body text.

--- a/docs/improvements/search-ranking-custom-status.md
+++ b/docs/improvements/search-ranking-custom-status.md
@@ -1,0 +1,267 @@
+---
+title: "Flat status multiplier map for search ranking"
+summary: "Replace the four named SearchConfig fields with a single status map — uniform, extensible, supports custom status values globally and per wiki."
+status: implemented
+last_updated: "2026-04-27"
+depends_on: search-ranking
+---
+
+# Flat status multiplier map for search ranking
+
+## Problem
+
+`SearchConfig` was introduced with four hardcoded fields:
+
+```rust
+pub status_active:   f32,   // 1.0
+pub status_draft:    f32,   // 0.8
+pub status_archived: f32,   // 0.3
+pub status_unknown:  f32,   // 0.9
+```
+
+This creates two problems:
+
+1. **No custom status support.** Any status not matching `active`, `draft`,
+   or `archived` falls through to `status_unknown`. A user who adds `verified`,
+   `stub`, `deprecated`, `review`, etc. cannot give it a distinct multiplier.
+
+2. **Split mental model in TOML.** Built-in statuses are top-level scalar
+   keys; custom ones would require a separate sub-table
+   (`[search.status_custom]`). This is an arbitrary distinction — from the
+   user's perspective, all status multipliers are the same thing.
+
+There is also no guide documenting the search ranking system or how to tune it.
+
+## Goal
+
+- **Single flat map** — all status multipliers live in `[search.status]`;
+  built-ins and custom entries are written the same way.
+- **Extensible** — adding a new status requires only config, not code.
+- **Global and per-wiki** — `config.toml` sets defaults; `wiki.toml`
+  overrides them for a specific wiki.
+- **Breaking change is safe** — `[search]` was just added and no user
+  config exists yet.
+- Add `docs/guides/search-ranking.md`.
+
+## Solution
+
+### Config — `src/config.rs`
+
+Replace the four named fields with a single map:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchConfig {
+    #[serde(default = "default_search_status")]
+    pub status: std::collections::HashMap<String, f32>,
+}
+
+fn default_search_status() -> std::collections::HashMap<String, f32> {
+    [
+        ("active".into(),   1.0_f32),
+        ("draft".into(),    0.8),
+        ("archived".into(), 0.3),
+        ("unknown".into(),  0.9),
+    ]
+    .into_iter()
+    .collect()
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self { status: default_search_status() }
+    }
+}
+```
+
+`unknown` is the reserved fallback key — used when a page's status is absent
+or not listed in the map.
+
+TOML representation in `config.toml` or `wiki.toml`:
+
+```toml
+[search.status]
+active     = 1.0
+draft      = 0.8
+archived   = 0.3
+unknown    = 0.9
+# custom entries — same table, no distinction
+verified   = 1.0
+stub       = 0.6
+deprecated = 0.1
+review     = 0.85
+```
+
+### Lookup in `src/search.rs`
+
+Replace the four-arm `match` with a single map lookup:
+
+```rust
+let status_mult = match &status_col {
+    Some(col) => match col.term_ords(doc).next() {
+        Some(ord) => {
+            let mut buf = String::new();
+            col.ord_to_str(ord, &mut buf).ok();
+            let unknown = sc.status.get("unknown").copied().unwrap_or(0.9);
+            sc.status.get(buf.as_str()).copied().unwrap_or(unknown)
+        }
+        None => sc.status.get("unknown").copied().unwrap_or(0.9),
+    },
+    None => sc.status.get("unknown").copied().unwrap_or(0.9),
+};
+```
+
+### Global and per-wiki resolution
+
+Unlike scalar sections (`[suggest]`, `[graph]`, etc.) which are resolved
+all-or-nothing, the `status` map is merged **key by key**: the global map
+provides the baseline; per-wiki entries override or extend it.
+
+```
+resolved[key] = per_wiki[key]  if present
+              | global[key]    otherwise
+```
+
+This means a `wiki.toml` only needs to declare the entries it wants to
+change or add. The four built-in defaults come from `config.toml` (or the
+compiled-in defaults) and are inherited automatically.
+
+Example:
+
+```toml
+# config.toml (global)
+[search.status]
+active   = 1.0
+draft    = 0.8
+archived = 0.3
+unknown  = 0.9
+```
+
+```toml
+# wiki.toml (per-wiki — only declares what differs)
+[search.status]
+archived = 0.0   # suppress archived for this wiki
+stub     = 0.6   # add a custom status
+```
+
+Resolved for that wiki:
+
+```toml
+active   = 1.0   # inherited from global
+draft    = 0.8   # inherited from global
+archived = 0.0   # overridden by wiki
+unknown  = 0.9   # inherited from global
+stub     = 0.6   # added by wiki
+```
+
+**Implementation** — replace the current wholesale-clone resolution in
+`resolve()` with an explicit map merge:
+
+```rust
+search: {
+    let mut merged = global.search.status.clone();
+    for (k, v) in &per_wiki.search.as_ref()
+                            .map(|s| &s.status)
+                            .unwrap_or(&Default::default()) {
+        merged.insert(k.clone(), *v);
+    }
+    SearchConfig { status: merged }
+},
+```
+
+### `config set` / `config get`
+
+`llm-wiki config set` only handles scalar keys today and cannot reach
+`search.status.*` map entries. Users must edit `wiki.toml` or `config.toml`
+by hand for status entries. This is acceptable — `config set` is for
+scalar settings. The gap can be addressed in a future improvement.
+
+### `get_config_value` / `set_global_config_value`
+
+The four existing `search.status_*` key handlers in these functions must be
+removed; map entries are not reachable via `config set`.
+
+## Known constraints
+
+- `unknown` is a reserved key name — it is the fallback, not an actual
+  `status: unknown` value. A page with `status: unknown` would match the
+  `unknown` entry in the map, which is intentional and useful.
+- Map keys are case-sensitive (matches YAML frontmatter values).
+- Values outside `[0.0, 1.0]` are not clamped. `0.0` effectively suppresses
+  a status; values above `1.0` boost it. Both are intentional escape hatches.
+
+## Tasks
+
+### Source code
+- [x] `src/config.rs`: replace four named fields on `SearchConfig` with
+  `status: HashMap<String, f32>`; `default_search_status()` seeds the four
+  built-in defaults; remove `default_search_status_active/draft/archived/unknown`
+  helper fns; remove the four `search.status_*` arms from
+  `get_config_value` and `set_global_config_value`; replace the
+  wholesale-clone `search` line in `resolve()` with a key-level merge
+  (global baseline, per-wiki entries override/extend).
+- [x] `src/search.rs`: replace the four-arm `match` with a single
+  `sc.status.get(buf.as_str())` lookup falling back to the `"unknown"` entry.
+
+### Tests
+- [x] `tests/config.rs`: update any existing `SearchConfig` tests for the new
+  shape; add round-trip test for TOML with custom entries.
+- [x] `tests/search.rs`: update the four existing ranking tests that construct
+  `SearchConfig` explicitly (they reference `status_active`, `status_draft`, etc.).
+- [x] `tests/search.rs`: add `search_ranking_custom_status_mapped` — index two
+  pages `status: stub` and `status: active`; configure `stub = 0.6`; assert
+  active (×1.0×0.5=0.5) ranks above stub (×0.6×0.5=0.3).
+- [x] `tests/search.rs`: add `search_ranking_custom_status_falls_back_to_unknown`
+  — index a page with `status: stub`; no `stub` entry in map; assert it scores
+  the same as a page with no status (both use the `unknown` multiplier).
+- [x] `tests/config.rs`: add `resolve_search_status_merges_per_wiki` — global
+  has `archived = 0.3`; per-wiki sets `archived = 0.0` and adds `stub = 0.6`;
+  resolved map contains `active = 1.0` (inherited), `archived = 0.0`
+  (overridden), `stub = 0.6` (added), `draft = 0.8` (inherited).
+
+### Spec docs
+- [x] `docs/specifications/tools/search.md`: rewrite `[search]` config section —
+  replace the four-key scalar table (`status_active`, `status_draft`,
+  `status_archived`, `status_unknown`) with the `[search.status]` map syntax;
+  document `unknown` as the reserved fallback key; add a custom status example
+  (`verified`, `stub`, `deprecated`); update the multiplier table to note that
+  the map is extensible; update any TOML example blocks that show the old scalar
+  keys.
+- [x] `docs/specifications/model/global-config.md`:
+  - Replace the four `search.status_active / status_draft / status_archived /
+    status_unknown` rows in the overridable defaults table with a single
+    `search.status` map entry (type: `{ string → float }`, default: the four
+    built-in key/value pairs).
+  - Update the `[search]` example block from four scalar keys to a
+    `[search.status]` sub-table.
+  - In the Resolution Order section (CLI → wiki.toml → config.toml → built-in),
+    add a note that `[search.status]` is resolved **key-by-key** (not
+    all-or-nothing like other sections): global map is the baseline, per-wiki
+    entries override or extend individual keys.
+- [x] `docs/specifications/model/wiki-toml.md`:
+  - Update the Complete Example to use `[search.status]` sub-table instead of
+    four scalar keys.
+  - Update the per-wiki overridable settings table: replace the four
+    `status_active / status_draft / status_archived / status_unknown` entries
+    with a single `[search.status]` row; add a note that only keys that differ
+    from the global baseline need to be declared.
+  - Add a short prose note below the table explaining the key-level merge: a
+    `wiki.toml` `[search.status]` block overrides or adds individual keys; it
+    does **not** replace the entire global map.
+
+### Guides
+- [x] Create `docs/guides/search-ranking.md` covering:
+  - Ranking formula: `final_score = bm25 × status_multiplier × confidence`
+  - The `[search.status]` map — all entries on equal footing
+  - Built-in defaults table (`active`, `draft`, `archived`, `unknown`)
+  - How to set globally in `config.toml`
+  - How to override per-wiki in `wiki.toml`
+  - How to add custom statuses (`verified`, `stub`, `deprecated`, …)
+  - Example: demoting stubs without suppressing them (`stub = 0.6`)
+  - Example: suppressing a status entirely (`deprecated = 0.0`)
+  - Example: wiki-specific override (a `review` wiki uses `review = 1.0`)
+  - Note: `config set` cannot reach map entries; edit TOML directly
+- [x] `docs/guides/configuration.md`: add `### Tune search ranking` section
+  with a one-liner example and link to `search-ranking.md`.
+- [x] `docs/guides/README.md`: add `search-ranking.md` row to the guide index.
+</content>

--- a/docs/improvements/search-ranking.md
+++ b/docs/improvements/search-ranking.md
@@ -1,7 +1,7 @@
 ---
 title: "Lifecycle-Aware Search Ranking"
 summary: "Apply status and confidence multipliers inside the tantivy collector via tweak_score, not as a post-retrieval sort."
-status: proposed
+status: implemented
 last_updated: "2026-04-27"
 depends_on: confidence
 ---
@@ -113,24 +113,24 @@ and passed into the `tweak_score` closure by copy — no change to the closure s
 ## Tasks
 
 ### Config
-- [ ] Add `SearchConfig` struct to `src/config.rs` with four `f32` multiplier fields and `Default` impl matching the table above.
-- [ ] Wire `SearchConfig` into `WikiConfig` under `[search]`; expose via `ResolvedConfig`.
-- [ ] Update `wiki.toml` spec (`docs/specifications/model/wiki-toml.md`): add `[search]` section with multiplier fields.
+- [x] Add `SearchConfig` struct to `src/config.rs` with four `f32` multiplier fields and `Default` impl matching the table above.
+- [x] Wire `SearchConfig` into `WikiConfig` under `[search]`; expose via `ResolvedConfig`.
+- [x] Update `wiki.toml` spec (`docs/specifications/model/wiki-toml.md`): add `[search]` section with multiplier fields.
 
 ### Source code
-- [ ] Add `add_numeric` method to `SchemaBuilder` in `src/index_schema.rs`: `f64 | FAST | STORED`; use it to register the `confidence` field (coordinate with improvement #1).
-- [ ] Replace `TopDocs::with_limit(...).order_by_score()` in `src/search.rs::search()` with `TopDocs::with_limit(...).tweak_score(...)`; pass resolved `SearchConfig` multipliers into the closure by copy.
-- [ ] In the `tweak_score` closure: read `status` via `fast_fields().str()` and `confidence` via `fast_fields().f64()`; apply multipliers from config.
-- [ ] Populate `confidence` on `PageRef` from the stored field (already a task in improvement #1).
+- [x] Add `add_numeric` method to `SchemaBuilder` in `src/index_schema.rs`: `f64 | FAST | STORED`; use it to register the `confidence` field (coordinate with improvement #1).
+- [x] Replace `TopDocs::with_limit(...).order_by_score()` in `src/search.rs::search()` with `TopDocs::with_limit(...).tweak_score(...)`; pass resolved `SearchConfig` multipliers into the closure by copy.
+- [x] In the `tweak_score` closure: read `status` via `fast_fields().str()` and `confidence` via `fast_fields().f64()`; apply multipliers from config.
+- [x] Populate `confidence` on `PageRef` from the stored field (already a task in improvement #1).
 
 ### Tests
-- [ ] Index three pages with identical body text, `status: active/draft/archived`; assert active ranks first, archived last (default config).
-- [ ] Index two pages with identical body and status; `confidence: 0.9` vs `confidence: 0.2`; assert high-confidence ranks first.
-- [ ] Combined: `archived + confidence 1.0` ranks below `active + confidence 0.5` (0.3 × 1.0 = 0.3 < 1.0 × 0.5 = 0.5).
-- [ ] Custom config: set `status_archived = 0.0`; assert archived pages never appear in results.
+- [x] Index three pages with identical body text, `status: active/draft/archived`; assert active ranks first, archived last (default config).
+- [x] Index two pages with identical body and status; `confidence: 0.9` vs `confidence: 0.2`; assert high-confidence ranks first.
+- [x] Combined: `archived + confidence 1.0` ranks below `active + confidence 0.5` (0.3 × 1.0 = 0.3 < 1.0 × 0.5 = 0.5).
+- [x] Custom config: set `status_archived = 0.0`; assert archived pages never appear in results.
 
 ### Spec docs
-- [ ] Update `docs/specifications/tools/search.md`: document ranking formula, multiplier table, and `[search]` config keys.
-- [ ] Update `docs/specifications/model/global-config.md`: add `[search]` to the overridable defaults table with all four keys and their defaults.
-- [ ] Update `docs/specifications/model/wiki-toml.md`: add `[search]` to the per-wiki overridable settings section.
-- [ ] Update `docs/specifications/model/global-config.md` example block: add `[search]` section.
+- [x] Update `docs/specifications/tools/search.md`: document ranking formula, multiplier table, and `[search]` config keys.
+- [x] Update `docs/specifications/model/global-config.md`: add `[search]` to the overridable defaults table with all four keys and their defaults.
+- [x] Update `docs/specifications/model/wiki-toml.md`: add `[search]` to the per-wiki overridable settings section.
+- [x] Update `docs/specifications/model/global-config.md` example block: add `[search]` section.

--- a/docs/specifications/engine/index-management.md
+++ b/docs/specifications/engine/index-management.md
@@ -67,6 +67,12 @@ How frontmatter fields map to roles:
   sorted pagination via `order_by_string_fast_field`.
 - **Keyword fields** (`type`, `status`, `tags`) are `STRING | FAST` —
   FAST enables both exact-match filtering and facet counting.
+- **Numeric fields** (`confidence`) are `f64 | FAST | STORED` — stored
+  for result output, FAST for per-document score access inside the
+  `tweak_score` collector. `confidence` is written via the dedicated
+  `frontmatter::confidence()` getter (not the generic text path), so
+  legacy string values (`"high"` → 0.9, `"medium"` → 0.5, `"low"` → 0.2)
+  are normalised to floats at index time.
 - **URI** is stored but not searched.
 
 The `slug` field is the unique key for delete+insert operations.

--- a/docs/specifications/model/global-config.md
+++ b/docs/specifications/model/global-config.md
@@ -64,6 +64,12 @@ default_limit = 10
 default_limit = 5
 min_score     = 0.1
 
+[search.status]
+active   = 1.0
+draft    = 0.8
+archived = 0.3
+unknown  = 0.9
+
 # ── Global-only settings ──────────────────────────────────────────────────────
 
 [index]
@@ -126,6 +132,7 @@ These keys can appear in both `config.toml` (global) and `wiki.toml`
 | `history.default_limit`      | `10`      | Default entry count for `wiki_history`             |
 | `suggest.default_limit`      | `5`       | Max suggestions for `wiki_suggest`                 |
 | `suggest.min_score`          | `0.1`     | Minimum score threshold for suggestions            |
+| `search.status`              | `{ active=1.0, draft=0.8, archived=0.3, unknown=0.9 }` | Status multiplier map. `unknown` is the reserved fallback for absent or unmapped statuses. Add custom entries (`stub`, `verified`, …) alongside built-ins. Per-wiki resolution merges key-by-key — a `wiki.toml` only needs to declare what differs. |
 | `read.no_frontmatter`        | `false`   | Strip frontmatter from `wiki_content_read` output         |
 | `ingest.auto_commit`         | `true`    | Commit after ingest                               |
 | `validation.type_strictness` | `loose`   | `strict`: unknown type is error; `loose`: warning |
@@ -167,3 +174,10 @@ is rejected.
 3. Global config     (config.toml)
 4. Built-in default
 ```
+
+Most sections resolve all-or-nothing: if a section is present in
+`wiki.toml`, it replaces the global section entirely. The one exception
+is `[search.status]`, which merges **key by key** — the global map
+provides the baseline, and per-wiki entries override or extend
+individual keys. A `wiki.toml` only needs to declare the entries it
+wants to change or add.

--- a/docs/specifications/model/types/base.md
+++ b/docs/specifications/model/types/base.md
@@ -33,6 +33,7 @@ field (registered as `[types.default]` in `wiki.toml`).
 | `tags`          | list[string] | Lowercase hyphenated search terms                |
 | `owner`         | string       | Person, team, or agent responsible               |
 | `superseded_by` | string       | Slug of replacement page                         |
+| `confidence`    | float 0.0–1.0 | Certainty of this page's content. Default `0.5`. `0.0–0.3` = speculative, `0.4–0.6` = partial, `0.7–0.9` = reviewed, `1.0` = verified. Used as a search ranking multiplier. |
 
 Uses `additionalProperties: true` — unrecognized fields are preserved
 on disk and indexed as text.

--- a/docs/specifications/model/types/concept.md
+++ b/docs/specifications/model/types/concept.md
@@ -27,7 +27,7 @@ Two types share this schema:
 | `tldr`       | string       | no       | none    | One-sentence key takeaway                       |
 | `sources`    | list[string] | no       | `[]`    | Slugs of source pages that contributed claims   |
 | `concepts`   | list[string] | no       | `[]`    | Slugs of concept pages this page depends on     |
-| `confidence` | string       | no       | none    | `high`, `medium`, `low`                         |
+| `confidence` | float 0.0–1.0 | no      | `0.5`   | Certainty of page content. See [base.md](base.md). Legacy strings `high`/`medium`/`low` are read as `0.9`/`0.5`/`0.2`. |
 | `claims`     | list[claim]  | no       | `[]`    | Structured claims extracted from sources        |
 
 ## Claims
@@ -38,7 +38,7 @@ confidence and location:
 | Field        | Type   | Required | Description                                   |
 | ------------ | ------ | -------- | --------------------------------------------- |
 | `text`       | string | yes      | The claim as a factual statement              |
-| `confidence` | string | no       | `high`, `medium`, `low`                       |
+| `confidence` | string | no       | `high`, `medium`, `low` — claim-level confidence, distinct from page-level `confidence` |
 | `source`     | string | no       | Slug of the source page                       |
 | `section`    | string | no       | Section in the source where the claim appears |
 
@@ -49,6 +49,8 @@ claims:
     source: sources/switch-transformer-2021
     section: "Results"
 ```
+
+> `claims[].confidence` is a string enum (`high`/`medium`/`low`) scoped to the claim object. It is distinct from the page-level `confidence` float field.
 
 ## Edge Declarations
 
@@ -72,7 +74,7 @@ last_updated: "2025-07-17"
 tags: [mixture-of-experts, scaling, transformers]
 sources: [sources/switch-transformer-2021]
 concepts: [concepts/scaling-laws]
-confidence: high
+confidence: 0.9
 claims:
   - text: "Sparse MoE reduces effective compute 8x"
     confidence: high

--- a/docs/specifications/model/types/concept.md
+++ b/docs/specifications/model/types/concept.md
@@ -35,22 +35,23 @@ Two types share this schema:
 A claim is a factual statement extracted from a source, with optional
 confidence and location:
 
-| Field        | Type   | Required | Description                                   |
-| ------------ | ------ | -------- | --------------------------------------------- |
-| `text`       | string | yes      | The claim as a factual statement              |
-| `confidence` | string | no       | `high`, `medium`, `low` — claim-level confidence, distinct from page-level `confidence` |
-| `source`     | string | no       | Slug of the source page                       |
-| `section`    | string | no       | Section in the source where the claim appears |
+| Field        | Type          | Required | Description                                   |
+| ------------ | ------------- | -------- | --------------------------------------------- |
+| `text`       | string        | yes      | The claim as a factual statement              |
+| `confidence` | float 0.0–1.0 | no       | Certainty of this claim. Same scale as page-level `confidence`. |
+| `source`     | string        | no       | Slug of the source page                       |
+| `section`    | string        | no       | Section in the source where the claim appears |
+
+Conventional values: `0.9` = well-corroborated; `0.5` = single source or caveats; `0.2` = speculative.
+Absence means no certainty signal was recorded (distinct from `0.5` neutral).
 
 ```yaml
 claims:
   - text: "Sparse MoE reduces effective compute 8x"
-    confidence: high
+    confidence: 0.9
     source: sources/switch-transformer-2021
     section: "Results"
 ```
-
-> `claims[].confidence` is a string enum (`high`/`medium`/`low`) scoped to the claim object. It is distinct from the page-level `confidence` float field.
 
 ## Edge Declarations
 
@@ -77,6 +78,6 @@ concepts: [concepts/scaling-laws]
 confidence: 0.9
 claims:
   - text: "Sparse MoE reduces effective compute 8x"
-    confidence: high
+    confidence: 0.9
     section: "Results"
 ```

--- a/docs/specifications/model/types/source.md
+++ b/docs/specifications/model/types/source.md
@@ -35,7 +35,7 @@ distinction. Classify by the source material's nature, not its topic.
 | `tldr` | string | no | none | One-sentence key takeaway |
 | `sources` | list[string] | no | `[]` | Slugs of other source pages (e.g. papers cited by a survey) |
 | `concepts` | list[string] | no | `[]` | Slugs of concept pages this source informs |
-| `confidence` | string | no | none | `high`, `medium`, `low` |
+| `confidence` | float 0.0–1.0 | no | `0.5` | Certainty of page content. See [base.md](base.md). Legacy strings `high`/`medium`/`low` are read as `0.9`/`0.5`/`0.2`. |
 | `claims` | list[claim] | no | `[]` | Structured claims (see [concept.md](concept.md) for claim format) |
 
 ## Edge Declarations
@@ -59,7 +59,7 @@ type: paper
 last_updated: "2025-07-17"
 tags: [mixture-of-experts, switch-transformer, scaling]
 concepts: [concepts/mixture-of-experts, concepts/scaling-laws]
-confidence: high
+confidence: 0.9
 claims:
   - text: "Switch routing achieves 4x speedup"
     confidence: high

--- a/docs/specifications/model/types/source.md
+++ b/docs/specifications/model/types/source.md
@@ -62,7 +62,7 @@ concepts: [concepts/mixture-of-experts, concepts/scaling-laws]
 confidence: 0.9
 claims:
   - text: "Switch routing achieves 4x speedup"
-    confidence: high
+    confidence: 0.9
     source: sources/switch-transformer-2021
     section: "Abstract"
 ```

--- a/docs/specifications/model/wiki-toml.md
+++ b/docs/specifications/model/wiki-toml.md
@@ -38,6 +38,10 @@ auto_commit = true
 
 [validation]
 type_strictness = "loose"
+
+[search.status]
+archived = 0.0   # suppress archived for this wiki
+stub     = 0.6   # add a custom status
 ```
 
 
@@ -78,3 +82,17 @@ from `x-wiki-types` in a schema file.
 Any key from the global config that is not global-only can be overridden
 here. See [global-config.md](global-config.md) for the full key
 reference.
+
+Commonly overridden per-wiki:
+
+| Section          | Keys / notes                                                                 |
+| ---------------- | ---------------------------------------------------------------------------- |
+| `[search.status]` | Status multiplier map. Only declare keys that differ from the global baseline. Built-ins (`active`, `draft`, `archived`, `unknown`) are inherited automatically. |
+| `[suggest]`      | `default_limit`, `min_score`                                                 |
+| `[ingest]`       | `auto_commit`                                                                |
+| `[graph]`        | `format`, `depth`                                                            |
+
+`[search.status]` is the only section resolved **key-by-key**: a
+`wiki.toml` block merges over the global map rather than replacing it.
+A wiki that sets `archived = 0.0` and `stub = 0.6` still inherits
+`active`, `draft`, and `unknown` from the global config unchanged.

--- a/docs/specifications/tools/list.md
+++ b/docs/specifications/tools/list.md
@@ -25,7 +25,7 @@ Results ordered alphabetically by slug via `order_by_string_fast_field`
 on the `slug` FAST field. No search ranking. Only the requested page
 window is extracted from the index.
 
-Each entry includes slug, `wiki://` URI, title, type, status, and tags.
+Each entry includes slug, `wiki://` URI, title, type, status, tags, and `confidence`.
 
 Facets (`type`, `status`, `tags` distributions) are always included.
 Same hybrid filtering as `wiki_search` — `type` facet is unfiltered,
@@ -55,7 +55,8 @@ JSON (`--format json`):
       "title": "Mixture of Experts",
       "type": "concept",
       "status": "active",
-      "tags": ["mixture-of-experts", "scaling"]
+      "tags": ["mixture-of-experts", "scaling"],
+      "confidence": 0.9
     }
   ],
   "total": 42,
@@ -80,3 +81,17 @@ JSON (`--format json`):
   }
 }
 ```
+
+### PageSummary fields
+
+Each page object (`PageSummary`) contains:
+
+| Field        | Type         | Description                             |
+| ------------ | ------------ | --------------------------------------- |
+| `slug`       | string       | Page slug                               |
+| `uri`        | string       | `wiki://<name>/<slug>`                 |
+| `title`      | string       | Page title                              |
+| `type`       | string       | Page type                               |
+| `status`     | string       | Lifecycle status                        |
+| `tags`       | list[string] | Tags                                    |
+| `confidence` | float        | Page `confidence` value (default `0.5`) |

--- a/docs/specifications/tools/search.md
+++ b/docs/specifications/tools/search.md
@@ -25,6 +25,27 @@ llm-wiki search "<query>"
 BM25 ranks across `title`, `summary`, `read_when`, `tldr`, `tags`, and
 body text. `--type` adds a keyword filter on the `type` field.
 
+Results are ranked by a combined score applied **inside** the tantivy
+collector (via `tweak_score`), so the top-k returned are the true
+top-k — not just the top-k by raw BM25:
+
+```
+final_score = bm25 × status_multiplier × confidence
+```
+
+| `status` | Default multiplier |
+|---|---|
+| `active` | ×1.0 |
+| `draft` | ×0.8 |
+| `archived` | ×0.3 |
+| absent / not in map | ×0.9 (the `unknown` entry) |
+| any custom status | configurable |
+
+`confidence` is the page-level float (default `0.5` when absent).
+Multipliers are configurable via `[search.status]` in `config.toml` / `wiki.toml`.
+Custom statuses (`verified`, `stub`, `deprecated`, …) can be added to the map
+alongside the built-ins — no code change required.
+
 Facets (`type`, `status`, `tags` distributions) are always included in
 the response. The `type` facet is unfiltered (shows full distribution
 even when `--type` is active). `status` and `tags` facets are filtered
@@ -61,6 +82,7 @@ JSON (`--format json`):
       "uri": "wiki://research/concepts/mixture-of-experts",
       "title": "Mixture of Experts",
       "score": 0.94,
+      "confidence": 0.9,
       "excerpt": "Sparse routing of tokens to expert subnetworks, trading compute..."
     }
   ],
@@ -89,3 +111,43 @@ agents suggest "there are also 8 papers on this topic".
 
 `status` and `tags` facets are filtered — they describe the current
 result set after type filtering.
+
+### PageRef fields
+
+Each result object (`PageRef`) contains:
+
+| Field        | Type   | Description                                   |
+| ------------ | ------ | --------------------------------------------- |
+| `slug`       | string | Page slug                                     |
+| `uri`        | string | `wiki://<name>/<slug>`                        |
+| `title`      | string | Page title                                    |
+| `score`      | float  | Combined final score (`bm25 × status × conf`) |
+| `confidence` | float  | Page `confidence` value (default `0.5`)       |
+| `excerpt`    | string | Highlighted body excerpt (omitted with `--no-excerpt`) |
+
+### `[search.status]` config
+
+Multipliers live in a flat map under `[search.status]` in `config.toml`
+(global) or `wiki.toml` (per-wiki). Built-in entries and custom entries
+are written identically:
+
+```toml
+[search.status]
+active     = 1.0
+draft      = 0.8
+archived   = 0.3
+unknown    = 0.9   # reserved fallback — used when status absent or not in map
+# custom entries
+verified   = 1.0
+stub       = 0.6
+deprecated = 0.1
+review     = 0.85
+```
+
+`unknown` is the reserved fallback key. A page whose status is absent or
+does not appear in the map uses the `unknown` multiplier.
+
+**Per-wiki resolution is key-by-key** — a `wiki.toml` `[search.status]`
+block overrides or extends individual entries; it does not replace the
+entire global map. A `wiki.toml` only needs to declare the keys that differ
+from the global baseline.

--- a/schemas/concept.json
+++ b/schemas/concept.json
@@ -60,9 +60,11 @@
       "description": "Slugs of concept pages this page depends on"
     },
     "confidence": {
-      "type": "string",
-      "description": "Confidence level",
-      "enum": ["high", "medium", "low"]
+      "type": "number",
+      "description": "Certainty of this page's content. 0.0=speculative, 1.0=verified.",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "default": 0.5
     },
     "claims": {
       "type": "array",

--- a/schemas/concept.json
+++ b/schemas/concept.json
@@ -78,8 +78,10 @@
             "description": "The claim as a factual statement"
           },
           "confidence": {
-            "type": "string",
-            "enum": ["high", "medium", "low"]
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": "Certainty of this claim. 0.0=speculative, 1.0=verified."
           },
           "source": {
             "type": "string",

--- a/schemas/paper.json
+++ b/schemas/paper.json
@@ -60,9 +60,11 @@
       "description": "Slugs of concept pages this source informs"
     },
     "confidence": {
-      "type": "string",
-      "description": "Confidence level",
-      "enum": ["high", "medium", "low"]
+      "type": "number",
+      "description": "Certainty of this page's content. 0.0=speculative, 1.0=verified.",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "default": 0.5
     },
     "claims": {
       "type": "array",

--- a/schemas/paper.json
+++ b/schemas/paper.json
@@ -78,8 +78,10 @@
             "description": "The claim as a factual statement"
           },
           "confidence": {
-            "type": "string",
-            "enum": ["high", "medium", "low"]
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": "Certainty of this claim. 0.0=speculative, 1.0=verified."
           },
           "source": {
             "type": "string",

--- a/src/config.rs
+++ b/src/config.rs
@@ -232,6 +232,31 @@ impl Default for SuggestConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchConfig {
+    #[serde(default = "default_search_status")]
+    pub status: std::collections::HashMap<String, f32>,
+}
+
+fn default_search_status() -> std::collections::HashMap<String, f32> {
+    [
+        ("active".into(), 1.0_f32),
+        ("draft".into(), 0.8),
+        ("archived".into(), 0.3),
+        ("unknown".into(), 0.9),
+    ]
+    .into_iter()
+    .collect()
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            status: default_search_status(),
+        }
+    }
+}
+
 // ── Composite configs ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -258,6 +283,8 @@ pub struct GlobalConfig {
     pub history: HistoryConfig,
     #[serde(default)]
     pub suggest: SuggestConfig,
+    #[serde(default)]
+    pub search: SearchConfig,
     #[serde(default)]
     pub logging: LoggingConfig,
     #[serde(default)]
@@ -293,6 +320,8 @@ pub struct WikiConfig {
     pub history: Option<HistoryConfig>,
     #[serde(default)]
     pub suggest: Option<SuggestConfig>,
+    #[serde(default)]
+    pub search: Option<SearchConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -306,6 +335,7 @@ pub struct ResolvedConfig {
     pub validation: ValidationConfig,
     pub history: HistoryConfig,
     pub suggest: SuggestConfig,
+    pub search: SearchConfig,
 }
 
 // ── Default value helpers ─────────────────────────────────────────────────────
@@ -387,7 +417,6 @@ fn default_suggest_limit() -> u32 {
 fn default_suggest_min_score() -> f32 {
     0.1
 }
-
 // ── Functions ─────────────────────────────────────────────────────────────────
 
 pub fn resolve(global: &GlobalConfig, per_wiki: &WikiConfig) -> ResolvedConfig {
@@ -419,6 +448,15 @@ pub fn resolve(global: &GlobalConfig, per_wiki: &WikiConfig) -> ResolvedConfig {
             .suggest
             .clone()
             .unwrap_or_else(|| global.suggest.clone()),
+        search: {
+            let mut merged = global.search.status.clone();
+            if let Some(wiki_search) = &per_wiki.search {
+                for (k, v) in &wiki_search.status {
+                    merged.insert(k.clone(), *v);
+                }
+            }
+            SearchConfig { status: merged }
+        },
     }
 }
 

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -4,6 +4,21 @@ use anyhow::{Result, bail};
 use chrono::Local;
 use serde_yaml::Value;
 
+/// Read page-level `confidence` from frontmatter; map legacy string values.
+pub fn confidence(fm: &BTreeMap<String, Value>) -> f32 {
+    match fm.get("confidence") {
+        Some(Value::Number(n)) => n.as_f64().unwrap_or(0.5) as f32,
+        Some(Value::String(s)) => match s.as_str() {
+            "high" => 0.9,
+            "medium" => 0.5,
+            "low" => 0.2,
+            _ => 0.5,
+        },
+        _ => 0.5,
+    }
+    .clamp(0.0, 1.0)
+}
+
 use crate::slug::Slug;
 
 /// A parsed markdown page — untyped frontmatter + body.
@@ -138,6 +153,10 @@ pub fn scaffold(slug: &Slug, section: bool) -> BTreeMap<String, Value> {
     fm.insert(
         "type".into(),
         Value::String(if section { "section" } else { "page" }.into()),
+    );
+    fm.insert(
+        "confidence".into(),
+        Value::Number(serde_yaml::Number::from(0.5f64)),
     );
     fm
 }

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -524,10 +524,20 @@ fn index_page(
     doc.add_text(is.field("slug"), slug);
     doc.add_text(is.field("uri"), uri);
 
+    // Write confidence as f64 FAST field using the dedicated getter
+    if let Some(conf_field) = is.try_field("confidence") {
+        let conf = frontmatter::confidence(&page.frontmatter) as f64;
+        doc.add_f64(conf_field, conf);
+    }
+
     let resolved = resolve_fields(page, registry);
     let mut extra_text = String::new();
 
     for (canonical, value) in &resolved {
+        // confidence is already written above as a numeric field; skip text indexing
+        if canonical == "confidence" {
+            continue;
+        }
         index_value(&mut doc, &mut extra_text, is, canonical, value);
     }
 

--- a/src/index_schema.rs
+++ b/src/index_schema.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 use anyhow::Result;
 use tantivy::schema::{
-    FAST, Field, IndexRecordOption, STORED, STRING, Schema, TextFieldIndexing, TextOptions,
+    FAST, Field, IndexRecordOption, NumericOptions, STORED, STRING, Schema, TextFieldIndexing,
+    TextOptions,
 };
 
 use crate::config;
@@ -18,6 +19,7 @@ pub struct IndexSchema {
     pub schema: Schema,
     pub fields: HashMap<String, Field>,
     keyword_fields: HashSet<String>,
+    numeric_fields: HashSet<String>,
 }
 
 impl IndexSchema {
@@ -65,6 +67,7 @@ impl IndexSchema {
                 match classification {
                     FieldClass::Text => builder.add_text(field_name),
                     FieldClass::Keyword => builder.add_keyword(field_name),
+                    FieldClass::Numeric => builder.add_numeric(field_name),
                 }
             }
         }
@@ -74,6 +77,10 @@ impl IndexSchema {
 
     pub fn is_keyword(&self, name: &str) -> bool {
         self.keyword_fields.contains(name)
+    }
+
+    pub fn is_numeric(&self, name: &str) -> bool {
+        self.numeric_fields.contains(name)
     }
 
     pub fn field(&self, name: &str) -> Field {
@@ -91,6 +98,7 @@ impl IndexSchema {
 pub(crate) enum FieldClass {
     Text,
     Keyword,
+    Numeric,
 }
 
 pub(crate) fn classify_field(prop: &serde_json::Value, is_slug_field: bool) -> FieldClass {
@@ -120,7 +128,8 @@ pub(crate) fn classify_field(prop: &serde_json::Value, is_slug_field: bool) -> F
             }
             FieldClass::Text
         }
-        // object, number, integer, or unknown → text (serialized)
+        "number" | "integer" => FieldClass::Numeric,
+        // object or unknown → text (serialized)
         _ => FieldClass::Text,
     }
 }
@@ -227,6 +236,7 @@ pub(crate) struct SchemaBuilder {
     builder: tantivy::schema::SchemaBuilder,
     fields: HashMap<String, Field>,
     keyword_fields: HashSet<String>,
+    numeric_fields: HashSet<String>,
     text_opts: TextOptions,
 }
 
@@ -243,6 +253,7 @@ impl SchemaBuilder {
             builder: Schema::builder(),
             fields: HashMap::new(),
             keyword_fields: HashSet::new(),
+            numeric_fields: HashSet::new(),
             text_opts,
         }
     }
@@ -273,11 +284,21 @@ impl SchemaBuilder {
         }
     }
 
+    pub(crate) fn add_numeric(&mut self, name: &str) {
+        if !self.fields.contains_key(name) {
+            let opts = NumericOptions::default() | FAST | STORED;
+            let field = self.builder.add_f64_field(name, opts);
+            self.fields.insert(name.to_string(), field);
+            self.numeric_fields.insert(name.to_string());
+        }
+    }
+
     pub(crate) fn finish(self) -> IndexSchema {
         IndexSchema {
             schema: self.builder.build(),
             fields: self.fields,
             keyword_fields: self.keyword_fields,
+            numeric_fields: self.numeric_fields,
         }
     }
 }

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -28,6 +28,7 @@ pub fn search(
             .unwrap_or(resolved.defaults.search_top_k as usize),
         r#type: params.type_filter.map(|s| s.to_string()),
         facets_top_tags: resolved.defaults.facets_top_tags as usize,
+        search_config: resolved.search.clone(),
     };
 
     if params.cross_wiki {

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,13 +4,14 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tantivy::{
-    Order, Searcher, Term,
+    DocId, Order, Score, Searcher, Term,
     collector::{Count, TopDocs},
     query::{AllQuery, BooleanQuery, Occur, QueryParser, TermQuery},
     schema::{IndexRecordOption, Value},
     snippet::{Snippet, SnippetGenerator},
 };
 
+use crate::config::SearchConfig;
 use crate::index_schema::IndexSchema;
 
 // ── Return types ──────────────────────────────────────────────────────────────
@@ -22,6 +23,7 @@ pub struct PageRef {
     pub uri: String,
     pub title: String,
     pub score: f32,
+    pub confidence: f32,
     pub excerpt: Option<String>,
 }
 
@@ -34,6 +36,7 @@ pub struct PageSummary {
     pub r#type: String,
     pub status: String,
     pub tags: Vec<String>,
+    pub confidence: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,6 +82,7 @@ pub struct SearchOptions {
     pub top_k: usize,
     pub r#type: Option<String>,
     pub facets_top_tags: usize,
+    pub search_config: SearchConfig,
 }
 
 impl Default for SearchOptions {
@@ -89,6 +93,7 @@ impl Default for SearchOptions {
             top_k: 10,
             r#type: None,
             facets_top_tags: 10,
+            search_config: SearchConfig::default(),
         }
     }
 }
@@ -162,16 +167,51 @@ pub fn search(
         Box::new(BooleanQuery::new(clauses))
     };
 
-    let top_docs = searcher.search(
-        &final_query,
-        &TopDocs::with_limit(options.top_k).order_by_score(),
-    )?;
+    let sc = options.search_config.clone();
+    let has_confidence = is.try_field("confidence").is_some();
+    let collector = TopDocs::with_limit(options.top_k).tweak_score(
+        move |segment_reader: &tantivy::SegmentReader| {
+            let status_col = segment_reader
+                .fast_fields()
+                .str("status")
+                .ok()
+                .flatten();
+            let conf_col = if has_confidence {
+                segment_reader.fast_fields().f64("confidence").ok()
+            } else {
+                None
+            };
+            let status_map = sc.status.clone();
+            move |doc: DocId, score: Score| {
+                let unknown_mult = status_map.get("unknown").copied().unwrap_or(0.9);
+                let status_mult = match &status_col {
+                    Some(col) => match col.term_ords(doc).next() {
+                        Some(ord) => {
+                            let mut buf = String::new();
+                            col.ord_to_str(ord, &mut buf).ok();
+                            status_map.get(buf.as_str()).copied().unwrap_or(unknown_mult)
+                        }
+                        None => unknown_mult,
+                    },
+                    None => unknown_mult,
+                };
+                let confidence = conf_col
+                    .as_ref()
+                    .and_then(|c| c.first(doc))
+                    .unwrap_or(0.5) as f32;
+                score * status_mult * confidence
+            }
+        },
+    );
+    let top_docs = searcher.search(&final_query, &collector)?;
 
     let snippet_gen = if !options.no_excerpt {
         Some(SnippetGenerator::create(searcher, &final_query, f_body)?)
     } else {
         None
     };
+
+    let f_confidence = is.try_field("confidence");
 
     let mut results = Vec::new();
     for (score, doc_addr) in top_docs {
@@ -189,6 +229,11 @@ pub fn search(
             .to_string();
         let uri = format!("wiki://{wiki_name}/{slug}");
 
+        let confidence = f_confidence
+            .and_then(|f| doc.get_first(f))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.5) as f32;
+
         let excerpt = snippet_gen.as_ref().map(|sg| {
             let snippet: Snippet = sg.snippet_from_doc(&doc);
             snippet.to_html()
@@ -199,6 +244,7 @@ pub fn search(
             uri,
             title,
             score,
+            confidence,
             excerpt,
         });
     }
@@ -250,6 +296,7 @@ pub fn list(
     let f_type = is.field("type");
     let f_status = is.field("status");
     let f_tags = is.field("tags");
+    let f_confidence = is.try_field("confidence");
 
     let query: Box<dyn tantivy::query::Query> = {
         let mut clauses: Vec<(Occur, Box<dyn tantivy::query::Query>)> = Vec::new();
@@ -357,6 +404,11 @@ pub fn list(
             .map(|s| s.to_string())
             .collect();
 
+        let confidence = f_confidence
+            .and_then(|f| doc.get_first(f))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.5) as f32;
+
         let uri = format!("wiki://{wiki_name}/{slug}");
 
         summaries.push(PageSummary {
@@ -366,6 +418,7 @@ pub fn list(
             r#type: page_type,
             status,
             tags,
+            confidence,
         });
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -171,11 +171,7 @@ pub fn search(
     let has_confidence = is.try_field("confidence").is_some();
     let collector = TopDocs::with_limit(options.top_k).tweak_score(
         move |segment_reader: &tantivy::SegmentReader| {
-            let status_col = segment_reader
-                .fast_fields()
-                .str("status")
-                .ok()
-                .flatten();
+            let status_col = segment_reader.fast_fields().str("status").ok().flatten();
             let conf_col = if has_confidence {
                 segment_reader.fast_fields().f64("confidence").ok()
             } else {
@@ -189,16 +185,16 @@ pub fn search(
                         Some(ord) => {
                             let mut buf = String::new();
                             col.ord_to_str(ord, &mut buf).ok();
-                            status_map.get(buf.as_str()).copied().unwrap_or(unknown_mult)
+                            status_map
+                                .get(buf.as_str())
+                                .copied()
+                                .unwrap_or(unknown_mult)
                         }
                         None => unknown_mult,
                     },
                     None => unknown_mult,
                 };
-                let confidence = conf_col
-                    .as_ref()
-                    .and_then(|c| c.first(doc))
-                    .unwrap_or(0.5) as f32;
+                let confidence = conf_col.as_ref().and_then(|c| c.first(doc)).unwrap_or(0.5) as f32;
                 score * status_mult * confidence
             }
         },

--- a/src/space_builder.rs
+++ b/src/space_builder.rs
@@ -177,6 +177,7 @@ fn assemble(
             match classify_field(field_def, is_slug) {
                 FieldClass::Text => schema_builder.add_text(field_name),
                 FieldClass::Keyword => schema_builder.add_keyword(field_name),
+                FieldClass::Numeric => schema_builder.add_numeric(field_name),
             }
         }
     }
@@ -249,6 +250,7 @@ fn assemble_without_overrides(
             match classify_field(field_def, is_slug) {
                 FieldClass::Text => schema_builder.add_text(field_name),
                 FieldClass::Keyword => schema_builder.add_keyword(field_name),
+                FieldClass::Numeric => schema_builder.add_numeric(field_name),
             }
         }
     }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -481,6 +481,78 @@ fn get_config_value_unknown_key() {
     assert!(get_config_value(&resolved, &global, "nonexistent.key").contains("unknown"));
 }
 
+// ── SearchConfig ──────────────────────────────────────────────────────────────
+
+#[test]
+fn search_config_default_has_four_built_ins() {
+    let sc = SearchConfig::default();
+    assert_eq!(sc.status.get("active").copied(), Some(1.0_f32));
+    assert_eq!(sc.status.get("draft").copied(), Some(0.8_f32));
+    assert_eq!(sc.status.get("archived").copied(), Some(0.3_f32));
+    assert_eq!(sc.status.get("unknown").copied(), Some(0.9_f32));
+}
+
+#[test]
+fn search_config_roundtrips_custom_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        r#"
+[search.status]
+active     = 1.0
+draft      = 0.8
+archived   = 0.3
+unknown    = 0.9
+verified   = 1.0
+stub       = 0.6
+deprecated = 0.1
+"#,
+    )
+    .unwrap();
+
+    let config = load_global(&path).unwrap();
+    let sc = &config.search;
+    assert_eq!(sc.status.get("active").copied(), Some(1.0_f32));
+    assert_eq!(sc.status.get("stub").copied(), Some(0.6_f32));
+    assert_eq!(sc.status.get("deprecated").copied(), Some(0.1_f32));
+    assert_eq!(sc.status.get("verified").copied(), Some(1.0_f32));
+}
+
+#[test]
+fn resolve_search_status_merges_per_wiki() {
+    let global = GlobalConfig {
+        search: SearchConfig {
+            status: [
+                ("active".into(), 1.0_f32),
+                ("draft".into(), 0.8),
+                ("archived".into(), 0.3),
+                ("unknown".into(), 0.9),
+            ]
+            .into_iter()
+            .collect(),
+        },
+        ..Default::default()
+    };
+    let per_wiki = WikiConfig {
+        search: Some(SearchConfig {
+            status: [
+                ("archived".into(), 0.0_f32), // override
+                ("stub".into(), 0.6),         // add
+            ]
+            .into_iter()
+            .collect(),
+        }),
+        ..Default::default()
+    };
+    let resolved = resolve(&global, &per_wiki);
+    assert_eq!(resolved.search.status.get("active").copied(), Some(1.0_f32), "active inherited");
+    assert_eq!(resolved.search.status.get("draft").copied(), Some(0.8_f32), "draft inherited");
+    assert_eq!(resolved.search.status.get("archived").copied(), Some(0.0_f32), "archived overridden");
+    assert_eq!(resolved.search.status.get("unknown").copied(), Some(0.9_f32), "unknown inherited");
+    assert_eq!(resolved.search.status.get("stub").copied(), Some(0.6_f32), "stub added by wiki");
+}
+
 // ── types registry in wiki.toml ──────────────────────────────────────────────
 
 #[test]

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -546,11 +546,31 @@ fn resolve_search_status_merges_per_wiki() {
         ..Default::default()
     };
     let resolved = resolve(&global, &per_wiki);
-    assert_eq!(resolved.search.status.get("active").copied(), Some(1.0_f32), "active inherited");
-    assert_eq!(resolved.search.status.get("draft").copied(), Some(0.8_f32), "draft inherited");
-    assert_eq!(resolved.search.status.get("archived").copied(), Some(0.0_f32), "archived overridden");
-    assert_eq!(resolved.search.status.get("unknown").copied(), Some(0.9_f32), "unknown inherited");
-    assert_eq!(resolved.search.status.get("stub").copied(), Some(0.6_f32), "stub added by wiki");
+    assert_eq!(
+        resolved.search.status.get("active").copied(),
+        Some(1.0_f32),
+        "active inherited"
+    );
+    assert_eq!(
+        resolved.search.status.get("draft").copied(),
+        Some(0.8_f32),
+        "draft inherited"
+    );
+    assert_eq!(
+        resolved.search.status.get("archived").copied(),
+        Some(0.0_f32),
+        "archived overridden"
+    );
+    assert_eq!(
+        resolved.search.status.get("unknown").copied(),
+        Some(0.9_f32),
+        "unknown inherited"
+    );
+    assert_eq!(
+        resolved.search.status.get("stub").copied(),
+        Some(0.6_f32),
+        "stub added by wiki"
+    );
 }
 
 // ── types registry in wiki.toml ──────────────────────────────────────────────

--- a/tests/default_schemas.rs
+++ b/tests/default_schemas.rs
@@ -81,9 +81,19 @@ fn concept_accepts_full_template() {
         "confidence": 0.9,
         "claims": [{
             "text": "Sparse MoE reduces effective compute 8x",
-            "confidence": "high",
+            "confidence": 0.9,
             "section": "Results"
         }]
+    })));
+}
+
+#[test]
+fn concept_rejects_string_confidence_in_claim() {
+    let v = compile("concept.json");
+    assert!(!v.is_valid(&json!({
+        "title": "Test", "type": "concept",
+        "read_when": ["test"],
+        "claims": [{"text": "some claim", "confidence": "high"}]
     })));
 }
 
@@ -110,7 +120,16 @@ fn paper_accepts_source_template() {
         "read_when": ["Looking for MoE benchmark results"],
         "concepts": ["concepts/mixture-of-experts"],
         "confidence": 0.9,
-        "claims": [{"text": "Switch routing achieves 4x speedup", "confidence": "high"}]
+        "claims": [{"text": "Switch routing achieves 4x speedup", "confidence": 0.9}]
+    })));
+}
+
+#[test]
+fn paper_rejects_string_confidence_in_claim() {
+    let v = compile("paper.json");
+    assert!(!v.is_valid(&json!({
+        "title": "Test", "type": "paper",
+        "claims": [{"text": "some claim", "confidence": "high"}]
     })));
 }
 

--- a/tests/default_schemas.rs
+++ b/tests/default_schemas.rs
@@ -78,7 +78,7 @@ fn concept_accepts_full_template() {
         "tags": ["mixture-of-experts", "scaling"],
         "sources": ["sources/switch-transformer-2021"],
         "concepts": ["concepts/scaling-laws"],
-        "confidence": "high",
+        "confidence": 0.9,
         "claims": [{
             "text": "Sparse MoE reduces effective compute 8x",
             "confidence": "high",
@@ -109,7 +109,7 @@ fn paper_accepts_source_template() {
         "status": "active",
         "read_when": ["Looking for MoE benchmark results"],
         "concepts": ["concepts/mixture-of-experts"],
-        "confidence": "high",
+        "confidence": 0.9,
         "claims": [{"text": "Switch routing achieves 4x speedup", "confidence": "high"}]
     })));
 }

--- a/tests/frontmatter.rs
+++ b/tests/frontmatter.rs
@@ -147,14 +147,17 @@ fn scaffold_emits_confidence_half() {
 
 #[test]
 fn confidence_maps_legacy_strings() {
-    use std::collections::BTreeMap;
     use serde_yaml::Value;
+    use std::collections::BTreeMap;
 
     let mut fm = BTreeMap::new();
     fm.insert("confidence".to_string(), Value::String("high".to_string()));
     assert!((confidence(&fm) - 0.9).abs() < f32::EPSILON);
 
-    fm.insert("confidence".to_string(), Value::String("medium".to_string()));
+    fm.insert(
+        "confidence".to_string(),
+        Value::String("medium".to_string()),
+    );
     assert!((confidence(&fm) - 0.5).abs() < f32::EPSILON);
 
     fm.insert("confidence".to_string(), Value::String("low".to_string()));
@@ -170,8 +173,8 @@ fn confidence_absent_returns_default() {
 
 #[test]
 fn confidence_numeric_value() {
-    use std::collections::BTreeMap;
     use serde_yaml::Value;
+    use std::collections::BTreeMap;
 
     let mut fm = BTreeMap::new();
     fm.insert(
@@ -183,8 +186,8 @@ fn confidence_numeric_value() {
 
 #[test]
 fn confidence_out_of_range_clamped() {
-    use std::collections::BTreeMap;
     use serde_yaml::Value;
+    use std::collections::BTreeMap;
 
     let mut fm = BTreeMap::new();
     fm.insert(

--- a/tests/frontmatter.rs
+++ b/tests/frontmatter.rs
@@ -135,6 +135,71 @@ fn scaffold_section() {
     assert_eq!(fm.get("type").unwrap().as_str(), Some("section"));
 }
 
+#[test]
+fn scaffold_emits_confidence_half() {
+    let slug = Slug::try_from("concepts/test").unwrap();
+    let fm = scaffold(&slug, false);
+    let c = fm.get("confidence").unwrap().as_f64().unwrap();
+    assert!((c - 0.5).abs() < f64::EPSILON);
+}
+
+// ── confidence getter ─────────────────────────────────────────────────────────
+
+#[test]
+fn confidence_maps_legacy_strings() {
+    use std::collections::BTreeMap;
+    use serde_yaml::Value;
+
+    let mut fm = BTreeMap::new();
+    fm.insert("confidence".to_string(), Value::String("high".to_string()));
+    assert!((confidence(&fm) - 0.9).abs() < f32::EPSILON);
+
+    fm.insert("confidence".to_string(), Value::String("medium".to_string()));
+    assert!((confidence(&fm) - 0.5).abs() < f32::EPSILON);
+
+    fm.insert("confidence".to_string(), Value::String("low".to_string()));
+    assert!((confidence(&fm) - 0.2).abs() < f32::EPSILON);
+}
+
+#[test]
+fn confidence_absent_returns_default() {
+    use std::collections::BTreeMap;
+    let fm = BTreeMap::new();
+    assert!((confidence(&fm) - 0.5).abs() < f32::EPSILON);
+}
+
+#[test]
+fn confidence_numeric_value() {
+    use std::collections::BTreeMap;
+    use serde_yaml::Value;
+
+    let mut fm = BTreeMap::new();
+    fm.insert(
+        "confidence".to_string(),
+        Value::Number(serde_yaml::Number::from(0.8f64)),
+    );
+    assert!((confidence(&fm) - 0.8).abs() < 1e-6);
+}
+
+#[test]
+fn confidence_out_of_range_clamped() {
+    use std::collections::BTreeMap;
+    use serde_yaml::Value;
+
+    let mut fm = BTreeMap::new();
+    fm.insert(
+        "confidence".to_string(),
+        Value::Number(serde_yaml::Number::from(1.5f64)),
+    );
+    assert!((confidence(&fm) - 1.0).abs() < f32::EPSILON);
+
+    fm.insert(
+        "confidence".to_string(),
+        Value::Number(serde_yaml::Number::from(-0.5f64)),
+    );
+    assert!((confidence(&fm) - 0.0).abs() < f32::EPSILON);
+}
+
 // ── title_from_body_or_filename ───────────────────────────────────────────────
 
 #[test]

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use llm_wiki::config::SearchConfig;
 use llm_wiki::git;
 use llm_wiki::index_manager::SpaceIndexManager;
 use llm_wiki::index_schema::IndexSchema;
@@ -363,4 +364,221 @@ fn search_all_skips_missing_index() {
     let wikis = vec![("good".into(), mgr.searcher().unwrap(), &is)];
     let results = search_all("Foo", &SearchOptions::default(), &wikis).unwrap();
     assert!(!results.results.is_empty());
+}
+
+// ── ranking: status multiplier ────────────────────────────────────────────────
+
+fn status_page(slug_name: &str, status: &str) -> String {
+    format!(
+        "---\ntitle: \"{slug_name}\"\nstatus: {status}\ntype: concept\n---\n\nidentical ranking body text for testing\n"
+    )
+}
+
+fn confidence_page(slug_name: &str, conf: f64) -> String {
+    format!(
+        "---\ntitle: \"{slug_name}\"\nstatus: active\ntype: concept\nconfidence: {conf}\n---\n\nidentical ranking body text for testing\n"
+    )
+}
+
+#[test]
+fn search_ranking_active_above_draft_above_archived() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(&wiki_root, "concepts/archived.md", &status_page("Archived", "archived"));
+    write_page(&wiki_root, "concepts/draft.md", &status_page("Draft", "draft"));
+    write_page(&wiki_root, "concepts/active.md", &status_page("Active", "active"));
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let results = search(
+        "identical ranking body",
+        &SearchOptions::default(),
+        &mgr.searcher().unwrap(),
+        "test",
+        &is,
+    )
+    .unwrap();
+
+    assert_eq!(results.results.len(), 3);
+    let slugs: Vec<&str> = results.results.iter().map(|r| r.slug.as_str()).collect();
+    let pos_active = slugs.iter().position(|&s| s == "concepts/active").unwrap();
+    let pos_draft = slugs.iter().position(|&s| s == "concepts/draft").unwrap();
+    let pos_archived = slugs.iter().position(|&s| s == "concepts/archived").unwrap();
+    assert!(pos_active < pos_draft, "active should rank above draft");
+    assert!(pos_draft < pos_archived, "draft should rank above archived");
+}
+
+#[test]
+fn search_ranking_high_confidence_above_low() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(&wiki_root, "concepts/low.md", &confidence_page("Low", 0.2));
+    write_page(&wiki_root, "concepts/high.md", &confidence_page("High", 0.9));
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let results = search(
+        "identical ranking body",
+        &SearchOptions::default(),
+        &mgr.searcher().unwrap(),
+        "test",
+        &is,
+    )
+    .unwrap();
+
+    assert_eq!(results.results.len(), 2);
+    assert_eq!(results.results[0].slug, "concepts/high");
+    assert_eq!(results.results[1].slug, "concepts/low");
+}
+
+#[test]
+fn search_ranking_archived_high_confidence_below_active_medium() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    // archived + 1.0 = 0.3 × 1.0 = 0.3 < active + 0.5 = 1.0 × 0.5 = 0.5
+    write_page(
+        &wiki_root,
+        "concepts/archived-high.md",
+        "---\ntitle: \"Archived High\"\nstatus: archived\ntype: concept\nconfidence: 1.0\n---\n\nidentical ranking body text for testing\n",
+    );
+    write_page(
+        &wiki_root,
+        "concepts/active-mid.md",
+        "---\ntitle: \"Active Mid\"\nstatus: active\ntype: concept\nconfidence: 0.5\n---\n\nidentical ranking body text for testing\n",
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let results = search(
+        "identical ranking body",
+        &SearchOptions::default(),
+        &mgr.searcher().unwrap(),
+        "test",
+        &is,
+    )
+    .unwrap();
+
+    assert_eq!(results.results.len(), 2);
+    assert_eq!(results.results[0].slug, "concepts/active-mid");
+}
+
+#[test]
+fn search_ranking_custom_config_zero_archived() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(&wiki_root, "concepts/archived.md", &status_page("Archived", "archived"));
+    write_page(&wiki_root, "concepts/active.md", &status_page("Active", "active"));
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let mut custom_status = llm_wiki::config::SearchConfig::default();
+    custom_status.status.insert("archived".into(), 0.0);
+    let opts = SearchOptions {
+        search_config: custom_status,
+        ..SearchOptions::default()
+    };
+    let results = search(
+        "identical ranking body",
+        &opts,
+        &mgr.searcher().unwrap(),
+        "test",
+        &is,
+    )
+    .unwrap();
+
+    // archived pages score 0 so should not appear or appear last with score 0
+    let slugs: Vec<&str> = results.results.iter().map(|r| r.slug.as_str()).collect();
+    let pos_active = slugs.iter().position(|&s| s == "concepts/active").unwrap();
+    let pos_archived = slugs.iter().position(|&s| s == "concepts/archived").unwrap();
+    assert!(pos_active < pos_archived);
+}
+
+#[test]
+fn search_ranking_custom_status_mapped() {
+    // active × 1.0 × 0.5 = 0.5  >  stub × 0.6 × 0.5 = 0.3
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/stub-page.md",
+        "---\ntitle: \"Stub\"\nstatus: stub\ntype: concept\nconfidence: 0.5\n---\n\nidentical ranking body text for testing\n",
+    );
+    write_page(
+        &wiki_root,
+        "concepts/active-page.md",
+        "---\ntitle: \"Active\"\nstatus: active\ntype: concept\nconfidence: 0.5\n---\n\nidentical ranking body text for testing\n",
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let mut custom_sc = SearchConfig::default();
+    custom_sc.status.insert("stub".into(), 0.6);
+    let opts = SearchOptions {
+        search_config: custom_sc,
+        ..SearchOptions::default()
+    };
+    let results = search(
+        "identical ranking body",
+        &opts,
+        &mgr.searcher().unwrap(),
+        "test",
+        &is,
+    )
+    .unwrap();
+
+    assert_eq!(results.results.len(), 2);
+    let slugs: Vec<&str> = results.results.iter().map(|r| r.slug.as_str()).collect();
+    let pos_active = slugs.iter().position(|&s| s == "concepts/active-page").unwrap();
+    let pos_stub = slugs.iter().position(|&s| s == "concepts/stub-page").unwrap();
+    assert!(pos_active < pos_stub, "active (×1.0) should rank above stub (×0.6)");
+}
+
+#[test]
+fn search_ranking_custom_status_falls_back_to_unknown() {
+    // stub has no entry in the map → uses unknown (×0.9)
+    // a page with no status also uses unknown (×0.9)
+    // both should produce the same multiplier and thus equal scores
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/has-stub.md",
+        "---\ntitle: \"Has Stub\"\nstatus: stub\ntype: concept\nconfidence: 0.5\n---\n\nidentical ranking body text for testing\n",
+    );
+    write_page(
+        &wiki_root,
+        "concepts/no-status.md",
+        "---\ntitle: \"No Status\"\ntype: concept\nconfidence: 0.5\n---\n\nidentical ranking body text for testing\n",
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    // default config: no "stub" entry — falls back to "unknown" = 0.9
+    let results = search(
+        "identical ranking body",
+        &SearchOptions::default(),
+        &mgr.searcher().unwrap(),
+        "test",
+        &is,
+    )
+    .unwrap();
+
+    assert_eq!(results.results.len(), 2);
+    let score_stub = results
+        .results
+        .iter()
+        .find(|r| r.slug == "concepts/has-stub")
+        .unwrap()
+        .score;
+    let score_no_status = results
+        .results
+        .iter()
+        .find(|r| r.slug == "concepts/no-status")
+        .unwrap()
+        .score;
+    // Both use unknown multiplier; scores should be equal (same body, same confidence, same multiplier)
+    assert!(
+        (score_stub - score_no_status).abs() < 1e-5,
+        "stub (no map entry) and no-status should score the same; got {score_stub} vs {score_no_status}"
+    );
 }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -384,9 +384,21 @@ fn confidence_page(slug_name: &str, conf: f64) -> String {
 fn search_ranking_active_above_draft_above_archived() {
     let dir = tempfile::tempdir().unwrap();
     let wiki_root = setup_repo(dir.path());
-    write_page(&wiki_root, "concepts/archived.md", &status_page("Archived", "archived"));
-    write_page(&wiki_root, "concepts/draft.md", &status_page("Draft", "draft"));
-    write_page(&wiki_root, "concepts/active.md", &status_page("Active", "active"));
+    write_page(
+        &wiki_root,
+        "concepts/archived.md",
+        &status_page("Archived", "archived"),
+    );
+    write_page(
+        &wiki_root,
+        "concepts/draft.md",
+        &status_page("Draft", "draft"),
+    );
+    write_page(
+        &wiki_root,
+        "concepts/active.md",
+        &status_page("Active", "active"),
+    );
 
     let mgr = build_index(dir.path(), &wiki_root);
     let is = schema();
@@ -403,7 +415,10 @@ fn search_ranking_active_above_draft_above_archived() {
     let slugs: Vec<&str> = results.results.iter().map(|r| r.slug.as_str()).collect();
     let pos_active = slugs.iter().position(|&s| s == "concepts/active").unwrap();
     let pos_draft = slugs.iter().position(|&s| s == "concepts/draft").unwrap();
-    let pos_archived = slugs.iter().position(|&s| s == "concepts/archived").unwrap();
+    let pos_archived = slugs
+        .iter()
+        .position(|&s| s == "concepts/archived")
+        .unwrap();
     assert!(pos_active < pos_draft, "active should rank above draft");
     assert!(pos_draft < pos_archived, "draft should rank above archived");
 }
@@ -413,7 +428,11 @@ fn search_ranking_high_confidence_above_low() {
     let dir = tempfile::tempdir().unwrap();
     let wiki_root = setup_repo(dir.path());
     write_page(&wiki_root, "concepts/low.md", &confidence_page("Low", 0.2));
-    write_page(&wiki_root, "concepts/high.md", &confidence_page("High", 0.9));
+    write_page(
+        &wiki_root,
+        "concepts/high.md",
+        &confidence_page("High", 0.9),
+    );
 
     let mgr = build_index(dir.path(), &wiki_root);
     let is = schema();
@@ -466,8 +485,16 @@ fn search_ranking_archived_high_confidence_below_active_medium() {
 fn search_ranking_custom_config_zero_archived() {
     let dir = tempfile::tempdir().unwrap();
     let wiki_root = setup_repo(dir.path());
-    write_page(&wiki_root, "concepts/archived.md", &status_page("Archived", "archived"));
-    write_page(&wiki_root, "concepts/active.md", &status_page("Active", "active"));
+    write_page(
+        &wiki_root,
+        "concepts/archived.md",
+        &status_page("Archived", "archived"),
+    );
+    write_page(
+        &wiki_root,
+        "concepts/active.md",
+        &status_page("Active", "active"),
+    );
 
     let mgr = build_index(dir.path(), &wiki_root);
     let is = schema();
@@ -489,7 +516,10 @@ fn search_ranking_custom_config_zero_archived() {
     // archived pages score 0 so should not appear or appear last with score 0
     let slugs: Vec<&str> = results.results.iter().map(|r| r.slug.as_str()).collect();
     let pos_active = slugs.iter().position(|&s| s == "concepts/active").unwrap();
-    let pos_archived = slugs.iter().position(|&s| s == "concepts/archived").unwrap();
+    let pos_archived = slugs
+        .iter()
+        .position(|&s| s == "concepts/archived")
+        .unwrap();
     assert!(pos_active < pos_archived);
 }
 
@@ -528,9 +558,18 @@ fn search_ranking_custom_status_mapped() {
 
     assert_eq!(results.results.len(), 2);
     let slugs: Vec<&str> = results.results.iter().map(|r| r.slug.as_str()).collect();
-    let pos_active = slugs.iter().position(|&s| s == "concepts/active-page").unwrap();
-    let pos_stub = slugs.iter().position(|&s| s == "concepts/stub-page").unwrap();
-    assert!(pos_active < pos_stub, "active (×1.0) should rank above stub (×0.6)");
+    let pos_active = slugs
+        .iter()
+        .position(|&s| s == "concepts/active-page")
+        .unwrap();
+    let pos_stub = slugs
+        .iter()
+        .position(|&s| s == "concepts/stub-page")
+        .unwrap();
+    assert!(
+        pos_active < pos_stub,
+        "active (×1.0) should rank above stub (×0.6)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Implements imp-1 (confidence field) and imp-2 (lifecycle-aware search ranking).

- Add `confidence: 0.0–1.0` to base schema as a numeric tantivy field
- Add `fn confidence()` getter with legacy string mapping
- Add `confidence: 0.5` to page scaffold
- Add `SearchConfig` with status map + key-level per-wiki merge (global + per-wiki)
- Replace `order_by_score()` with `tweak_score` collector
- Align `claims[].confidence` to float (was string enum — imp-1b)
- Add `docs/guides/search-ranking.md` guide (imp-2b)

Closes geronimo-iia/llm-wiki#22 (imp-1, imp-1b, imp-2, imp-2b)

Spec: docs/improvements/confidence.md, docs/improvements/search-ranking.md, docs/improvements/claims-confidence-float.md, docs/improvements/search-ranking-custom-status.md