### PR TITLE
feat: llms format on wiki_list/search/graph + wiki_export tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`[search.status]` map in config** — flat `HashMap<String, f32>` replaces four named fields; built-in defaults (`active=1.0`, `draft=0.8`, `archived=0.3`, `unknown=0.9`); custom statuses (`verified`, `stub`, `deprecated`, …) added with no code change; per-wiki `wiki.toml` overrides individual keys (key-level merge, not all-or-nothing)
 - **`claims[].confidence` as float** — aligned with page-level confidence; was string enum `high/medium/low`; now `0.0–1.0` in `concept` and `paper` schemas
 - **`confidence: 0.5` in page scaffold** — `wiki_content_new` emits the field by default
+- **`format: "llms"` on existing tools** — `wiki_list`, `wiki_search`, `wiki_graph` accept `format: "llms"`; produces LLM-optimised output (type-grouped pages with summaries, compact search results, natural language graph description) directly in the tool response
+- **`wiki_export` tool** — new MCP tool and `llm-wiki export` CLI command; writes full wiki to a file (no pagination); formats: `llms-txt` (default), `llms-full` (with bodies), `json`; path relative to wiki root; response is a confirmation report
+- **Lint guide** — `docs/guides/lint.md` covering all 5 rules, fix guidance, CI usage, and stale rule tuning
+- **Redaction guide** — `docs/guides/redaction.md` covering built-in patterns, per-wiki config, and lossy-by-design warning
 - **Search ranking guide** — `docs/guides/search-ranking.md` covering the formula, status map, per-wiki overrides, and custom status examples
 
 ## [0.1.1] — 2026-04-26

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -12,6 +12,7 @@ llm-wiki.
 | [multi-wiki.md](multi-wiki.md)           | Manage multiple wikis, cross-wiki search, wiki:// URIs            |
 | [custom-types.md](custom-types.md)       | Add custom page types with JSON Schema                            |
 | [search-ranking.md](search-ranking.md)   | Tune search ranking: status multipliers, custom statuses, per-wiki overrides |
+| [llms-format.md](llms-format.md)         | LLM-optimized output: when and how to use `format: "llms"` and `wiki_export` |
 | [lint.md](lint.md)                       | Catch broken links, orphans, missing fields, stale pages, and unknown types  |
 | [redaction.md](redaction.md)             | Scrub secrets from page bodies before commit with `redact: true`             |
 | [ci-cd.md](ci-cd.md)                     | Schema validation, index rebuild, and ingest in CI pipelines      |

--- a/docs/guides/llms-format.md
+++ b/docs/guides/llms-format.md
@@ -20,6 +20,29 @@ structured JSON or a diagram syntax requiring a renderer.
 ecosystem, offline analysis, or CI auditing. It is the file-production
 counterpart to the session-use `format: "llms"`.
 
+## The `llms.txt` standard
+
+`llms.txt` is a community convention proposed by Jeremy Howard
+(Answer.AI / fast.ai) for making project documentation accessible to
+LLMs. The canonical specification and reference implementation are at:
+
+- Spec: <https://llmstxt.org>
+- Reference implementation: <https://github.com/AnswerDotAI/llms-txt>
+
+The convention places a Markdown file at `<site>/llms.txt` — analogous
+to `robots.txt` — containing a project name (H1), an optional summary
+blockquote, and file lists pointing to key documentation pages. An
+extended variant, `llms-full.txt`, inlines the full content of those
+pages for long-context consumption.
+
+`wiki_export` produces files that follow this structure: `llms-txt`
+generates the summary listing (equivalent to `llms.txt`), `llms-full`
+generates the inlined-bodies variant (equivalent to `llms-full.txt`).
+The exported file can be committed to the wiki repository root and
+served by Hugo or any static host, making the wiki's knowledge directly
+available to tools like Cursor, Perplexity, and other LLM clients that
+support the `llms.txt` convention.
+
 ## The orientation problem
 
 Skills that need to act on an existing wiki before writing spend tool

--- a/docs/guides/llms-format.md
+++ b/docs/guides/llms-format.md
@@ -1,0 +1,159 @@
+---
+title: "LLM-Optimized Output"
+summary: "When and how to use format: llms on wiki_list, wiki_search, wiki_graph, and wiki_export."
+read_when:
+  - Orienting an LLM agent before acting on the wiki
+  - Choosing between format options for a tool call
+  - Publishing a wiki snapshot for external LLM tools
+status: ready
+last_updated: "2026-04-27"
+---
+
+# LLM-Optimized Output
+
+`format: "llms"` is a rendering mode available on `wiki_list`,
+`wiki_search`, and `wiki_graph`. It produces output shaped for direct
+LLM consumption — grouped, annotated, and compact — instead of machine-
+structured JSON or a diagram syntax requiring a renderer.
+
+`wiki_export` writes the same rendering to a file for the `llms.txt`
+ecosystem, offline analysis, or CI auditing. It is the file-production
+counterpart to the session-use `format: "llms"`.
+
+## The orientation problem
+
+Skills that need to act on an existing wiki before writing spend tool
+calls building a map:
+
+- `wiki_search(query: "X")` × N — misses pages that don't match the query
+- `wiki_list(page_size: 100)` — paginated slugs with no content signal
+- `wiki_graph()` → parse Mermaid manually — indirect and error-prone
+
+None of these produce a complete, directly readable map in one call.
+`format: "llms"` solves this.
+
+## When to use each format
+
+### `wiki_list(format: "llms")`
+
+Use when the goal is **"what does this wiki contain?"** before deciding
+what to create or update.
+
+One call returns all pages on the current page, grouped by type with
+summaries. Pagination is unchanged — call `page: 2` etc. if the wiki
+is large.
+
+**Use it in:** crystallize (before searching for an existing home),
+ingest (first-file orientation), lint (gap analysis before judgment-
+based checks), research (broad coverage questions).
+
+**Don't use it when:** you have a specific topic to find — use
+`wiki_search` instead.
+
+### `wiki_search(format: "llms")`
+
+Use when you want search results **without excerpt noise** — compact
+`- [title](uri): summary` lines instead of the scored excerpt block.
+
+Useful when feeding results into a prompt where the score and HTML
+excerpt add no value and consume tokens.
+
+**Use it in:** research (when you want a clean list of candidates to
+read, not scored excerpts), crystallize (targeted follow-up after
+orientation).
+
+### `wiki_graph(format: "llms")`
+
+Use when you need to **interpret graph structure** — clusters, hubs,
+isolated nodes, relation counts — without parsing Mermaid syntax.
+
+The output is a natural language paragraph + bullet summary that
+surfaces what a visual graph would show but requires no renderer.
+
+**Use it in:** graph skill's "Interpret the graph" step; any time
+you want a structural digest rather than a diagram.
+
+**Use `mermaid` or `dot` when:** the goal is a renderable visualization
+for a user or document.
+
+### `wiki_export`
+
+Use when you need a **file** — for the `llms.txt` ecosystem, offline
+analysis, or CI auditing. Response is a report, not the content.
+
+```
+wiki_export(wiki: "research")                           # → <wiki-root>/llms.txt
+wiki_export(wiki: "research", format: "llms-full")      # with full bodies
+wiki_export(wiki: "research", format: "json")           # JSON array
+wiki_export(wiki: "research", status: "all")            # include archived
+```
+
+This is not a session tool — it writes to disk and is most useful for
+publishing, sharing, or batch processing outside the session.
+
+## Output formats at a glance
+
+| Tool | `format: "llms"` output | Use case |
+|------|------------------------|----------|
+| `wiki_list` | Pages grouped by type, one line each with summary | Pre-action orientation |
+| `wiki_search` | `- [title](uri): summary` per result, no score | Clean candidate list |
+| `wiki_graph` | Natural language: clusters, hubs, relations, isolated | Graph interpretation |
+| `wiki_export` (llms-txt) | Same as list but all pages, with wiki header | llms.txt publishing |
+| `wiki_export` (llms-full) | llms-txt + full bodies separated by `---` | Long-context analysis |
+| `wiki_export` (json) | JSON array with metadata + body | Batch processing |
+
+## `format: "llms"` output structure
+
+### `wiki_list(format: "llms")`
+
+```markdown
+## concept (18)
+
+- [Mixture of Experts](wiki://research/concepts/mixture-of-experts): Sparse routing of tokens to expert subnetworks.
+- [Scaling Laws](wiki://research/concepts/scaling-laws): Empirical laws relating model size, data, and compute.
+- ~~[Old Concept](wiki://research/concepts/old): Superseded.~~
+
+## paper (14)
+
+- [Switch Transformer](wiki://research/sources/switch-transformer-2021): Scales to trillion parameters using MoE.
+```
+
+- Groups ordered by page count desc
+- Within group: confidence desc, then title asc
+- Archived pages shown with `~~strikethrough~~`
+- Pagination footer when more than one page
+
+### `wiki_search(format: "llms")`
+
+```markdown
+- [Mixture of Experts](wiki://research/concepts/mixture-of-experts): Sparse routing of tokens to expert subnetworks.
+- [Switch Transformer](wiki://research/sources/switch-transformer-2021): Scales to trillion parameters using MoE.
+```
+
+### `wiki_graph(format: "llms")`
+
+```markdown
+The wiki graph has 42 nodes and 87 edges across 5 type groups.
+
+**concept** (18 nodes): Agent, Context Window, Mixture of Experts, ...
+**paper** (14 nodes): Karpathy LLM Wiki, Switch Transformer, ...
+
+Key hubs: Mixture of Experts (12 edges), Scaling Laws (9 edges)
+
+**Edges by relation:**
+- `fed-by` (32)
+- `depends-on` (28)
+- `links-to` (9)
+
+**Isolated nodes (3):** draft-stub-xyz, tangent-note-abc, orphan-page
+```
+
+## `summary` in the index
+
+The `summary` frontmatter field is stored in the tantivy index (TEXT +
+STORED), so `format: "llms"` output is produced entirely from the
+index — no disk reads per page. Pages without a `summary` field appear
+as `- [title](uri)` without the colon annotation.
+
+Setting a concise `summary` on pages you own improves orientation
+quality for all callers.

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -15,7 +15,7 @@ items that follow it.
 | 6   | ✅ | [redaction.md](redaction.md)                           | Opt-in `redact: true` on `wiki_ingest`; built-in patterns + per-wiki `wiki.toml` config              | —          |
 | 7   | ✅ | [crystallize.md](crystallize.md)                       | Two-step extraction pass, confidence calibration table, post-ingest lint step in `crystallize` skill | #1, #4     |
 | 8   | — | [community-detection.md](community-detection.md)       | Louvain clustering on `petgraph::DiGraph`; `communities` in `wiki_stats`; strategy 4 in `wiki_suggest` | —        |
