### PR TITLE
feat: cross-wiki links (imp-10)

### DIFF
--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -18,7 +18,7 @@ items that follow it.
 | 9   | ✅ | [export.md](export.md)                                 | `format: "llms"` on `wiki_list`/`wiki_search`/`wiki_graph`; `wiki_export(path:)` writes full wiki to file | #1    |
 | 10  | — | [cross-wiki-links.md](cross-wiki-links.md)             | `wiki://` URIs as link targets; cross-wiki edges resolved at graph build time; `wiki_graph(cross_wiki: true)` | — |
 | 11  | ✅ | [ingest-two-step.md](ingest-two-step.md)               | Explicit analysis pass in `ingest` skill before writes: enumerate entities, detect contradictions, produce ingest plan | — |
-| 12  | — | [review-skill.md](review-skill.md)                     | New `review` skill: prioritized queue from `wiki_lint` + draft/low-confidence pages; guided review loop per page | #1, #4 |
+| 12  | ✅ | [review-skill.md](review-skill.md)                     | New `review` skill: prioritized queue from `wiki_lint` + draft/low-confidence pages; guided review loop per page | #1, #4 |
 
 Items 1–2 are coupled: implement confidence first, then wire it into search ranking
 in the same pass. Items 3, 5, 6 are fully independent. Item 4 (lint) can start

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -17,7 +17,7 @@ items that follow it.
 | 8   | — | [community-detection.md](community-detection.md)       | Louvain clustering on `petgraph::DiGraph`; `communities` in `wiki_stats`; strategy 4 in `wiki_suggest` | —        |
 | 9   | ✅ | [export.md](export.md)                                 | `format: "llms"` on `wiki_list`/`wiki_search`/`wiki_graph`; `wiki_export(path:)` writes full wiki to file | #1    |
 | 10  | — | [cross-wiki-links.md](cross-wiki-links.md)             | `wiki://` URIs as link targets; cross-wiki edges resolved at graph build time; `wiki_graph(cross_wiki: true)` | — |
-| 11  | — | [ingest-two-step.md](ingest-two-step.md)               | Explicit analysis pass in `ingest` skill before writes: enumerate entities, detect contradictions, produce ingest plan | — |
+| 11  | ✅ | [ingest-two-step.md](ingest-two-step.md)               | Explicit analysis pass in `ingest` skill before writes: enumerate entities, detect contradictions, produce ingest plan | — |
 | 12  | — | [review-skill.md](review-skill.md)                     | New `review` skill: prioritized queue from `wiki_lint` + draft/low-confidence pages; guided review loop per page | #1, #4 |
 
 Items 1–2 are coupled: implement confidence first, then wire it into search ranking

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,7 +38,7 @@ ordered by priority:
 | 9   | ✅ | `llms` format + `wiki_export` (file-writing, default `llms.txt` at wiki root) |   ✦    |   ✦    |
 | 10  | — | Cross-wiki links (`wiki://` URIs in graph, `wiki_graph(cross_wiki: true)`)    |   ✦    |   ✦    |
 | 11  | ✅ | Ingest two-step: analysis pass before write (entities, contradictions, plan)  |   —    |   ✦    |
