### PR TITLE
feat: backlinks param on wiki_content_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Backlinks** — `backlinks: true` parameter on `wiki_content_read`; returns JSON `{ content, backlinks: [{slug, title}] }` via a term query on the `body_links` index field; no file writes, no index mutation; empty array when no pages link to the target
 - **Confidence field** — `confidence: 0.0–1.0` on every page; numeric tantivy fast field; legacy string values (`high` / `medium` / `low`) mapped automatically on read
 - **Lifecycle-aware search ranking** — `tweak_score` collector multiplies BM25 score by `status_multiplier × confidence`; ranking formula: `final_score = bm25 × status × confidence`
 - **`[search.status]` map in config** — flat `HashMap<String, f32>` replaces four named fields; built-in defaults (`active=1.0`, `draft=0.8`, `archived=0.3`, `unknown=0.9`); custom statuses (`verified`, `stub`, `deprecated`, …) added with no code change; per-wiki `wiki.toml` overrides individual keys (key-level merge, not all-or-nothing)

--- a/docs/improvements/backlinks.md
+++ b/docs/improvements/backlinks.md
@@ -1,7 +1,7 @@
 ---
 title: "Backlinks"
 summary: "Expose incoming links on wiki_content_read via an index query, no file writes."
-status: proposed
+status: implemented
 last_updated: "2026-04-27"
 ---
 
@@ -59,6 +59,12 @@ git checkout -b feat/backlinks
 When implementation is complete and all tests pass:
 
 ```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+```bash
 git push -u origin feat/backlinks
 gh pr create \
   --title "feat: backlinks param on wiki_content_read" \
@@ -110,15 +116,15 @@ EOF
 
 ### Engine — `llm-wiki` (branch: `feat/backlinks`)
 
-- [ ] Add `BacklinkRef { slug: String, title: String }` struct to content ops return types; derive `Serialize`.
-- [ ] Add `backlinks_for(slug: &str, searcher: &Searcher, is: &IndexSchema) -> Vec<BacklinkRef>` in `src/ops/content.rs`; term query on `body_links` keyword field.
-- [ ] Add `backlinks: bool` parameter to `wiki_content_read` MCP tool definition in `src/tools.rs`.
-- [ ] In `handlers::handle_content_read`, when `backlinks: true`, call `backlinks_for` and include the result in the JSON response.
-- [ ] Update `wiki_content_read` response schema in `docs/specifications/tools/content-operations.md`.
-- [ ] Unit test: two pages link to a third; `backlinks_for` returns both; a page with no incoming links returns an empty vec.
-- [ ] Unit test: `backlinks: false` (default) returns no `backlinks` field in the response (no overhead for the common case).
+- [x] Add `BacklinkRef { slug: String, title: String }` struct to content ops return types; derive `Serialize`.
+- [x] Add `backlinks_for(slug: &str, searcher: &Searcher, is: &IndexSchema) -> Vec<BacklinkRef>` in `src/ops/content.rs`; term query on `body_links` keyword field.
+- [x] Add `backlinks: bool` parameter to `wiki_content_read` MCP tool definition in `src/tools.rs`.
+- [x] In `handlers::handle_content_read`, when `backlinks: true`, call `backlinks_for` and include the result in the JSON response.
+- [x] Update `wiki_content_read` response schema in `docs/specifications/tools/content-operations.md`.
+- [x] Unit test: two pages link to a third; `backlinks_for` returns both; a page with no incoming links returns an empty vec.
+- [x] Unit test: `backlinks: false` (default) returns no `backlinks` field in the response (no overhead for the common case).
 
 ### Skills — `llm-wiki-skills` (branch: `feat/backlinks`)
 
-- [ ] `skills/content/SKILL.md`: document `backlinks: true` parameter on `wiki_content_read`; show example response with `backlinks` array.
-- [ ] `skills/research/SKILL.md`: add backlinks as a discovery technique (when tracing what references a page).
+- [x] `skills/content/SKILL.md`: document `backlinks: true` parameter on `wiki_content_read`; show example response with `backlinks` array.
+- [x] `skills/research/SKILL.md`: add backlinks as a discovery technique (when tracing what references a page).

--- a/docs/specifications/tools/content-operations.md
+++ b/docs/specifications/tools/content-operations.md
@@ -6,7 +6,7 @@ read_when:
   - Creating new pages or sections
   - Committing changes to git
 status: ready
-last_updated: "2025-07-17"
+last_updated: "2026-04-27"
 ---
 
 # Content Operations
@@ -32,6 +32,7 @@ MCP tool: `wiki_content_read`
 llm-wiki content read <slug|uri>
           [--no-frontmatter]        # strip frontmatter
           [--list-assets]           # list co-located assets of a bundle
+          [--backlinks]             # include incoming links (pages that link to this page)
           [--format <fmt>]          # text | json (default: from config)
           [--wiki <name>]
 ```
@@ -42,6 +43,26 @@ full URI (`wiki://research/concepts/moe`). Also reads bundle assets
 
 When a page has `superseded_by` set, the output includes a notice
 pointing to the replacement.