-| 9   | — | [export.md](export.md)                                 | `format: "llms"` on `wiki_list`/`wiki_search`/`wiki_graph`; `wiki_export(path:)` writes full wiki to file | #1    |
+| 9   | ✅ | [export.md](export.md)                                 | `format: "llms"` on `wiki_list`/`wiki_search`/`wiki_graph`; `wiki_export(path:)` writes full wiki to file | #1    |
 | 10  | — | [cross-wiki-links.md](cross-wiki-links.md)             | `wiki://` URIs as link targets; cross-wiki edges resolved at graph build time; `wiki_graph(cross_wiki: true)` | — |
 | 11  | — | [ingest-two-step.md](ingest-two-step.md)               | Explicit analysis pass in `ingest` skill before writes: enumerate entities, detect contradictions, produce ingest plan | — |
 | 12  | — | [review-skill.md](review-skill.md)                     | New `review` skill: prioritized queue from `wiki_lint` + draft/low-confidence pages; guided review loop per page | #1, #4 |

--- a/docs/improvements/export.md
+++ b/docs/improvements/export.md
@@ -1,7 +1,7 @@
 ---
 title: "llms Format + wiki_export"
 summary: "Add format: llms to wiki_list, wiki_search, wiki_graph for LLM-readable tool responses; wiki_export MCP tool writes a file (all pages, no pagination)."
-status: proposed
+status: implemented
 last_updated: "2026-04-27"
 depends_on: confidence
 ---
@@ -274,44 +274,44 @@ EOF
 
 ### Engine — `src/graph.rs`
 
-- [ ] Add `pub fn render_llms(graph: &WikiGraph) -> String`: natural language
+- [x] Add `pub fn render_llms(graph: &WikiGraph) -> String`: natural language
   summary — node count, edge count, cluster count (if `compute_communities`
   is available), nodes grouped by type, top hubs by degree, edge relation
   counts, isolated nodes list.
-- [ ] Add `"llms"` as a valid `format` option in the graph tool/CLI; route
+- [x] Add `"llms"` as a valid `format` option in the graph tool/CLI; route
   to `render_llms`.
 
 ### Engine — `src/search.rs` / `src/ops/list.rs`
 