-| 12  | — | Review skill: prioritized queue from lint + draft/low-confidence pages        |   —    |   ✦    |
+| 12  | ✅ | Review skill: prioritized queue from lint + draft/low-confidence pages        |   —    |   ✦    |
 | —   | — | **Pre-release doc pass** — rustdocs, spec/guide audit, CHANGELOG date         |   ✦    |   ✦    |
 
 Full specs, task lists, and dependency order: [`docs/improvements/README.md`](improvements/README.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,7 +37,7 @@ ordered by priority:
 | 8   | — | Graph community detection (Louvain, `wiki_stats` + `wiki_suggest`)            |   ✦    |   ✦    |
 | 9   | ✅ | `llms` format + `wiki_export` (file-writing, default `llms.txt` at wiki root) |   ✦    |   ✦    |
 | 10  | — | Cross-wiki links (`wiki://` URIs in graph, `wiki_graph(cross_wiki: true)`)    |   ✦    |   ✦    |
-| 11  | — | Ingest two-step: analysis pass before write (entities, contradictions, plan)  |   —    |   ✦    |
+| 11  | ✅ | Ingest two-step: analysis pass before write (entities, contradictions, plan)  |   —    |   ✦    |
 | 12  | — | Review skill: prioritized queue from lint + draft/low-confidence pages        |   —    |   ✦    |
 | —   | — | **Pre-release doc pass** — rustdocs, spec/guide audit, CHANGELOG date         |   ✦    |   ✦    |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,9 @@ pub enum Commands {
         /// File path for output (default: stdout)
         #[arg(long)]
         output: Option<String>,
+        /// Merge all mounted wikis into a unified graph
+        #[arg(long)]
+        cross_wiki: bool,
     },
     /// Manage the tantivy search index
     Index {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -12,6 +12,7 @@ use tantivy::query::AllQuery;
 use tantivy::schema::Value;
 
 use crate::index_schema::IndexSchema;
+use crate::links::ParsedLink;
 use crate::type_registry::SpaceTypeRegistry;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -21,6 +22,8 @@ pub struct PageNode {
     pub slug: String,
     pub title: String,
     pub r#type: String,
+    #[serde(default)]
+    pub external: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -145,6 +148,7 @@ pub fn build_graph(
             slug: slug.clone(),
             title,
             r#type: page_type.clone(),
+            external: false,
         };
         let idx = graph.add_node(node);
         slug_to_idx.insert(slug.clone(), idx);
@@ -198,7 +202,8 @@ pub fn build_graph(
             }
 
             for target in targets {
-                if let Some(&to_idx) = slug_to_idx.get(target)
+                let to_idx = resolve_or_external(target, &mut graph, &mut slug_to_idx);
+                if let Some(to_idx) = to_idx
                     && from_idx != to_idx
                 {
                     graph.add_edge(
@@ -215,7 +220,8 @@ pub fn build_graph(
         // Body wiki-links → "links-to"
         if filter.relation.is_none() || filter.relation.as_deref() == Some("links-to") {
             for target in &doc_info.body_links {
-                if let Some(&to_idx) = slug_to_idx.get(target)
+                let to_idx = resolve_or_external(target, &mut graph, &mut slug_to_idx);
+                if let Some(to_idx) = to_idx
                     && from_idx != to_idx
                 {
                     graph.add_edge(
@@ -238,6 +244,125 @@ pub fn build_graph(
     Ok(graph)
 }
 
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Resolve a target slug to a node index. If the target is a `wiki://` URI,
+/// insert an external placeholder node on demand. Returns `None` only for
+/// plain local slugs that don't exist in the index.
+fn resolve_or_external(
+    target: &str,
+    graph: &mut WikiGraph,
+    slug_to_idx: &mut HashMap<String, NodeIndex>,
+) -> Option<NodeIndex> {
+    if target.starts_with("wiki://") {
+        let key = target.to_string();
+        let idx = *slug_to_idx.entry(key.clone()).or_insert_with(|| {
+            let (_wiki, slug) = match ParsedLink::parse(target) {
+                ParsedLink::CrossWiki { wiki, slug } => (wiki, slug),
+                ParsedLink::Local(_) => ("external".to_string(), target.to_string()),
+            };
+            graph.add_node(PageNode {
+                slug: slug.clone(),
+                title: key.clone(),
+                r#type: "external".to_string(),
+                external: true,
+            })
+        });
+        Some(idx)
+    } else {
+        slug_to_idx.get(target).copied()
+    }
+}
+
+// ── build_graph_cross_wiki ────────────────────────────────────────────────────
+
+/// Build a unified graph merging all provided wikis. Cross-wiki edges that
+/// were external placeholders in single-wiki graphs become resolved connections
+/// when both endpoint wikis are present in `wikis`.
+pub fn build_graph_cross_wiki(
+    wikis: &[(&str, &Searcher, &IndexSchema, &SpaceTypeRegistry)],
+    filter: &GraphFilter,
+) -> Result<WikiGraph> {
+    // Build per-wiki graphs and merge into one, prefixing slugs with wiki name
+    let mut merged = WikiGraph::new();
+    // Map from "wikiname/slug" -> NodeIndex in merged graph
+    let mut global_idx: HashMap<String, NodeIndex> = HashMap::new();
+
+    // First: add all local (non-external) nodes from each wiki
+    for (wiki_name, searcher, is, registry) in wikis {
+        let g = build_graph(searcher, is, filter, registry)?;
+        for idx in g.node_indices() {
+            let node = &g[idx];
+            if node.external {
+                continue; // will re-resolve below
+            }
+            let key = format!("{wiki_name}/{}", node.slug);
+            let new_idx = merged.add_node(PageNode {
+                slug: key.clone(),
+                title: node.title.clone(),
+                r#type: node.r#type.clone(),
+                external: false,
+            });
+            global_idx.insert(key, new_idx);
+        }
+    }
+
+    // Second: add edges, re-resolving cross-wiki targets
+    for (wiki_name, searcher, is, registry) in wikis {
+        let g = build_graph(searcher, is, filter, registry)?;
+        for edge_idx in g.edge_indices() {
+            let (from, to) = g.edge_endpoints(edge_idx).unwrap();
+            let from_node = &g[from];
+            let to_node = &g[to];
+
+            let from_key = format!("{wiki_name}/{}", from_node.slug);
+            let from_merged = match global_idx.get(&from_key) {
+                Some(&i) => i,
+                None => continue,
+            };
+
+            // to_node is external if it has external=true; its title is the wiki:// URI
+            let to_key = if to_node.external {
+                // title was set to "wiki://otherwiki/slug"
+                if let ParsedLink::CrossWiki { wiki, slug } = ParsedLink::parse(&to_node.title) {
+                    format!("{wiki}/{slug}")
+                } else {
+                    continue;
+                }
+            } else {
+                format!("{wiki_name}/{}", to_node.slug)
+            };
+
+            let to_merged = match global_idx.get(&to_key) {
+                Some(&i) => i,
+                None => {
+                    // target wiki not mounted — keep as external placeholder
+                    *global_idx.entry(to_key.clone()).or_insert_with(|| {
+                        merged.add_node(PageNode {
+                            slug: to_key.clone(),
+                            title: to_node.title.clone(),
+                            r#type: "external".to_string(),
+                            external: true,
+                        })
+                    })
+                }
+            };
+
+            if from_merged != to_merged {
+                merged.add_edge(
+                    from_merged,
+                    to_merged,
+                    LabeledEdge {
+                        relation: g[edge_idx].relation.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(merged)
+}
+
 // ── render_llms ───────────────────────────────────────────────────────────────
 
 /// Natural language description of graph structure for direct LLM consumption.
@@ -245,10 +370,20 @@ pub fn render_llms(graph: &WikiGraph) -> String {
     let nodes = graph.node_count();
     let edges = graph.edge_count();
 
-    // Group nodes by type
+    // Separate external placeholder nodes
+    let external_refs: Vec<String> = graph
+        .node_indices()
+        .filter(|&idx| graph[idx].external)
+        .map(|idx| graph[idx].title.clone())
+        .collect();
+
+    // Group local nodes by type
     let mut by_type: HashMap<String, Vec<String>> = HashMap::new();
     for idx in graph.node_indices() {
         let node = &graph[idx];
+        if node.external {
+            continue;
+        }
         by_type
             .entry(node.r#type.clone())
             .or_default()
@@ -333,6 +468,16 @@ pub fn render_llms(graph: &WikiGraph) -> String {
         ));
     }
 
+    if !external_refs.is_empty() {
+        let mut sorted = external_refs.clone();
+        sorted.sort();
+        out.push_str(&format!(
+            "\n**External references ({}):** {}\n",
+            sorted.len(),
+            sorted.join(", ")
+        ));
+    }
+
     out
 }
 
@@ -344,15 +489,22 @@ pub fn render_mermaid(graph: &WikiGraph) -> String {
     // Collect unique types for classDef
     let mut types_seen: HashSet<String> = HashSet::new();
 
+    let mut has_external = false;
+
     // Declare nodes with titles and type classes
     for idx in graph.node_indices() {
         let node = &graph[idx];
-        let safe_slug = mermaid_id(&node.slug);
-        out.push_str(&format!(
-            "  {safe_slug}[\"{}\"]:::{}\n",
-            node.title, node.r#type
-        ));
-        types_seen.insert(node.r#type.clone());
+        let safe_id = mermaid_id(&node.title);
+        if node.external {
+            out.push_str(&format!("  {safe_id}[\"{}\"]:::external\n", node.title));
+            has_external = true;
+        } else {
+            out.push_str(&format!(
+                "  {safe_id}[\"{}\"]:::{}\n",
+                node.title, node.r#type
+            ));
+            types_seen.insert(node.r#type.clone());
+        }
     }
 
     out.push('\n');
@@ -360,14 +512,17 @@ pub fn render_mermaid(graph: &WikiGraph) -> String {
     // Edges with relation labels
     for edge in graph.edge_indices() {
         let (from, to) = graph.edge_endpoints(edge).unwrap();
-        let from_id = mermaid_id(&graph[from].slug);
-        let to_id = mermaid_id(&graph[to].slug);
+        let from_id = mermaid_id(&graph[from].title);
+        let to_id = mermaid_id(&graph[to].title);
         let relation = &graph[edge].relation;
         out.push_str(&format!("  {from_id} -->|{relation}| {to_id}\n"));
     }
 
-    // classDef for known types
+    // classDef for known types + external
     out.push('\n');
+    if has_external {
+        out.push_str("  classDef external fill:#eee,stroke:#999,stroke-dasharray:5 5\n");
+    }
     let type_colors = [
         ("concept", "#cce5ff"),
         ("query-result", "#cce5ff"),
@@ -388,7 +543,7 @@ pub fn render_mermaid(graph: &WikiGraph) -> String {
 }
 
 fn mermaid_id(slug: &str) -> String {
-    slug.replace(['/', '-'], "_")
+    slug.replace("://", "__").replace(['/', '-', ':'], "_")
 }
 
 // ── render_dot ────────────────────────────────────────────────────────────────
@@ -398,18 +553,34 @@ pub fn render_dot(graph: &WikiGraph) -> String {
 
     for idx in graph.node_indices() {
         let node = &graph[idx];
-        out.push_str(&format!(
-            "  \"{}\" [label=\"{}\" type=\"{}\"];\n",
-            node.slug, node.title, node.r#type
-        ));
+        if node.external {
+            out.push_str(&format!(
+                "  \"{}\" [label=\"{}\" type=\"external\" style=\"dashed\"];\n",
+                node.title, node.title
+            ));
+        } else {
+            out.push_str(&format!(
+                "  \"{}\" [label=\"{}\" type=\"{}\"];\n",
+                node.slug, node.title, node.r#type
+            ));
+        }
     }
 
     for edge in graph.edge_indices() {
         let (from, to) = graph.edge_endpoints(edge).unwrap();
         let relation = &graph[edge].relation;
+        let from_id = if graph[from].external {
+            &graph[from].title
+        } else {
+            &graph[from].slug
+        };
+        let to_id = if graph[to].external {
+            &graph[to].title
+        } else {
+            &graph[to].slug
+        };
         out.push_str(&format!(
-            "  \"{}\" -> \"{}\" [label=\"{}\"];\n",
-            graph[from].slug, graph[to].slug, relation
+            "  \"{from_id}\" -> \"{to_id}\" [label=\"{relation}\"];\n"
         ));
     }
 

--- a/src/links.rs
+++ b/src/links.rs
@@ -2,6 +2,81 @@ use std::collections::HashSet;
 
 use crate::frontmatter::ParsedPage;
 
+// ── ParsedLink ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedLink {
+    Local(String),
+    CrossWiki { wiki: String, slug: String },
+}
+
+impl ParsedLink {
+    pub fn parse(s: &str) -> Self {
+        if let Some(rest) = s.strip_prefix("wiki://")
+            && let Some(slash) = rest.find('/')
+        {
+            return ParsedLink::CrossWiki {
+                wiki: rest[..slash].to_string(),
+                slug: rest[slash + 1..].to_string(),
+            };
+        }
+        ParsedLink::Local(s.to_string())
+    }
+
+    pub fn as_raw(&self) -> &str {
+        match self {
+            ParsedLink::Local(s) => s,
+            ParsedLink::CrossWiki { wiki, slug } => {
+                // We store the original string form; callers needing the raw
+                // form reconstruct it. This returns the slug portion only for
+                // local use; graph.rs uses the wiki/slug fields directly.
+                let _ = wiki;
+                slug
+            }
+        }
+    }
+}
+
+/// Like `extract_links` but returns typed `ParsedLink` values distinguishing
+/// local slugs from `wiki://name/slug` cross-wiki references.
+/// Use this in graph.rs. The original `extract_links` stays for index consumers.
+pub fn extract_parsed_links(page: &ParsedPage) -> Vec<ParsedLink> {
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
+
+    for slug in page.string_list("sources") {
+        let raw = slug.to_string();
+        if seen.insert(raw.clone()) {
+            result.push(ParsedLink::parse(&raw));
+        }
+    }
+    for slug in page.string_list("concepts") {
+        let raw = slug.to_string();
+        if seen.insert(raw.clone()) {
+            result.push(ParsedLink::parse(&raw));
+        }
+    }
+    extract_parsed_wikilinks(&page.body, &mut seen, &mut result);
+
+    result
+}
+
+fn extract_parsed_wikilinks(text: &str, seen: &mut HashSet<String>, result: &mut Vec<ParsedLink>) {
+    let mut rest = text;
+    while let Some(start) = rest.find("[[") {
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find("]]") {
+            let raw = after[..end].trim().to_string();
+            if !raw.is_empty() && seen.insert(raw.clone()) {
+                result.push(ParsedLink::parse(&raw));
+            }
+            rest = &after[end + 2..];
+        } else {
+            break;
+        }
+    }
+}
+
 /// Extract all linked slugs from a parsed page: frontmatter `sources`,
 /// `concepts`, and body `[[wikilinks]]`. Deduplicated, order preserved.
 pub fn extract_links(page: &ParsedPage) -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,7 @@ fn main() -> Result<()> {
             r#type,
             relation,
             output,
+            cross_wiki,
         } => {
             let manager = WikiEngine::build(&config_path)?;
             let engine = manager.state.read().map_err(|_| anyhow::anyhow!("lock"))?;
@@ -379,6 +380,7 @@ fn main() -> Result<()> {
                     type_filter: r#type.as_deref(),
                     relation,
                     output: output.as_deref(),
+                    cross_wiki,
                 },
             )?;
 

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -328,6 +328,7 @@ pub fn handle_graph(server: &McpServer, args: &Map<String, Value>) -> ToolHandle
             type_filter: arg_str(args, "type").as_deref(),
             relation: arg_str(args, "relation"),
             output: arg_str(args, "output").as_deref(),
+            cross_wiki: arg_bool(args, "cross_wiki"),
         },
     )
     .map_err(|e| format!("{e}"))?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -230,6 +230,7 @@ pub fn tool_list() -> Vec<Tool> {
                     "type": opt_str("Comma-separated page types to include"),
                     "relation": opt_str("Filter edges by relation label"),
                     "output": opt_str("File path for output (default: stdout/return)"),
+                    "cross_wiki": opt_bool("Merge all mounted wikis into a unified graph"),
                     "wiki": opt_str("Target wiki name"),
                 }),
                 &[],

--- a/src/ops/graph.rs
+++ b/src/ops/graph.rs
@@ -15,6 +15,7 @@ pub struct GraphParams<'a> {
     pub type_filter: Option<&'a str>,
     pub relation: Option<String>,
     pub output: Option<&'a str>,
+    pub cross_wiki: bool,
 }
 
 pub fn graph_build(
@@ -37,13 +38,37 @@ pub fn graph_build(
         types,
         relation: params.relation.clone(),
     };
-    let searcher = space.index_manager.searcher()?;
-    let g = graph::build_graph(
-        &searcher,
-        &space.index_schema,
-        &filter,
-        &space.type_registry,
-    )?;
+    let g = if params.cross_wiki {
+        // Collect (name, searcher) pairs; Arc keeps schema/registry alive
+        let space_data: Vec<(String, tantivy::Searcher)> = engine
+            .spaces
+            .iter()
+            .filter_map(|(name, sp)| sp.index_manager.searcher().ok().map(|s| (name.clone(), s)))
+            .collect();
+        let tuples: Vec<(
+            &str,
+            &tantivy::Searcher,
+            &crate::index_schema::IndexSchema,
+            &crate::type_registry::SpaceTypeRegistry,
+        )> = space_data
+            .iter()
+            .filter_map(|(name, searcher)| {
+                engine
+                    .spaces
+                    .get(name)
+                    .map(|sp| (name.as_str(), searcher, &sp.index_schema, &sp.type_registry))
+            })
+            .collect();
+        graph::build_graph_cross_wiki(&tuples, &filter)?
+    } else {
+        let searcher = space.index_manager.searcher()?;
+        graph::build_graph(
+            &searcher,
+            &space.index_schema,
+            &filter,
+            &space.type_registry,
+        )?
+    };
 
     let rendered = match fmt {
         "dot" => graph::render_dot(&g),

--- a/src/ops/lint.rs
+++ b/src/ops/lint.rs
@@ -55,6 +55,7 @@ pub fn run_lint(
         None | Some("") => [
             "orphan",
             "broken-link",
+            "broken-cross-wiki-link",
             "missing-fields",
             "stale",
             "unknown-type",
@@ -76,8 +77,14 @@ pub fn run_lint(
     if active_rules.contains("orphan") {
         findings.extend(rule_orphan(&searcher, is)?);
     }
-    if active_rules.contains("broken-link") {
-        findings.extend(rule_broken_link(&searcher, is)?);
+    if active_rules.contains("broken-link") || active_rules.contains("broken-cross-wiki-link") {
+        let mounted: HashSet<String> = engine.spaces.keys().cloned().collect();
+        findings.extend(rule_broken_link(
+            &searcher,
+            is,
+            active_rules.contains("broken-cross-wiki-link"),
+            &mounted,
+        )?);
     }
     if active_rules.contains("missing-fields") {
         findings.extend(rule_missing_fields(&searcher, is, &space.type_registry)?);
@@ -201,7 +208,12 @@ fn slug_exists(searcher: &tantivy::Searcher, is: &IndexSchema, slug: &str) -> Re
     Ok(!results.is_empty())
 }
 
-fn rule_broken_link(searcher: &tantivy::Searcher, is: &IndexSchema) -> Result<Vec<LintFinding>> {
+fn rule_broken_link(
+    searcher: &tantivy::Searcher,
+    is: &IndexSchema,
+    check_cross_wiki: bool,
+    mounted_wiki_names: &HashSet<String>,
+) -> Result<Vec<LintFinding>> {
     let f_slug = is.field("slug");
     let link_fields = [
         "body_links",
@@ -236,8 +248,20 @@ fn rule_broken_link(searcher: &tantivy::Searcher, is: &IndexSchema) -> Result<Ve
                     Some(s) => s,
                     None => continue,
                 };
-                // Skip cross-wiki links (imp-10's concern)
                 if target.starts_with("wiki://") {
+                    if check_cross_wiki
+                        && let Some(wiki_name) = target
+                            .strip_prefix("wiki://")
+                            .and_then(|r| r.split('/').next())
+                        && !mounted_wiki_names.contains(wiki_name)
+                    {
+                        findings.push(LintFinding {
+                            slug: slug.clone(),
+                            rule: "broken-cross-wiki-link",
+                            severity: Severity::Warning,
+                            message: format!("cross-wiki link to unmounted wiki: {target}"),
+                        });
+                    }
                     continue;
                 }
                 if !slug_exists(searcher, is, target)? {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -560,3 +560,135 @@ fn render_llms_shows_hubs_and_isolated() {
     assert!(output.contains("**Isolated nodes"));
     assert!(output.contains("Isolated"));
 }
+
+// ── cross-wiki graph ──────────────────────────────────────────────────────────
+
+fn page_with_cross_wiki_link(title: &str, target: &str) -> String {
+    format!(
+        "---\ntitle: \"{title}\"\ntype: concept\nstatus: active\nsources:\n  - {target}\n---\n\nBody.\n"
+    )
+}
+
+#[test]
+fn build_graph_with_cross_wiki_target_produces_external_node() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/local.md",
+        &page_with_cross_wiki_link("Local", "wiki://other/concepts/remote"),
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    // Should have 2 nodes: local + external placeholder
+    assert_eq!(g.node_count(), 2);
+
+    let external = g
+        .node_indices()
+        .find(|&idx| g[idx].external)
+        .expect("external node should exist");
+    assert_eq!(g[external].r#type, "external");
+    assert!(g[external].title.contains("wiki://other/concepts/remote"));
+
+    // Should have 1 edge
+    assert_eq!(g.edge_count(), 1);
+}
+
+#[test]
+fn build_graph_cross_wiki_resolves_cross_wiki_edge() {
+    // Two wikis: wiki-a has a page linking to wiki-b
+    let dir_a = tempfile::tempdir().unwrap();
+    let wiki_root_a = setup_repo(dir_a.path());
+    write_page(
+        &wiki_root_a,
+        "concepts/concept-a.md",
+        &page_with_cross_wiki_link("ConceptA", "wiki://wiki-b/concepts/concept-b"),
+    );
+
+    let dir_b = tempfile::tempdir().unwrap();
+    let wiki_root_b = setup_repo(dir_b.path());
+    write_page(
+        &wiki_root_b,
+        "concepts/concept-b.md",
+        &simple_page("ConceptB", "concept"),
+    );
+
+    let index_a = dir_a.path().join("idx");
+    let index_b = dir_b.path().join("idx");
+    let (is, reg) = schema_and_registry();
+
+    git::commit(dir_a.path(), "pages").unwrap();
+    git::commit(dir_b.path(), "pages").unwrap();
+
+    let mgr_a = SpaceIndexManager::new("wiki-a", &index_a);
+    mgr_a
+        .rebuild(&wiki_root_a, dir_a.path(), &is, &reg)
+        .unwrap();
+    mgr_a.open(&is, None).unwrap();
+
+    let mgr_b = SpaceIndexManager::new("wiki-b", &index_b);
+    mgr_b
+        .rebuild(&wiki_root_b, dir_b.path(), &is, &reg)
+        .unwrap();
+    mgr_b.open(&is, None).unwrap();
+
+    let searcher_a = mgr_a.searcher().unwrap();
+    let searcher_b = mgr_b.searcher().unwrap();
+
+    let filter = GraphFilter::default();
+    let tuples: Vec<(&str, &tantivy::Searcher, &IndexSchema, &SpaceTypeRegistry)> = vec![
+        ("wiki-a", &searcher_a, &is, &reg),
+        ("wiki-b", &searcher_b, &is, &reg),
+    ];
+
+    let g = build_graph_cross_wiki(&tuples, &filter).unwrap();
+
+    // Both wikis: 2 local nodes, cross-wiki edge should be resolved (no external)
+    let external_count = g.node_indices().filter(|&idx| g[idx].external).count();
+    assert_eq!(
+        external_count, 0,
+        "cross-wiki edge should resolve to local node"
+    );
+    assert_eq!(g.node_count(), 2);
+    assert_eq!(g.edge_count(), 1);
+}
+
+#[test]
+fn render_mermaid_external_node_has_class_def() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/local.md",
+        &page_with_cross_wiki_link("Local", "wiki://other/concepts/remote"),
+    );
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    let mermaid = render_mermaid(&g);
+    assert!(
+        mermaid.contains("classDef external"),
+        "should have external classDef"
+    );
+    assert!(
+        mermaid.contains(":::external"),
+        "external node should have :::external class"
+    );
+}

--- a/tests/links.rs
+++ b/tests/links.rs
@@ -1,5 +1,5 @@
 use llm_wiki::frontmatter;
-use llm_wiki::links::{extract_body_wikilinks, extract_links};
+use llm_wiki::links::{ParsedLink, extract_body_wikilinks, extract_links, extract_parsed_links};
 
 #[test]
 fn extract_links_from_sources() {
@@ -77,4 +77,51 @@ fn extract_body_wikilinks_ignores_empty() {
 fn extract_body_wikilinks_unclosed_bracket() {
     let links = extract_body_wikilinks("See [[concepts/moe and nothing else.");
     assert!(links.is_empty());
+}
+
+// ── ParsedLink ────────────────────────────────────────────────────────────────
+
+#[test]
+fn parsed_link_local() {
+    assert_eq!(
+        ParsedLink::parse("concepts/moe"),
+        ParsedLink::Local("concepts/moe".to_string())
+    );
+}
+
+#[test]
+fn parsed_link_cross_wiki() {
+    assert_eq!(
+        ParsedLink::parse("wiki://other/concepts/foo"),
+        ParsedLink::CrossWiki {
+            wiki: "other".to_string(),
+            slug: "concepts/foo".to_string(),
+        }
+    );
+}
+
+#[test]
+fn parsed_link_cross_wiki_no_slash_is_local() {
+    // "wiki://nopath" has no slash after the wiki name — treated as local
+    assert_eq!(
+        ParsedLink::parse("wiki://nopath"),
+        ParsedLink::Local("wiki://nopath".to_string())
+    );
+}
+
+#[test]
+fn extract_parsed_links_returns_cross_wiki_variant() {
+    let page = frontmatter::parse(
+        "---\ntitle: \"Test\"\ntype: concept\nsources:\n  - wiki://other/concepts/foo\n  - concepts/local\n---\n\nBody with [[wiki://third/bar]].\n",
+    );
+    let links = extract_parsed_links(&page);
+    assert!(links.contains(&ParsedLink::CrossWiki {
+        wiki: "other".to_string(),
+        slug: "concepts/foo".to_string(),
+    }));
+    assert!(links.contains(&ParsedLink::Local("concepts/local".to_string())));
+    assert!(links.contains(&ParsedLink::CrossWiki {
+        wiki: "third".to_string(),
+        slug: "bar".to_string(),
+    }));
 }

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -369,3 +369,86 @@ fn integration_known_bad_wiki() {
     );
     assert!(report.errors > 0, "should have errors");
 }
+
+// ── broken-cross-wiki-link ────────────────────────────────────────────────────
+
+fn build_engine_with_name(dir: &Path, wiki_root: &Path, name: &str) -> EngineState {
+    let index_path = dir.join("index-store");
+    git::commit(dir, "index pages").unwrap();
+    let mgr = SpaceIndexManager::new(name, &index_path);
+    mgr.rebuild(wiki_root, dir, &schema(), &registry()).unwrap();
+    mgr.open(&schema(), None).unwrap();
+
+    let space = Arc::new(SpaceContext {
+        name: name.to_string(),
+        wiki_root: wiki_root.to_path_buf(),
+        repo_root: dir.to_path_buf(),
+        type_registry: registry(),
+        index_schema: schema(),
+        index_manager: mgr,
+    });
+
+    let mut spaces = HashMap::new();
+    spaces.insert(name.to_string(), space);
+
+    EngineState {
+        config: GlobalConfig::default(),
+        config_path: dir.join("config.toml"),
+        state_dir: dir.to_path_buf(),
+        spaces,
+    }
+}
+
+#[test]
+fn broken_cross_wiki_link_to_unmounted_wiki_is_warning() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/a.md",
+        "---\ntitle: \"A\"\ntype: concept\nread_when: [\"x\"]\nsources:\n  - wiki://unmounted/concepts/b\n---\n\nBody.\n",
+    );
+
+    let engine = build_engine_with_name(dir.path(), &wiki_root, "mywiki");
+    let report = run_lint(&engine, "mywiki", Some("broken-cross-wiki-link"), None).unwrap();
+
+    let cross_wiki_findings = slugs_for_rule(&report.findings, "broken-cross-wiki-link");
+    assert!(
+        cross_wiki_findings.contains(&"concepts/a".to_string()),
+        "should flag cross-wiki link to unmounted wiki: {cross_wiki_findings:?}"
+    );
+    // Should be Warning severity, not Error
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule == "broken-cross-wiki-link")
+        .unwrap();
+    assert_eq!(finding.severity, Severity::Warning);
+}
+
+#[test]
+fn broken_cross_wiki_link_to_mounted_wiki_no_finding() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/a.md",
+        "---\ntitle: \"A\"\ntype: concept\nread_when: [\"x\"]\nsources:\n  - wiki://mywiki/concepts/local\n---\n\nBody.\n",
+    );
+    // Provide a second page so there's an incoming link to concepts/a
+    write_page(
+        &wiki_root,
+        "concepts/b.md",
+        "---\ntitle: \"B\"\ntype: concept\nread_when: [\"x\"]\n---\n\nSee [[concepts/a]].\n",
+    );
+
+    // Engine named "mywiki" — the wiki:// link targets "mywiki" which IS mounted
+    let engine = build_engine_with_name(dir.path(), &wiki_root, "mywiki");
+    let report = run_lint(&engine, "mywiki", Some("broken-cross-wiki-link"), None).unwrap();
+
+    let cross_wiki_findings = slugs_for_rule(&report.findings, "broken-cross-wiki-link");
+    assert!(
+        cross_wiki_findings.is_empty(),
+        "mounted wiki should not produce findings: {cross_wiki_findings:?}"
+    );
+}

--- a/tests/ops/graph.rs
+++ b/tests/ops/graph.rs
@@ -21,6 +21,7 @@ fn graph_build_returns_nodes() {
             type_filter: None,
             relation: None,
             output: None,
+            cross_wiki: false,
         },
     )
     .unwrap();
@@ -45,6 +46,7 @@ fn graph_build_dot_format() {
             type_filter: None,
             relation: None,
             output: None,
+            cross_wiki: false,
         },
     )
     .unwrap();


### PR DESCRIPTION
## Summary

- `src/links.rs`: new `ParsedLink` enum + `extract_parsed_links` — typed local vs `wiki://` links; original `extract_links` unchanged
- `src/graph.rs`: `external: bool` on `PageNode`; `resolve_or_external` helper inserts external placeholder nodes for `wiki://` targets in single-wiki graph; `build_graph_cross_wiki` merges multiple wikis resolving cross-wiki edges; Mermaid `classDef external` + `:::external` + sanitized IDs; DOT `style="dashed"`; `llms` renderer lists external refs separately
- `src/ops/graph.rs`: `cross_wiki: bool` in `GraphParams`; dispatches to `build_graph_cross_wiki` when true
- `src/mcp/tools.rs` + `handlers.rs`: `cross_wiki` param on `wiki_graph`
- `src/ops/lint.rs`: `broken-cross-wiki-link` Warning — fires when `wiki://` target names an unmounted wiki; default rule set; threaded via `check_cross_wiki` + `mounted_wiki_names`
- `src/cli.rs` + `src/main.rs`: `--cross-wiki` flag on `graph` subcommand
- Tests: `ParsedLink` parse, `extract_parsed_links`, external node in single-wiki graph, `build_graph_cross_wiki` resolution, Mermaid classDef, lint rule mounted/unmounted

wiki:// URIs as first-class link targets. Closes #22 imp-10.

## Test plan

- [ ] `cargo test` passes (all existing + 9 new tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `wiki_graph(cross_wiki: true)` merges mounted wikis
- [ ] Single-wiki graph with `wiki://` link shows external dashed node
- [ ] `wiki_lint()` produces `broken-cross-wiki-link` Warning for unmounted wiki
- [ ] `wiki_lint()` no finding for mounted wiki target