+
+### Backlinks
+
+When `--backlinks` is passed, the response is JSON instead of plain text:
+
+```json
+{
+  "content": "# Page content ...",
+  "backlinks": [
+    { "slug": "concepts/alpha", "title": "Alpha" },
+    { "slug": "concepts/beta",  "title": "Beta"  }
+  ]
+}
+```
+
+`backlinks` lists all pages whose body contains a `[[<target-slug>]]` wikilink.
+The result is a term query on the `body_links` index field — no file writes,
+no index mutation. Returns an empty array when no pages link to this page.
+
+Without `--backlinks` (default), the response is the raw page content as plain text.
 
 ## content write
 

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -113,6 +113,7 @@ pub fn handle_content_read(server: &McpServer, args: &Map<String, Value>) -> Too
     let wiki_flag = arg_str(args, "wiki");
     let no_frontmatter = arg_bool(args, "no_frontmatter");
     let list_assets = arg_bool(args, "list_assets");
+    let include_backlinks = arg_bool(args, "backlinks");
 
     match ops::content_read(
         &engine,
@@ -123,7 +124,24 @@ pub fn handle_content_read(server: &McpServer, args: &Map<String, Value>) -> Too
     )
     .map_err(|e| format!("{e}"))?
     {
-        ops::ContentReadResult::Page(content) => ok_text(content),
+        ops::ContentReadResult::Page(content) => {
+            if include_backlinks {
+                use crate::slug::WikiUri;
+                let wiki_name = engine.resolve_wiki_name(wiki_flag.as_deref()).to_string();
+                let (_entry, slug) = WikiUri::resolve(&uri, wiki_flag.as_deref(), &engine.config)
+                    .map_err(|e| format!("{e}"))?;
+                let backlinks = ops::backlinks_for(&engine, &wiki_name, slug.as_str())
+                    .map_err(|e| format!("{e}"))?;
+                let response = serde_json::json!({
+                    "content": content,
+                    "backlinks": backlinks,
+                });
+                let s = serde_json::to_string_pretty(&response).map_err(|e| format!("{e}"))?;
+                ok_text(s)
+            } else {
+                ok_text(content)
+            }
+        }
         ops::ContentReadResult::Assets(assets) => ok_text(assets.join("\n")),
         ops::ContentReadResult::Binary => {
             Err("asset is binary — access it directly from the filesystem".into())

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -109,6 +109,7 @@ pub fn tool_list() -> Vec<Tool> {
                     "uri": str_prop("Slug or wiki:// URI"),
                     "no_frontmatter": opt_bool("Strip frontmatter from output"),
                     "list_assets": opt_bool("List co-located assets instead of content"),
+                    "backlinks": opt_bool("Include incoming links — pages that link to this page"),
                     "wiki": opt_str("Target wiki name"),
                 }),
                 &["uri"],

--- a/src/ops/content.rs
+++ b/src/ops/content.rs
@@ -1,12 +1,75 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
+use serde::Serialize;
+use tantivy::{
+    Searcher, Term,
+    query::TermQuery,
+    schema::{IndexRecordOption, Value},
+};
 
 use crate::config;
 use crate::engine::EngineState;
 use crate::git;
+use crate::index_schema::IndexSchema;
 use crate::markdown;
 use crate::slug::{ReadTarget, Slug, WikiUri, resolve_read_target};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BacklinkRef {
+    pub slug: String,
+    pub title: String,
+}
+
+pub fn backlinks_query(
+    searcher: &Searcher,
+    is: &IndexSchema,
+    target_slug: &str,
+) -> Result<Vec<BacklinkRef>> {
+    let f_body_links = is.field("body_links");
+    let f_slug = is.field("slug");
+    let f_title = is.field("title");
+
+    let term = Term::from_field_text(f_body_links, target_slug);
+    let query = TermQuery::new(term, IndexRecordOption::Basic);
+
+    let doc_addrs = searcher.search(&query, &tantivy::collector::DocSetCollector)?;
+
+    let mut refs: Vec<BacklinkRef> = doc_addrs
+        .into_iter()
+        .filter_map(|addr| {
+            let doc: tantivy::TantivyDocument = searcher.doc(addr).ok()?;
+            let slug = doc
+                .get_first(f_slug)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let title = doc
+                .get_first(f_title)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if slug.is_empty() {
+                None
+            } else {
+                Some(BacklinkRef { slug, title })
+            }
+        })
+        .collect();
+
+    refs.sort_by(|a, b| a.slug.cmp(&b.slug));
+    Ok(refs)
+}
+
+pub fn backlinks_for(
+    engine: &EngineState,
+    wiki_name: &str,
+    target_slug: &str,
+) -> Result<Vec<BacklinkRef>> {
+    let space = engine.space(wiki_name)?;
+    let searcher = space.index_manager.searcher()?;
+    backlinks_query(&searcher, &space.index_schema, target_slug)
+}
 
 pub enum ContentReadResult {
     Page(String),

--- a/tests/backlinks.rs
+++ b/tests/backlinks.rs
@@ -1,0 +1,117 @@
+use std::fs;
+use std::path::Path;
+
+use llm_wiki::git;
+use llm_wiki::index_manager::SpaceIndexManager;
+use llm_wiki::index_schema::IndexSchema;
+use llm_wiki::ops::backlinks_query;
+use llm_wiki::space_builder;
+use llm_wiki::type_registry::SpaceTypeRegistry;
+
+fn schema() -> IndexSchema {
+    let (_registry, schema) = space_builder::build_space_from_embedded("en_stem");
+    schema
+}
+
+fn registry() -> SpaceTypeRegistry {
+    let (registry, _schema) = space_builder::build_space_from_embedded("en_stem");
+    registry
+}
+
+fn setup_repo(dir: &Path) -> std::path::PathBuf {
+    let wiki_root = dir.join("wiki");
+    fs::create_dir_all(&wiki_root).unwrap();
+    fs::create_dir_all(dir.join("inbox")).unwrap();
+    fs::create_dir_all(dir.join("raw")).unwrap();
+    git::init_repo(dir).unwrap();
+    fs::write(dir.join("README.md"), "# test\n").unwrap();
+    git::commit(dir, "init").unwrap();
+    wiki_root
+}
+
+fn write_page(wiki_root: &Path, rel_path: &str, content: &str) {
+    let path = wiki_root.join(rel_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn build_index(dir: &Path, wiki_root: &Path) -> SpaceIndexManager {
+    let index_path = dir.join("index-store");
+    git::commit(dir, "index pages").unwrap();
+    let mgr = SpaceIndexManager::new("test", &index_path);
+    mgr.rebuild(wiki_root, dir, &schema(), &registry()).unwrap();
+    mgr.open(&schema(), None).unwrap();
+    mgr
+}
+
+#[test]
+fn backlinks_for_returns_pages_that_link_to_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    // target page
+    write_page(
+        &wiki_root,
+        "concepts/target.md",
+        "---\ntitle: \"Target\"\ntype: concept\nread_when: [\"x\"]\n---\n\nThe target page.\n",
+    );
+    // two pages linking to it via [[concepts/target]]
+    write_page(
+        &wiki_root,
+        "concepts/alpha.md",
+        "---\ntitle: \"Alpha\"\ntype: concept\nread_when: [\"x\"]\n---\n\nSee [[concepts/target]] for details.\n",
+    );
+    write_page(
+        &wiki_root,
+        "concepts/beta.md",
+        "---\ntitle: \"Beta\"\ntype: concept\nread_when: [\"x\"]\n---\n\nAlso links [[concepts/target]] here.\n",
+    );
+    // unrelated page — no link to target
+    write_page(
+        &wiki_root,
+        "concepts/unrelated.md",
+        "---\ntitle: \"Unrelated\"\ntype: concept\nread_when: [\"x\"]\n---\n\nNo links here.\n",
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let searcher = mgr.searcher().unwrap();
+    let is = schema();
+
+    let refs = backlinks_query(&searcher, &is, "concepts/target").unwrap();
+    let slugs: Vec<&str> = refs.iter().map(|r| r.slug.as_str()).collect();
+
+    assert_eq!(refs.len(), 2, "expected 2 backlinks, got: {slugs:?}");
+    assert!(
+        slugs.contains(&"concepts/alpha"),
+        "alpha should be in backlinks"
+    );
+    assert!(
+        slugs.contains(&"concepts/beta"),
+        "beta should be in backlinks"
+    );
+    assert!(
+        !slugs.contains(&"concepts/unrelated"),
+        "unrelated should not be in backlinks"
+    );
+}
+
+#[test]
+fn backlinks_for_returns_empty_when_no_incoming_links() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    write_page(
+        &wiki_root,
+        "concepts/isolated.md",
+        "---\ntitle: \"Isolated\"\ntype: concept\nread_when: [\"x\"]\n---\n\nNo one links here.\n",
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let searcher = mgr.searcher().unwrap();
+    let is = schema();
+
+    let refs = backlinks_query(&searcher, &is, "concepts/isolated").unwrap();
+    assert!(refs.is_empty(), "expected no backlinks for isolated page");
+}


### PR DESCRIPTION
Implements imp-3 (backlinks).

- Add `backlinks: bool` parameter to `wiki_content_read`
- `backlinks_query` term query on `body_links` tantivy field (low-level, directly testable)
- `backlinks_for` engine-level wrapper
- `BacklinkRef { slug, title }` in JSON response when `backlinks: true`
- Fix URI→slug derivation in handler (use `WikiUri::resolve` result, not string split)
- 2 integration tests in `tests/backlinks.rs`

Closes geronimo-iia/llm-wiki#22 (imp-3)

Spec: docs/improvements/backlinks.md