-- [ ] Add `Format::Llms` variant to the list/search output format enum.
-- [ ] Implement `llms` renderer for `ListResult`: group pages by type (count
+- [x] Add `Format::Llms` variant to the list/search output format enum.
+- [x] Implement `llms` renderer for `ListResult`: group pages by type (count
   desc), one line per page `- [title](uri): summary`, `~~title~~` for
   archived.
-- [ ] Implement `llms` renderer for `SearchResult`: `- [title](uri): summary`
+- [x] Implement `llms` renderer for `SearchResult`: `- [title](uri): summary`
   per result, no score, no excerpt block.
-- [ ] Add `--format llms` to `llm-wiki list` and `llm-wiki search` CLI.
+- [x] Add `--format llms` to `llm-wiki list` and `llm-wiki search` CLI.
 
 ### Engine — `src/ops/export.rs`
 
-- [ ] Create `src/ops/export.rs`; define `ExportOptions { wiki, path, format,
+- [x] Create `src/ops/export.rs`; define `ExportOptions { wiki, path, format,
   status }` and `ExportFormat { LlmsTxt, LlmsFull, Json }`.
-- [ ] Implement `fn export(engine, options) -> Result<ExportReport>`: walk
+- [x] Implement `fn export(engine, options) -> Result<ExportReport>`: walk
   index, filter, sort, render, write to resolved path.
-- [ ] `llms-txt` renderer: same output as `Format::Llms` on `wiki_list` but
+- [x] `llms-txt` renderer: same output as `Format::Llms` on `wiki_list` but
   unbounded (all pages), with wiki name + description header.
-- [ ] `llms-full` renderer: `llms-txt` output + full page body per entry
+- [x] `llms-full` renderer: `llms-txt` output + full page body per entry
   separated by `---`; read body from disk.
-- [ ] `json` renderer: JSON array of `{ slug, uri, title, type, status,
+- [x] `json` renderer: JSON array of `{ slug, uri, title, type, status,
   confidence, summary, body }`.
-- [ ] Path resolution: relative paths resolved against wiki root.
-- [ ] Return `ExportReport { path: String, pages_written: usize, bytes: usize, format: String }`.
+- [x] Path resolution: relative paths resolved against wiki root.
+- [x] Return `ExportReport { path: String, pages_written: usize, bytes: usize, format: String }`.
 
 ### Engine — MCP + CLI
 
-- [ ] Add `wiki_export` to `src/tools.rs` with parameters `wiki` (required),
+- [x] Add `wiki_export` to `src/tools.rs` with parameters `wiki` (required),
   `path` (optional, default `"llms.txt"` relative to wiki root), `format`,
   `status`.
-- [ ] Add `export` subcommand to `src/cli.rs` with `--wiki` (required),
+- [x] Add `export` subcommand to `src/cli.rs` with `--wiki` (required),
   `--path` (optional, default `llms.txt` at wiki root), `--format`,
   `--status`.
 
@@ -328,53 +328,53 @@ EOF
 
 ### Skill — `llm-wiki-skills/skills/crystallize/SKILL.md`
 
-- [ ] Add `wiki_list(format: "llms")` as the first step in
+- [x] Add `wiki_list(format: "llms")` as the first step in
   `## Search for an existing home`; retain `wiki_search` for targeted
   follow-up.
-- [ ] Update `metadata.version` to `0.3.0` and `last_updated`.
+- [x] Update `metadata.version` to `0.3.0` and `last_updated`.
 
 ### Skill — `llm-wiki-skills/skills/ingest/SKILL.md`
 
-- [ ] In step 2c, add `wiki_list(format: "llms")` as the first-file
+- [x] In step 2c, add `wiki_list(format: "llms")` as the first-file
   orientation call; note subsequent files in the same session can skip it.
-- [ ] Update `metadata.version` to `0.4.0` and `last_updated`.
+- [x] Update `metadata.version` to `0.4.0` and `last_updated`.
 
 ### Skill — `llm-wiki-skills/skills/research/SKILL.md`
 
-- [ ] Add `## Orient` section before `## Search`: use
+- [x] Add `## Orient` section before `## Search`: use
   `wiki_list(format: "llms")` for broad/coverage questions; use
   `wiki_search` for narrow queries.
-- [ ] Update `metadata.version` to `0.3.0` and `last_updated`.
+- [x] Update `metadata.version` to `0.3.0` and `last_updated`.
 
 ### Skill — `llm-wiki-skills/skills/lint/SKILL.md`
 
-- [ ] Replace `wiki_list(page_size: 100)` with `wiki_list(format: "llms")`
-  for structural enumeration.
-- [ ] Update `metadata.version` to `0.3.0` and `last_updated`.
+- [x] Add `wiki_list(format: "llms")` for structural enumeration (Structural
+  orientation section added in Judgment-based checks).
+- [x] Update `metadata.version` to `0.3.0` and `last_updated`.
 
 ### Skill — `llm-wiki-skills/skills/graph/SKILL.md`
 
-- [ ] Replace manual Mermaid interpretation guidance in
+- [x] Replace manual Mermaid interpretation guidance in
   `## Interpret the graph` with `wiki_graph(format: "llms")` as the
   primary interpretation call; retain `wiki_graph(format: "mermaid")` for
   visualization use cases.
-- [ ] Update `metadata.version` to `0.3.0` and `last_updated`.
+- [x] Update `metadata.version` to `0.3.0` and `last_updated`.
 
 ### Tests
 
-- [ ] `render_llms` on a graph with 3 type groups → correct section headers,
+- [x] `render_llms` on a graph with 3 type groups → correct section headers,
   hub list, relation counts.
-- [ ] `Format::Llms` on `wiki_list`: pages grouped by type, archived
+- [x] `Format::Llms` on `wiki_list`: pages grouped by type, archived
   page rendered with strikethrough.
-- [ ] `wiki_export(format: "llms-txt")`: all pages written, response
+- [x] `wiki_export(format: "llms-txt")`: all pages written, response
   contains correct `pages_written` count.
-- [ ] `wiki_export(format: "llms-full")`: each page entry followed by body
+- [x] `wiki_export(format: "llms-full")`: each page entry followed by body
   and `---` separator.
-- [ ] Path resolution: relative path resolves to wiki root.
-- [ ] `wiki_export(status: "all")` includes archived pages;
+- [x] Path resolution: relative path resolves to wiki root.
+- [x] `wiki_export(status: "all")` includes archived pages;
   default excludes them.
 
 ### Issue update
 After merging:
 - Check off imp-9 in `geronimo-iia/llm-wiki#22` and `geronimo-iia/llm-wiki-skills#1`
-- Mark `status: implemented` in this file
+- Mark `status: implemented` in this file ✓

--- a/docs/improvements/export.md
+++ b/docs/improvements/export.md
@@ -317,13 +317,13 @@ EOF
 
 ### Spec docs
 
-- [ ] Update `docs/specifications/tools/list.md`: add `llms` to `--format`
+- [x] Update `docs/specifications/tools/list.md`: add `llms` to `--format`
   options; document grouped output format.
-- [ ] Update `docs/specifications/tools/search.md`: add `llms` to
+- [x] Update `docs/specifications/tools/search.md`: add `llms` to
   `--format` options; document `- [title](uri): summary` output.
-- [ ] Update `docs/specifications/tools/graph.md`: add `llms` to
+- [x] Update `docs/specifications/tools/graph.md`: add `llms` to
   `--format` options; document natural language output structure.
-- [ ] Create `docs/specifications/tools/export.md`: document `wiki_export`
+- [x] Create `docs/specifications/tools/export.md`: document `wiki_export`
   parameters, formats, path resolution, response struct.
 
 ### Skill — `llm-wiki-skills/skills/crystallize/SKILL.md`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ ordered by priority:
 | 6   | ✅ | Privacy redaction (`redact:` flag on `wiki_ingest`)                           |   ✦    |   —    |
 | 7   | ✅ | Crystallize skill improvements (two-step extraction, confidence calibration)  |   —    |   ✦    |
 | 8   | — | Graph community detection (Louvain, `wiki_stats` + `wiki_suggest`)            |   ✦    |   ✦    |
-| 9   | — | `llms` format + `wiki_export` (file-writing, default `llms.txt` at wiki root) |   ✦    |   ✦    |
+| 9   | ✅ | `llms` format + `wiki_export` (file-writing, default `llms.txt` at wiki root) |   ✦    |   ✦    |
 | 10  | — | Cross-wiki links (`wiki://` URIs in graph, `wiki_graph(cross_wiki: true)`)    |   ✦    |   ✦    |
 | 11  | — | Ingest two-step: analysis pass before write (entities, contradictions, plan)  |   —    |   ✦    |
 | 12  | — | Review skill: prioritized queue from lint + draft/low-confidence pages        |   —    |   ✦    |

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -5,7 +5,7 @@ read_when:
   - Finding the right spec for a concept or component
   - Checking specification progress
 status: active
-last_updated: "2025-07-17"
+last_updated: "2026-04-27"
 ---
 
 # Specifications
@@ -37,11 +37,16 @@ Data model and knowledge structure.
 | [space-management.md](tools/space-management.md)       | init, spaces list/remove/set-default (4 tools)                     |
 | [config-management.md](tools/config-management.md)     | wiki_config tool — get/set/list                                    |
 | [content-operations.md](tools/content-operations.md)   | read, write, new-page, new-section, commit (5 tools)               |
-| [search.md](tools/search.md)                           | Full-text search with optional type filter         |
-| [list.md](tools/list.md)                               | Paginated page listing with type and status filters |
-| [ingest.md](tools/ingest.md)                           | Validate, index, and optionally commit             |
-| [graph.md](tools/graph.md)                             | Generate concept graph (Mermaid/DOT)               |
-| [index.md](tools/index.md)                             | Rebuild and inspect the search index               |
+| [search.md](tools/search.md)                           | Full-text search with optional type filter and `format: "llms"`    |
+| [list.md](tools/list.md)                               | Paginated page listing with type and status filters and `format: "llms"` |
+| [ingest.md](tools/ingest.md)                           | Validate, index, and optionally commit                             |
+| [graph.md](tools/graph.md)                             | Generate concept graph (Mermaid, DOT, or `format: "llms"`)         |
+| [export.md](tools/export.md)                           | Export full wiki to file — llms-txt, llms-full, json               |
+| [history.md](tools/history.md)                         | Git commit history for a page                                      |
+| [lint.md](tools/lint.md)                               | Deterministic index-based lint rules (orphan, broken-link, …)      |
+| [stats.md](tools/stats.md)                             | Wiki health dashboard — page counts, orphans, connectivity         |
+| [suggest.md](tools/suggest.md)                         | Suggest related pages to link                                      |
+| [index.md](tools/index.md)                             | Rebuild and inspect the search index                               |
 
 ## Engine
 
@@ -89,6 +94,11 @@ How external tools connect.
 | `tools/list.md`                     | ready    |
 | `tools/ingest.md`                   | ready    |
 | `tools/graph.md`                    | ready    |
+| `tools/export.md`                   | ready    |
+| `tools/history.md`                  | ready    |
+| `tools/lint.md`                     | ready    |
+| `tools/stats.md`                    | ready    |
+| `tools/suggest.md`                  | ready    |
 | `tools/index.md`                    | ready    |
 | `engine/engine-state.md`            | ready    |
 | `engine/index-management.md`        | ready    |

--- a/docs/specifications/tools/export.md
+++ b/docs/specifications/tools/export.md
@@ -1,0 +1,132 @@
+---
+title: "Export"
+summary: "Export the full wiki to a file — llms.txt, llms-full, or JSON."
+read_when:
+  - Exporting wiki for llms.txt ecosystem
+  - Offline analysis or CI auditing
+  - Batch processing scripts
+status: ready
+last_updated: "2026-04-27"
+---
+
+# Export
+
+MCP tool: `wiki_export`
+
+```
+llm-wiki export
+          [--path <path>]           # output path (default: llms.txt at wiki root)
+          [--format <fmt>]          # llms-txt | llms-full | json (default: llms-txt)
+          [--status <filter>]       # active | all (default: active)
+          [--wiki <name>]
+```
+
+Writes the full wiki to a file. All pages, no pagination. Response is
+a report (`path`, `pages_written`, `bytes`, `format`), not the content.
+
+This is the publishing and audit path — distinct from `format: "llms"` on
+`wiki_list` / `wiki_search` / `wiki_graph`, which produce LLM-optimized
+tool responses for session use.
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `wiki` | yes | — | Target wiki name |
+| `path` | no | `llms.txt` | Output path — relative to wiki root or absolute |
+| `format` | no | `llms-txt` | Export format (see table below) |
+| `status` | no | `active` | `active` excludes archived; `all` includes them |
+
+## Formats
+
+| `format` | Content | Use case |
+|----------|---------|----------|
+| `llms-txt` (default) | Grouped summary, one line per page | `llms.txt` ecosystem publishing, offline orientation |
+| `llms-full` | Summary + full body per page, separated by `---` | Long-context offline analysis |
+| `json` | JSON array of all page metadata + body | Batch processing scripts |
+
+## Path resolution
+
+`path` is resolved relative to the wiki root when not absolute.
+Default when `path` is omitted: `llms.txt` at the wiki repository root
+(`<wiki-root>/llms.txt`). This file can be committed to git, served by
+Hugo, or picked up by external `llms.txt` ecosystem tools without the
+caller needing to know the filesystem path.
+
+## Output: `llms-txt`
+
+Wiki name header, total page count, pages grouped by type (count desc),
+one line per page with summary:
+
+```markdown
+# research
+
+42 pages
+
+## concept (18)
+
+- [Mixture of Experts](wiki://research/concepts/mixture-of-experts): Sparse routing of tokens to expert subnetworks.
+- [Scaling Laws](wiki://research/concepts/scaling-laws): Empirical laws relating model size, data, and compute to performance.
+
+## paper (14)
+
+- [Switch Transformer](wiki://research/sources/switch-transformer-2021): Scales to trillion parameters using sparse MoE routing.
+```
+
+Within each type group, pages are ordered by `confidence` desc, then title asc.
+
+## Output: `llms-full`
+
+Same as `llms-txt` but each entry is preceded by `---` and followed by
+the full page body (frontmatter stripped):
+
+```markdown
+# research
+
+42 pages
+
+---
+
+# [Mixture of Experts](wiki://research/concepts/mixture-of-experts)
+
+_Sparse routing of tokens to expert subnetworks._
+
+Mixture of Experts (MoE) is a technique that routes tokens to a subset of
+expert subnetworks...
+```
+
+## Output: `json`
+
+JSON array of page objects. Each object includes metadata and body:
+
+```json
+[
+  {
+    "slug": "concepts/mixture-of-experts",
+    "uri": "wiki://research/concepts/mixture-of-experts",
+    "title": "Mixture of Experts",
+    "type": "concept",
+    "status": "active",
+    "confidence": 0.9,
+    "summary": "Sparse routing of tokens to expert subnetworks.",
+    "body": "Mixture of Experts (MoE) is a technique..."
+  }
+]
+```
+
+## Response (MCP tool)
+
+```json
+{
+  "path": "/home/user/wiki/llms.txt",
+  "pages_written": 42,
+  "bytes": 18340,
+  "format": "llms-txt"
+}
+```
+
+## Sorting
+
+Pages are sorted: type groups by page count desc (largest groups first),
+within group by `confidence` desc, then title asc. Ensures the most
+populated and highest-confidence content appears first.

--- a/docs/specifications/tools/graph.md
+++ b/docs/specifications/tools/graph.md
@@ -1,11 +1,12 @@
 ---
 title: "Graph"
-summary: "Generate concept graph in Mermaid or DOT format."
+summary: "Generate concept graph in Mermaid, DOT, or LLM-readable format."
 read_when:
   - Generating concept graphs
   - Visualizing wiki structure
+  - Interpreting wiki structure for LLM consumption
 status: ready
-last_updated: "2025-07-17"
+last_updated: "2026-04-27"
 ---
 
 # Graph
@@ -14,7 +15,7 @@ MCP tool: `wiki_graph`
 
 ```
 llm-wiki graph
-          [--format <fmt>]          # mermaid | dot (default: from config)
+          [--format <fmt>]          # mermaid | dot | llms (default: from config)
           [--root <slug|uri>]       # subgraph from this node
           [--depth <n>]             # hop limit
           [--type <types>]          # comma-separated page types
@@ -62,6 +63,32 @@ digraph wiki {
   "concepts/moe" -> "concepts/scaling" [label="depends-on"];
 }
 ```
+
+LLM (`--format llms`):
+
+Natural language description of graph structure — directly readable
+without a renderer. Surfaces clusters, hubs, relation counts, and
+isolated nodes.
+
+```markdown
+The wiki graph has 42 nodes and 87 edges across 5 type groups.
+
+**concept** (18 nodes): Agent, Context Window, Mixture of Experts, Scaling Laws, ...
+**paper** (14 nodes): Karpathy LLM Wiki, Switch Transformer, ...
+
+Key hubs: Mixture of Experts (12 edges), Scaling Laws (9 edges), Agent (7 edges)
+
+**Edges by relation:**
+- `fed-by` (32)
+- `depends-on` (28)
+- `informs` (18)
+- `links-to` (9)
+
+**Isolated nodes (3):** draft-stub-xyz, tangent-note-abc, orphan-page
+```
+
+Use `format: "llms"` when the goal is interpretation or analysis.
+Use `format: "mermaid"` or `format: "dot"` when a renderable diagram is needed.
 
 A summary line is printed to stderr:
 

--- a/docs/specifications/tools/list.md
+++ b/docs/specifications/tools/list.md
@@ -4,7 +4,7 @@ summary: "Paginated page listing with type and status filters and facets."
 read_when:
   - Listing pages with filters
 status: ready
-last_updated: "2025-07-22"
+last_updated: "2026-04-27"
 ---
 
 # List
@@ -17,7 +17,7 @@ llm-wiki list
          [--status <status>]
          [--page <n>]               # 1-based (default: 1)
          [--page-size <n>]          # default: from config
-         [--format <fmt>]           # text | json (default: text)
+         [--format <fmt>]           # text | json | llms (default: text)
          [--wiki <name>]
 ```
 
@@ -82,6 +82,27 @@ JSON (`--format json`):
 }
 ```
 
+LLM (`--format llms`):
+
+Pages grouped by type (count desc), one line per page, with summary.
+Archived pages rendered with `~~strikethrough~~`. Pagination footer
+included when more than one page of results exists.
+
+```markdown
+## concept (25)
+
+- [Mixture of Experts](wiki://research/concepts/mixture-of-experts): Sparse routing of tokens to expert subnetworks.
+- [Scaling Laws](wiki://research/concepts/scaling-laws): Empirical laws relating model size, data, and compute to performance.
+- ~~[Old Concept](wiki://research/concepts/old-concept): Superseded by newer understanding.~~
+
+## paper (10)
+
+- [Switch Transformer](wiki://research/sources/switch-transformer-2021): Scales to trillion parameters using sparse MoE routing.
+```
+
+Within each type group, pages are ordered by `confidence` desc, then title asc.
+Pagination is unchanged — call `wiki_list(format: "llms", page: 2)` etc.
+
 ### PageSummary fields
 
 Each page object (`PageSummary`) contains:
@@ -95,3 +116,4 @@ Each page object (`PageSummary`) contains:
 | `status`     | string       | Lifecycle status                        |
 | `tags`       | list[string] | Tags                                    |
 | `confidence` | float        | Page `confidence` value (default `0.5`) |
+| `summary`    | string       | Page summary (omitted when empty)       |

--- a/docs/specifications/tools/search.md
+++ b/docs/specifications/tools/search.md
@@ -4,7 +4,7 @@ summary: "Full-text search with optional type filter and facets."
 read_when:
   - Searching the wiki
 status: ready
-last_updated: "2025-07-22"
+last_updated: "2026-04-27"
 ---
 
 # Search
@@ -18,7 +18,7 @@ llm-wiki search "<query>"
             [--top-k <n>]             # default: from config
             [--include-sections]      # include section index pages
             [--all]                   # search across all registered wikis
-            [--format <fmt>]          # text | json (default: text)
+            [--format <fmt>]          # text | json | llms (default: text)
             [--wiki <name>]
 ```
 
@@ -112,6 +112,16 @@ agents suggest "there are also 8 papers on this topic".
 `status` and `tags` facets are filtered — they describe the current
 result set after type filtering.
 
+LLM (`--format llms`):
+
+One line per result: `- [title](uri): summary`. No score, no excerpt
+block. When `format: "llms"` is set, excerpts are suppressed.
+
+```markdown
+- [Mixture of Experts](wiki://research/concepts/mixture-of-experts): Sparse routing of tokens to expert subnetworks.
+- [Switch Transformer](wiki://research/sources/switch-transformer-2021): Scales to trillion parameters using sparse MoE routing.
+```
+
 ### PageRef fields
 
 Each result object (`PageRef`) contains:
@@ -124,6 +134,7 @@ Each result object (`PageRef`) contains:
 | `score`      | float  | Combined final score (`bm25 × status × conf`) |
 | `confidence` | float  | Page `confidence` value (default `0.5`)       |
 | `excerpt`    | string | Highlighted body excerpt (omitted with `--no-excerpt`) |
+| `summary`    | string | Page summary (omitted when empty)             |
 
 ### `[search.status]` config
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,7 +89,7 @@ pub enum Commands {
     },
     /// Generate a concept graph
     Graph {
-        /// Output format: mermaid | dot
+        /// Output format: mermaid | dot | llms
         #[arg(long)]
         format: Option<String>,
         /// Subgraph from this node (slug)
@@ -160,6 +160,18 @@ pub enum Commands {
     Schema {
         #[command(subcommand)]
         action: SchemaAction,
+    },
+    /// Export the full wiki to a file (llms.txt, llms-full, or json)
+    Export {
+        /// Output path (relative to wiki root or absolute; default: llms.txt)
+        #[arg(long)]
+        path: Option<String>,
+        /// Export format: llms-txt | llms-full | json
+        #[arg(long)]
+        format: Option<String>,
+        /// Page status filter: active | all (default: active, excludes archived)
+        #[arg(long)]
+        status: Option<String>,
     },
     /// Start the wiki MCP/ACP server
     Serve {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use anyhow::Result;
@@ -235,6 +236,104 @@ pub fn build_graph(
     }
 
     Ok(graph)
+}
+
+// ── render_llms ───────────────────────────────────────────────────────────────
+
+/// Natural language description of graph structure for direct LLM consumption.
+pub fn render_llms(graph: &WikiGraph) -> String {
+    let nodes = graph.node_count();
+    let edges = graph.edge_count();
+
+    // Group nodes by type
+    let mut by_type: HashMap<String, Vec<String>> = HashMap::new();
+    for idx in graph.node_indices() {
+        let node = &graph[idx];
+        by_type
+            .entry(node.r#type.clone())
+            .or_default()
+            .push(node.title.clone());
+    }
+
+    // Sort type groups by count descending
+    let mut type_groups: Vec<(String, Vec<String>)> = by_type.into_iter().collect();
+    type_groups.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then(a.0.cmp(&b.0)));
+
+    // Count edge relations
+    let mut relation_counts: HashMap<String, usize> = HashMap::new();
+    for edge in graph.edge_indices() {
+        *relation_counts
+            .entry(graph[edge].relation.clone())
+            .or_default() += 1;
+    }
+    let mut relations: Vec<(String, usize)> = relation_counts.into_iter().collect();
+    relations.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    // Compute per-node total degree for hub detection
+    let mut degree: Vec<(usize, String)> = graph
+        .node_indices()
+        .map(|idx| {
+            let d = graph.neighbors_directed(idx, Direction::Incoming).count()
+                + graph.neighbors_directed(idx, Direction::Outgoing).count();
+            (d, graph[idx].title.clone())
+        })
+        .collect();
+    degree.sort_by_key(|a| Reverse(a.0));
+    let top_hubs: Vec<String> = degree
+        .iter()
+        .take(5)
+        .filter(|(d, _)| *d > 0)
+        .map(|(d, t)| format!("{t} ({d} edges)"))
+        .collect();
+
+    // Isolated nodes (no edges at all)
+    let isolated: Vec<String> = graph
+        .node_indices()
+        .filter(|&idx| {
+            graph.neighbors_directed(idx, Direction::Incoming).count() == 0
+                && graph.neighbors_directed(idx, Direction::Outgoing).count() == 0
+        })
+        .map(|idx| graph[idx].title.clone())
+        .collect();
+
+    let cluster_count = type_groups.len();
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "The wiki graph has {nodes} nodes and {edges} edges across {cluster_count} type groups.\n\n"
+    ));
+
+    for (type_name, mut titles) in type_groups {
+        titles.sort();
+        let count = titles.len();
+        let sample = if titles.len() > 8 {
+            format!("{}, ...", titles[..8].join(", "))
+        } else {
+            titles.join(", ")
+        };
+        out.push_str(&format!("**{type_name}** ({count} nodes): {sample}\n"));
+    }
+
+    if !top_hubs.is_empty() {
+        out.push_str(&format!("\nKey hubs: {}\n", top_hubs.join(", ")));
+    }
+
+    if !relations.is_empty() {
+        out.push_str("\n**Edges by relation:**\n");
+        for (rel, count) in &relations {
+            out.push_str(&format!("- `{rel}` ({count})\n"));
+        }
+    }
+
+    if !isolated.is_empty() {
+        out.push_str(&format!(
+            "\n**Isolated nodes ({}):** {}\n",
+            isolated.len(),
+            isolated.join(", ")
+        ));
+    }
+
+    out
 }
 
 // ── render_mermaid ────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use llm_wiki::cli::{
 use llm_wiki::config;
 use llm_wiki::engine::WikiEngine;
 use llm_wiki::ops;
+use llm_wiki::search;
 
 fn global_config_path() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
@@ -253,6 +254,8 @@ fn main() -> Result<()> {
 
             if is_json(&format) {
                 println!("{}", serde_json::to_string_pretty(&results)?);
+            } else if format.as_deref() == Some("llms") {
+                print!("{}", search::render_search_llms(&results));
             } else {
                 for r in &results.results {
                     println!("slug:  {}", r.slug);
@@ -290,6 +293,8 @@ fn main() -> Result<()> {
 
             if is_json(&format) {
                 println!("{}", serde_json::to_string_pretty(&result)?);
+            } else if format.as_deref() == Some("llms") {
+                print!("{}", search::render_list_llms(&result));
             } else {
                 for p in &result.pages {
                     println!(
@@ -383,6 +388,34 @@ fn main() -> Result<()> {
             } else {
                 println!("Wrote graph to {}", result.report.output);
             }
+        }
+
+        // ── Export ────────────────────────────────────────────────────
+        Commands::Export {
+            path,
+            format,
+            status,
+        } => {
+            let manager = WikiEngine::build(&config_path)?;
+            let engine = manager.state.read().map_err(|_| anyhow::anyhow!("lock"))?;
+            let wiki_name = engine.resolve_wiki_name(cli.wiki.as_deref()).to_string();
+
+            let export_format = ops::ExportFormat::parse(format.as_deref().unwrap_or("llms-txt"));
+            let include_archived = status.as_deref() == Some("all");
+
+            let report = ops::export(
+                &engine,
+                &ops::ExportOptions {
+                    wiki: wiki_name,
+                    path,
+                    format: export_format,
+                    include_archived,
+                },
+            )?;
+            println!(
+                "Exported {} pages ({} bytes) → {}",
+                report.pages_written, report.bytes, report.path
+            );
         }
 
         // ── Index ─────────────────────────────────────────────────────

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -207,6 +207,7 @@ pub fn handle_content_commit(server: &McpServer, args: &Map<String, Value>) -> T
 pub fn handle_search(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let query = arg_str_req(args, "query")?;
     let cross_wiki = arg_bool(args, "cross_wiki");
+    let format = arg_str(args, "format");
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
 
@@ -216,7 +217,7 @@ pub fn handle_search(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
         &ops::SearchParams {
             query: &query,
             type_filter: arg_str(args, "type").as_deref(),
-            no_excerpt: arg_bool(args, "no_excerpt"),
+            no_excerpt: format.as_deref() == Some("llms") || arg_bool(args, "no_excerpt"),
             top_k: arg_usize(args, "top_k"),
             include_sections: arg_bool(args, "include_sections"),
             cross_wiki,
@@ -224,8 +225,12 @@ pub fn handle_search(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
     )
     .map_err(|e| format!("{e}"))?;
 
-    let s = serde_json::to_string_pretty(&results).map_err(|e| format!("{e}"))?;
-    ok_text(s)
+    if format.as_deref() == Some("llms") {
+        ok_text(crate::search::render_search_llms(&results))
+    } else {
+        let s = serde_json::to_string_pretty(&results).map_err(|e| format!("{e}"))?;
+        ok_text(s)
+    }
 }
 
 // ── List ──────────────────────────────────────────────────────────────────────
@@ -233,6 +238,7 @@ pub fn handle_search(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
 pub fn handle_list(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
+    let format = arg_str(args, "format");
 
     let result = ops::list(
         &engine,
@@ -244,8 +250,12 @@ pub fn handle_list(server: &McpServer, args: &Map<String, Value>) -> ToolHandler
     )
     .map_err(|e| format!("{e}"))?;
 
-    let s = serde_json::to_string_pretty(&result).map_err(|e| format!("{e}"))?;
-    ok_text(s)
+    if format.as_deref() == Some("llms") {
+        ok_text(crate::search::render_list_llms(&result))
+    } else {
+        let s = serde_json::to_string_pretty(&result).map_err(|e| format!("{e}"))?;
+        ok_text(s)
+    }
 }
 
 // ── Ingest ────────────────────────────────────────────────────────────────────
@@ -450,4 +460,28 @@ pub fn handle_schema(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
         }
         _ => Err(format!("unknown action: {action}")),
     }
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+pub fn handle_export(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
+    let wiki = arg_str_req(args, "wiki")?;
+    let engine = server.engine();
+
+    let format = ops::ExportFormat::parse(arg_str(args, "format").as_deref().unwrap_or("llms-txt"));
+    let include_archived = arg_str(args, "status").as_deref() == Some("all");
+
+    let report = ops::export(
+        &engine,
+        &ops::ExportOptions {
+            wiki: wiki.clone(),
+            path: arg_str(args, "path"),
+            format,
+            include_archived,
+        },
+    )
+    .map_err(|e| format!("{e}"))?;
+
+    let s = serde_json::to_string_pretty(&report).map_err(|e| format!("{e}"))?;
+    ok_text(s)
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -166,6 +166,7 @@ pub fn tool_list() -> Vec<Tool> {
                     "top_k": opt_int("Max results"),
                     "wiki": opt_str("Target wiki name"),
                     "cross_wiki": opt_bool("Search across all wikis"),
+                    "format": opt_str("Output format: json | llms (default: json)"),
                 }),
                 &["query"],
             ),
@@ -180,6 +181,7 @@ pub fn tool_list() -> Vec<Tool> {
                     "page": opt_int("Page number, 1-based"),
                     "page_size": opt_int("Results per page"),
                     "wiki": opt_str("Target wiki name"),
+                    "format": opt_str("Output format: json | llms (default: json)"),
                 }),
                 &[],
             ),
@@ -222,7 +224,7 @@ pub fn tool_list() -> Vec<Tool> {
             "Generate concept graph, returns GraphReport",
             schema(
                 json!({
-                    "format": opt_str("Output format: mermaid | dot"),
+                    "format": opt_str("Output format: mermaid | dot | llms (default: mermaid)"),
                     "root": opt_str("Subgraph from this node (slug)"),
                     "depth": opt_int("Hop limit from root"),
                     "type": opt_str("Comma-separated page types to include"),
@@ -231,6 +233,19 @@ pub fn tool_list() -> Vec<Tool> {
                     "wiki": opt_str("Target wiki name"),
                 }),
                 &[],
+            ),
+        ),
+        Tool::new(
+            "wiki_export",
+            "Export the full wiki to a file (llms.txt, llms-full, or json)",
+            schema(
+                json!({
+                    "wiki": str_prop("Target wiki name"),
+                    "path": opt_str("Output path (relative to wiki root or absolute; default: llms.txt)"),
+                    "format": opt_str("Export format: llms-txt | llms-full | json (default: llms-txt)"),
+                    "status": opt_str("Page status filter: active | all (default: active, excludes archived)"),
+                }),
+                &["wiki"],
             ),
         ),
         Tool::new(
@@ -325,6 +340,7 @@ pub fn call(server: &McpServer, name: &str, args: &Map<String, Value>) -> ToolRe
         "wiki_lint" => handlers::handle_lint(server, args),
         "wiki_suggest" => handlers::handle_suggest(server, args),
         "wiki_schema" => handlers::handle_schema(server, args),
+        "wiki_export" => handlers::handle_export(server, args),
         _ => Err(format!("unknown tool: {name}")),
     }));
     match result {

--- a/src/ops/export.rs
+++ b/src/ops/export.rs
@@ -1,0 +1,297 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tantivy::collector::TopDocs;
+use tantivy::query::AllQuery;
+use tantivy::schema::Value;
+
+use crate::engine::EngineState;
+use crate::index_schema::IndexSchema;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    pub wiki: String,
+    /// Output path — resolved against wiki root if relative.
+    pub path: Option<String>,
+    pub format: ExportFormat,
+    /// Whether to include archived pages (default: false).
+    pub include_archived: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum ExportFormat {
+    #[default]
+    LlmsTxt,
+    LlmsFull,
+    Json,
+}
+
+impl ExportFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExportFormat::LlmsTxt => "llms-txt",
+            ExportFormat::LlmsFull => "llms-full",
+            ExportFormat::Json => "json",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "llms-full" => ExportFormat::LlmsFull,
+            "json" => ExportFormat::Json,
+            _ => ExportFormat::LlmsTxt,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportReport {
+    pub path: String,
+    pub pages_written: usize,
+    pub bytes: usize,
+    pub format: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PageEntry {
+    slug: String,
+    uri: String,
+    title: String,
+    r#type: String,
+    status: String,
+    confidence: f64,
+    summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+}
+
+// ── export ────────────────────────────────────────────────────────────────────
+
+pub fn export(engine: &EngineState, options: &ExportOptions) -> Result<ExportReport> {
+    let space = engine.space(&options.wiki)?;
+    let wiki_root = &space.wiki_root;
+
+    let resolved_path = resolve_path(options.path.as_deref(), wiki_root);
+
+    let searcher = space.index_manager.searcher()?;
+    let is = &space.index_schema;
+
+    let pages = collect_pages(&searcher, is, &options.wiki, options.include_archived)?;
+
+    let need_bodies = matches!(options.format, ExportFormat::LlmsFull | ExportFormat::Json);
+    let pages = if need_bodies {
+        load_bodies(pages, wiki_root)?
+    } else {
+        pages
+    };
+
+    let content = match options.format {
+        ExportFormat::LlmsTxt => render_llms_txt(&pages, &options.wiki),
+        ExportFormat::LlmsFull => render_llms_full(&pages, &options.wiki),
+        ExportFormat::Json => {
+            serde_json::to_string_pretty(&pages).context("failed to serialize pages to JSON")?
+        }
+    };
+
+    if let Some(parent) = resolved_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+    std::fs::write(&resolved_path, &content)
+        .with_context(|| format!("failed to write export to {}", resolved_path.display()))?;
+
+    Ok(ExportReport {
+        path: resolved_path.to_string_lossy().to_string(),
+        pages_written: pages.len(),
+        bytes: content.len(),
+        format: options.format.as_str().to_string(),
+    })
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn resolve_path(path: Option<&str>, wiki_root: &Path) -> PathBuf {
+    let p = path.unwrap_or("llms.txt");
+    let pb = PathBuf::from(p);
+    if pb.is_absolute() {
+        pb
+    } else {
+        wiki_root.join(pb)
+    }
+}
+
+fn collect_pages(
+    searcher: &tantivy::Searcher,
+    is: &IndexSchema,
+    wiki_name: &str,
+    include_archived: bool,
+) -> Result<Vec<PageEntry>> {
+    let f_slug = is.field("slug");
+    let f_title = is.field("title");
+    let f_type = is.field("type");
+    let f_status = is.field("status");
+    let f_confidence = is.try_field("confidence");
+    let f_summary = is.try_field("summary");
+
+    let top_docs = searcher.search(&AllQuery, &TopDocs::with_limit(100_000).order_by_score())?;
+
+    let mut pages = Vec::new();
+    for (_score, doc_addr) in &top_docs {
+        let doc: tantivy::TantivyDocument = searcher.doc(*doc_addr)?;
+
+        let slug = doc
+            .get_first(f_slug)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if slug.is_empty() {
+            continue;
+        }
+
+        let status = doc
+            .get_first(f_status)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if !include_archived && status == "archived" {
+            continue;
+        }
+
+        let title = doc
+            .get_first(f_title)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let page_type = doc
+            .get_first(f_type)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let confidence = f_confidence
+            .and_then(|f| doc.get_first(f))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.5);
+        let summary = f_summary
+            .and_then(|f| doc.get_first(f))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("")
+            .to_string();
+
+        let uri = format!("wiki://{wiki_name}/{slug}");
+
+        pages.push(PageEntry {
+            slug,
+            uri,
+            title,
+            r#type: page_type,
+            status,
+            confidence,
+            summary,
+            body: None,
+        });
+    }
+
+    // Sort: group by type (count desc), within group by confidence desc then title asc
+    let mut type_counts: HashMap<String, usize> = HashMap::new();
+    for p in &pages {
+        *type_counts.entry(p.r#type.clone()).or_insert(0) += 1;
+    }
+    pages.sort_by(|a, b| {
+        let ca = type_counts.get(&a.r#type).copied().unwrap_or(0);
+        let cb = type_counts.get(&b.r#type).copied().unwrap_or(0);
+        cb.cmp(&ca)
+            .then(a.r#type.cmp(&b.r#type))
+            .then(
+                b.confidence
+                    .partial_cmp(&a.confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then(a.title.cmp(&b.title))
+    });
+
+    Ok(pages)
+}
+
+fn load_bodies(mut pages: Vec<PageEntry>, wiki_root: &Path) -> Result<Vec<PageEntry>> {
+    for page in &mut pages {
+        let path = wiki_root.join(format!("{}.md", page.slug));
+        if path.exists() {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            // Strip frontmatter (between --- delimiters)
+            let body = strip_frontmatter(&raw);
+            page.body = Some(body.to_string());
+        }
+    }
+    Ok(pages)
+}
+
+fn strip_frontmatter(content: &str) -> &str {
+    if !content.starts_with("---") {
+        return content;
+    }
+    // Find second --- after the opening
+    if let Some(rest) = content[3..].find("\n---") {
+        let end = 3 + rest + 4; // skip past the closing ---
+        // Skip past optional newline after ---
+        let end = if content[end..].starts_with('\n') {
+            end + 1
+        } else {
+            end
+        };
+        &content[end..]
+    } else {
+        content
+    }
+}
+
+// ── Renderers ─────────────────────────────────────────────────────────────────
+
+fn render_llms_txt(pages: &[PageEntry], wiki_name: &str) -> String {
+    let mut out = format!("# {wiki_name}\n\n");
+    out.push_str(&format!("{} pages\n\n", pages.len()));
+
+    let mut current_type = "";
+    for page in pages {
+        if page.r#type != current_type {
+            current_type = &page.r#type;
+            let count = pages.iter().filter(|p| p.r#type == current_type).count();
+            out.push_str(&format!("## {} ({})\n\n", current_type, count));
+        }
+        if page.summary.is_empty() {
+            out.push_str(&format!("- [{}]({})\n", page.title, page.uri));
+        } else {
+            out.push_str(&format!(
+                "- [{}]({}): {}\n",
+                page.title, page.uri, page.summary
+            ));
+        }
+    }
+    out
+}
+
+fn render_llms_full(pages: &[PageEntry], wiki_name: &str) -> String {
+    let mut out = format!("# {wiki_name}\n\n");
+    out.push_str(&format!("{} pages\n\n", pages.len()));
+
+    for page in pages {
+        out.push_str("---\n\n");
+        out.push_str(&format!("# [{}]({})\n\n", page.title, page.uri));
+        if !page.summary.is_empty() {
+            out.push_str(&format!("_{}_\n\n", page.summary));
+        }
+        if let Some(ref body) = page.body {
+            out.push_str(body.trim());
+            out.push_str("\n\n");
+        }
+    }
+    out
+}

--- a/src/ops/graph.rs
+++ b/src/ops/graph.rs
@@ -47,6 +47,7 @@ pub fn graph_build(
 
     let rendered = match fmt {
         "dot" => graph::render_dot(&g),
+        "llms" => graph::render_llms(&g),
         _ => graph::render_mermaid(&g),
     };
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,5 +1,6 @@
 mod config;
 mod content;
+pub mod export;
 mod graph;
 mod history;
 mod index;
@@ -15,6 +16,7 @@ mod suggest;
 
 pub use config::*;
 pub use content::*;
+pub use export::*;
 pub use graph::*;
 pub use history::*;
 pub use index::*;

--- a/src/search.rs
+++ b/src/search.rs
@@ -25,6 +25,8 @@ pub struct PageRef {
     pub score: f32,
     pub confidence: f32,
     pub excerpt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +39,8 @@ pub struct PageSummary {
     pub status: String,
     pub tags: Vec<String>,
     pub confidence: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -129,12 +133,16 @@ pub fn search(
 ) -> Result<SearchResult> {
     let f_slug = is.field("slug");
     let f_title = is.field("title");
-    let f_summary = is.field("summary");
+    let f_summary = is.try_field("summary");
     let f_body = is.field("body");
     let f_type = is.field("type");
 
     let index = searcher.index();
-    let query_parser = QueryParser::for_index(index, vec![f_title, f_summary, f_body]);
+    let mut query_fields = vec![f_title, f_body];
+    if let Some(f) = f_summary {
+        query_fields.insert(1, f);
+    }
+    let query_parser = QueryParser::for_index(index, query_fields);
     let parsed = query_parser
         .parse_query(query_str)
         .with_context(|| format!("failed to parse query: {query_str}"))?;
@@ -235,6 +243,12 @@ pub fn search(
             snippet.to_html()
         });
 
+        let summary = f_summary
+            .and_then(|f| doc.get_first(f))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
         results.push(PageRef {
             slug,
             uri,
@@ -242,6 +256,7 @@ pub fn search(
             score,
             confidence,
             excerpt,
+            summary,
         });
     }
 
@@ -293,6 +308,7 @@ pub fn list(
     let f_status = is.field("status");
     let f_tags = is.field("tags");
     let f_confidence = is.try_field("confidence");
+    let f_summary = is.try_field("summary");
 
     let query: Box<dyn tantivy::query::Query> = {
         let mut clauses: Vec<(Occur, Box<dyn tantivy::query::Query>)> = Vec::new();
@@ -405,6 +421,12 @@ pub fn list(
             .and_then(|v| v.as_f64())
             .unwrap_or(0.5) as f32;
 
+        let summary = f_summary
+            .and_then(|f| doc.get_first(f))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
         let uri = format!("wiki://{wiki_name}/{slug}");
 
         summaries.push(PageSummary {
@@ -415,6 +437,7 @@ pub fn list(
             status,
             tags,
             confidence,
+            summary,
         });
     }
 
@@ -521,4 +544,74 @@ fn collect_facet(
     }
 
     Ok(counts)
+}
+
+// ── llms renderers ────────────────────────────────────────────────────────────
+
+/// Render a `PageList` as LLM-optimized markdown: pages grouped by type,
+/// one line per page with summary. Archived pages shown with strikethrough.
+pub fn render_list_llms(result: &PageList) -> String {
+    // Group by type, sorted by count desc then name asc
+    let mut by_type: std::collections::HashMap<String, Vec<&PageSummary>> =
+        std::collections::HashMap::new();
+    for page in &result.pages {
+        by_type.entry(page.r#type.clone()).or_default().push(page);
+    }
+    let mut groups: Vec<(String, Vec<&PageSummary>)> = by_type.into_iter().collect();
+    groups.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then(a.0.cmp(&b.0)));
+
+    let mut out = String::new();
+    for (type_name, mut pages) in groups {
+        pages.sort_by(|a, b| {
+            b.confidence
+                .partial_cmp(&a.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.title.cmp(&b.title))
+        });
+        out.push_str(&format!("## {} ({})\n\n", type_name, pages.len()));
+        for page in pages {
+            let summary = page.summary.as_deref().unwrap_or("");
+            let line = if page.status == "archived" {
+                if summary.is_empty() {
+                    format!("- ~~[{}]({})~~\n", page.title, page.uri)
+                } else {
+                    format!("- ~~[{}]({}): {}~~\n", page.title, page.uri, summary)
+                }
+            } else if summary.is_empty() {
+                format!("- [{}]({})\n", page.title, page.uri)
+            } else {
+                format!("- [{}]({}): {}\n", page.title, page.uri, summary)
+            };
+            out.push_str(&line);
+        }
+        out.push('\n');
+    }
+
+    if result.total > result.page_size {
+        let total_pages = (result.total + result.page_size - 1) / result.page_size.max(1);
+        out.push_str(&format!(
+            "_Page {}/{} — {} total pages_\n",
+            result.page, total_pages, result.total
+        ));
+    }
+
+    out
+}
+
+/// Render a `SearchResult` as LLM-optimized markdown: one line per result
+/// with title, uri, and summary. No score, no excerpt block.
+pub fn render_search_llms(result: &SearchResult) -> String {
+    if result.results.is_empty() {
+        return "No results found.\n".to_string();
+    }
+    let mut out = String::new();
+    for r in &result.results {
+        let summary = r.summary.as_deref().unwrap_or("");
+        if summary.is_empty() {
+            out.push_str(&format!("- [{}]({})\n", r.title, r.uri));
+        } else {
+            out.push_str(&format!("- [{}]({}): {}\n", r.title, r.uri, summary));
+        }
+    }
+    out
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -484,3 +484,79 @@ fn build_graph_multiple_edge_types_from_same_page() {
     assert!(has_fed_by, "expected fed-by edge");
     assert!(has_depends_on, "expected depends-on edge");
 }
+
+// ── render_llms ───────────────────────────────────────────────────────────────
+
+#[test]
+fn render_llms_shows_node_and_edge_counts() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/a.md",
+        &page_with_body_links("Alpha", "See [[concepts/b]]."),
+    );
+    write_page(&wiki_root, "concepts/b.md", &simple_page("Beta", "concept"));
+    write_page(&wiki_root, "sources/s.md", &simple_page("Source", "paper"));
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    let output = render_llms(&g);
+    assert!(output.contains("3 nodes"));
+    assert!(output.contains("1 edge"));
+    assert!(output.contains("**concept**"));
+    assert!(output.contains("**paper**"));
+    assert!(output.contains("`links-to`"));
+}
+
+#[test]
+fn render_llms_shows_hubs_and_isolated() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    // Hub: a linked from b and c
+    write_page(
+        &wiki_root,
+        "concepts/a.md",
+        &page_with_body_links("Hub", "See [[concepts/b]] and [[concepts/c]]."),
+    );
+    write_page(
+        &wiki_root,
+        "concepts/b.md",
+        &simple_page("Spoke1", "concept"),
+    );
+    write_page(
+        &wiki_root,
+        "concepts/c.md",
+        &simple_page("Spoke2", "concept"),
+    );
+    // Isolated: no edges
+    write_page(
+        &wiki_root,
+        "concepts/z.md",
+        &simple_page("Isolated", "concept"),
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    let output = render_llms(&g);
+    assert!(output.contains("Key hubs:"));
+    assert!(output.contains("Hub"));
+    assert!(output.contains("**Isolated nodes"));
+    assert!(output.contains("Isolated"));
+}

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -3,7 +3,7 @@ use llm_wiki::mcp::tools;
 #[test]
 fn tool_list_returns_20_tools() {
     let tools = tools::tool_list();
-    assert_eq!(tools.len(), 20);
+    assert_eq!(tools.len(), 21);
 }
 
 #[test]
@@ -30,6 +30,7 @@ fn tool_list_contains_expected_names() {
         "wiki_stats",
         "wiki_lint",
         "wiki_suggest",
+        "wiki_export",
     ];
     for name in &expected {
         assert!(names.contains(name), "missing tool: {name}");

--- a/tests/ops/export.rs
+++ b/tests/ops/export.rs
@@ -1,0 +1,173 @@
+use super::helpers::setup_wiki;
+use llm_wiki::engine::WikiEngine;
+use llm_wiki::ops;
+use llm_wiki::ops::{ExportFormat, ExportOptions};
+
+// ── llms-txt ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn export_llms_txt_writes_file_and_reports() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+
+    let report = ops::export(
+        &engine,
+        &ExportOptions {
+            wiki: "test".into(),
+            path: Some("llms.txt".into()),
+            format: ExportFormat::LlmsTxt,
+            include_archived: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(report.format, "llms-txt");
+    assert!(report.pages_written >= 2);
+    assert!(report.bytes > 0);
+
+    let content = std::fs::read_to_string(&report.path).unwrap();
+    assert!(content.contains("# test"));
+    assert!(content.contains("## concept"));
+    assert!(content.contains("wiki://test/concepts/moe"));
+}
+
+// ── llms-full ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn export_llms_full_includes_page_bodies() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+
+    let report = ops::export(
+        &engine,
+        &ExportOptions {
+            wiki: "test".into(),
+            path: Some("llms-full.txt".into()),
+            format: ExportFormat::LlmsFull,
+            include_archived: false,
+        },
+    )
+    .unwrap();
+
+    let content = std::fs::read_to_string(&report.path).unwrap();
+    // Each page entry is preceded by ---
+    assert!(content.contains("---\n\n# ["));
+    // Body text from helpers::setup_wiki
+    assert!(content.contains("Mixture of Experts"));
+}
+
+// ── json ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn export_json_produces_valid_json_array() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+
+    let report = ops::export(
+        &engine,
+        &ExportOptions {
+            wiki: "test".into(),
+            path: Some("wiki.json".into()),
+            format: ExportFormat::Json,
+            include_archived: false,
+        },
+    )
+    .unwrap();
+
+    let content = std::fs::read_to_string(&report.path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(parsed.is_array());
+    let arr = parsed.as_array().unwrap();
+    assert!(arr.len() >= 2);
+    let first = &arr[0];
+    assert!(first.get("slug").is_some());
+    assert!(first.get("title").is_some());
+    assert!(first.get("type").is_some());
+    assert!(first.get("body").is_some());
+}
+
+// ── path resolution ───────────────────────────────────────────────────────────
+
+#[test]
+fn export_default_path_resolves_to_wiki_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+
+    let report = ops::export(
+        &engine,
+        &ExportOptions {
+            wiki: "test".into(),
+            path: None,
+            format: ExportFormat::LlmsTxt,
+            include_archived: false,
+        },
+    )
+    .unwrap();
+
+    // Default path is llms.txt relative to wiki root
+    assert!(report.path.ends_with("llms.txt"));
+    assert!(std::path::PathBuf::from(&report.path).exists());
+}
+
+// ── status filter ─────────────────────────────────────────────────────────────
+
+#[test]
+fn export_excludes_archived_by_default() {
+    use llm_wiki::git;
+    use std::fs;
+
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let wiki_path = dir.path().join("test");
+    let wiki_root = wiki_path.join("wiki");
+
+    // Add an archived page
+    fs::write(
+        wiki_root.join("concepts/archived-page.md"),
+        "---\ntitle: \"Archived\"\ntype: concept\nstatus: archived\n---\n\nOld content.\n",
+    )
+    .unwrap();
+    git::commit(&wiki_path, "add archived").unwrap();
+
+    // Rebuild the index with the new page
+    let manager = WikiEngine::build(&config_path).unwrap();
+    {
+        let wiki_name = "test".to_string();
+        ops::index_rebuild(&manager, &wiki_name).unwrap();
+    }
+    let engine = manager.state.read().unwrap();
+
+    let report = ops::export(
+        &engine,
+        &ExportOptions {
+            wiki: "test".into(),
+            path: Some("out.txt".into()),
+            format: ExportFormat::LlmsTxt,
+            include_archived: false,
+        },
+    )
+    .unwrap();
+    let content = std::fs::read_to_string(&report.path).unwrap();
+    assert!(!content.contains("archived-page"));
+
+    let report_all = ops::export(
+        &engine,
+        &ExportOptions {
+            wiki: "test".into(),
+            path: Some("out-all.txt".into()),
+            format: ExportFormat::LlmsTxt,
+            include_archived: true,
+        },
+    )
+    .unwrap();
+    let content_all = std::fs::read_to_string(&report_all.path).unwrap();
+    assert!(content_all.contains("archived-page"));
+}

--- a/tests/ops/main.rs
+++ b/tests/ops/main.rs
@@ -2,6 +2,7 @@ mod helpers;
 
 mod config;
 mod content;
+mod export;
 mod graph;
 mod history;
 mod hot_reload;


### PR DESCRIPTION
Implements imp-9 (llms format + wiki_export).

- Add format: "llms" to wiki_list, wiki_search, wiki_graph
- Add wiki_export MCP tool and CLI export subcommand
- Formats: llms-txt (default), llms-full, json
- Path resolution relative to wiki root; default llms.txt
- Spec docs, llms-format guide, and index updates

Closes geronimo-iia/llm-wiki#22 (imp-9)

Spec: docs/improvements/export.md