### PR TITLE
feat: community detection (imp-08)

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -15,5 +15,6 @@ llm-wiki.
 | [llms-format.md](llms-format.md)         | LLM-optimized output: when and how to use `format: "llms"` and `wiki_export` |
 | [lint.md](lint.md)                       | Catch broken links, orphans, missing fields, stale pages, and unknown types  |
 | [redaction.md](redaction.md)             | Scrub secrets from page bodies before commit with `redact: true`             |
+| [graph.md](graph.md)                     | Community detection, cross-cluster suggestions, threshold tuning  |
 | [ci-cd.md](ci-cd.md)                     | Schema validation, index rebuild, and ingest in CI pipelines      |
 | [release.md](release.md)                 | Release process and distribution channels                         |

--- a/docs/guides/graph.md
+++ b/docs/guides/graph.md
@@ -1,0 +1,42 @@
+---
+title: "Graph Guide"
+summary: "Community detection, cross-cluster suggestions, and graph tuning."
+status: ready
+last_updated: "2026-04-27"
+---
+
+# Graph Guide
+
+## Community detection
+
+When a wiki reaches 30+ pages, `wiki_stats()` returns a `communities` field:
+
+| Field | Description |
+|---|---|
+| `count` | Number of distinct knowledge clusters |
+| `largest` | Size of the biggest cluster |
+| `smallest` | Size of the smallest cluster |
+| `isolated` | Slugs in communities of size ≤ 2 — candidates for new links or consolidation |
+
+Use the `isolated` list as a prioritized review queue. These pages are structurally
+disconnected from the main knowledge body. Run `wiki_suggest(slug: "<isolated-slug>")`
+to find the best connection candidates.
+
+## Cross-cluster suggestions
+
+`wiki_suggest` includes a "same knowledge cluster" strategy (strategy 4). These results
+identify thematically related pages that have no direct link path — the highest-value
+link candidates for improving graph connectivity.
+
+Look for suggestions with `reason: "same knowledge cluster"` in the output.
+
+## Tuning
+
+Below 30 nodes, community detection is suppressed — clusters at small scale produce
+noise. Tune per wiki in `wiki.toml`:
+
+```toml
+[graph]
+min_nodes_for_communities   = 50  # raise for large, dense wikis
+community_suggestions_limit = 3   # more cross-cluster suggestions per call
+```

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -14,9 +14,9 @@ items that follow it.
 | 5   | ✅ | [incremental-validation.md](incremental-validation.md) | Restrict `wiki_ingest` validation to git-changed files via `collect_changed_files`                   | —          |
 | 6   | ✅ | [redaction.md](redaction.md)                           | Opt-in `redact: true` on `wiki_ingest`; built-in patterns + per-wiki `wiki.toml` config              | —          |
 | 7   | ✅ | [crystallize.md](crystallize.md)                       | Two-step extraction pass, confidence calibration table, post-ingest lint step in `crystallize` skill | #1, #4     |
-| 8   | — | [community-detection.md](community-detection.md)       | Louvain clustering on `petgraph::DiGraph`; `communities` in `wiki_stats`; strategy 4 in `wiki_suggest` | —        |
+| 8   | ✅ | [community-detection.md](community-detection.md)       | Louvain clustering on `petgraph::DiGraph`; `communities` in `wiki_stats`; strategy 4 in `wiki_suggest` | —        |
 | 9   | ✅ | [export.md](export.md)                                 | `format: "llms"` on `wiki_list`/`wiki_search`/`wiki_graph`; `wiki_export(path:)` writes full wiki to file | #1    |
-| 10  | — | [cross-wiki-links.md](cross-wiki-links.md)             | `wiki://` URIs as link targets; cross-wiki edges resolved at graph build time; `wiki_graph(cross_wiki: true)` | — |
+| 10  | ✅ | [cross-wiki-links.md](cross-wiki-links.md)             | `wiki://` URIs as link targets; cross-wiki edges resolved at graph build time; `wiki_graph(cross_wiki: true)` | — |
 | 11  | ✅ | [ingest-two-step.md](ingest-two-step.md)               | Explicit analysis pass in `ingest` skill before writes: enumerate entities, detect contradictions, produce ingest plan | — |
 | 12  | ✅ | [review-skill.md](review-skill.md)                     | New `review` skill: prioritized queue from `wiki_lint` + draft/low-confidence pages; guided review loop per page | #1, #4 |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,9 +34,9 @@ ordered by priority:
 | 5   | ✅ | Incremental validation (git-diff scoped)                                      |   ✦    |   —    |
 | 6   | ✅ | Privacy redaction (`redact:` flag on `wiki_ingest`)                           |   ✦    |   —    |
 | 7   | ✅ | Crystallize skill improvements (two-step extraction, confidence calibration)  |   —    |   ✦    |
-| 8   | — | Graph community detection (Louvain, `wiki_stats` + `wiki_suggest`)            |   ✦    |   ✦    |
+| 8   | ✅ | Graph community detection (Louvain, `wiki_stats` + `wiki_suggest`)            |   ✦    |   ✦    |
 | 9   | ✅ | `llms` format + `wiki_export` (file-writing, default `llms.txt` at wiki root) |   ✦    |   ✦    |
-| 10  | — | Cross-wiki links (`wiki://` URIs in graph, `wiki_graph(cross_wiki: true)`)    |   ✦    |   ✦    |
+| 10  | ✅ | Cross-wiki links (`wiki://` URIs in graph, `wiki_graph(cross_wiki: true)`)    |   ✦    |   ✦    |
 | 11  | ✅ | Ingest two-step: analysis pass before write (entities, contradictions, plan)  |   —    |   ✦    |
 | 12  | ✅ | Review skill: prioritized queue from lint + draft/low-confidence pages        |   —    |   ✦    |
 | —   | — | **Pre-release doc pass** — rustdocs, spec/guide audit, CHANGELOG date         |   ✦    |   ✦    |

--- a/docs/specifications/model/global-config.md
+++ b/docs/specifications/model/global-config.md
@@ -55,6 +55,8 @@ type_strictness = "loose"
 [graph]
 format = "mermaid"
 depth  = 3
+min_nodes_for_communities   = 30  # suppress below this; default 30
+community_suggestions_limit = 2   # extra suggest results from community strategy
 
 [history]
 follow        = true
@@ -142,6 +144,8 @@ These keys can appear in both `config.toml` (global) and `wiki.toml`
 | `graph.depth`                | `3`       | Default hop limit when `--root` is set            |
 | `graph.type`                 | `[]`      | Page types to include; empty = all                |
 | `graph.output`               | `""`      | Default output path; empty = stdout               |
+| `graph.min_nodes_for_communities` | `30` | Suppress community detection below this node count |
+| `graph.community_suggestions_limit` | `2` | Max extra results from community strategy in `wiki_suggest` |
 | `index.memory_budget_mb`     | `50`      | Tantivy writer memory budget in MB                |
 | `index.tokenizer`            | `en_stem` | Tantivy tokenizer for text fields                 |
 

--- a/docs/specifications/model/wiki-toml.md
+++ b/docs/specifications/model/wiki-toml.md
@@ -91,7 +91,7 @@ Commonly overridden per-wiki:
 | `[suggest]`      | `default_limit`, `min_score`                                                 |
 | `[lint]`         | `stale_days`, `stale_confidence_threshold` — replaces global value entirely  |
 | `[ingest]`       | `auto_commit`                                                                |
-| `[graph]`        | `format`, `depth`                                                            |
+| `[graph]`        | `format`, `depth`, `min_nodes_for_communities`, `community_suggestions_limit` |
 | `[redact]`       | `disable` (list of built-in pattern names to skip), `[[redact.patterns]]` (custom patterns) |
 
 `[search.status]` is the only section resolved **key-by-key**: a

--- a/docs/specifications/tools/stats.md
+++ b/docs/specifications/tools/stats.md
@@ -53,7 +53,21 @@ JSON (`--format json`):
   "index": {
     "stale": false,
     "built": "2025-07-21T14:32:01Z"
+  },
+  "communities": {
+    "count": 7,
+    "largest": 34,
+    "smallest": 3,
+    "isolated": ["tangent-thought-xyz", "draft-stub-abc"]
   }
+}
+```
+
+`communities` is `null` when the wiki has fewer pages than `graph.min_nodes_for_communities` (default 30):
+
+```json
+{
+  "communities": null
 }
 ```
 
@@ -70,6 +84,22 @@ JSON (`--format json`):
 | `graph_density` | graph | edges / (nodes * (nodes-1)) |
 | `staleness` | `last_updated` | Fixed buckets: fresh (<7d), stale_7d (7-30d), stale_30d (>30d) |
 | `index` | index status | Stale flag and last build time |
+| `communities` | Louvain (graph) | Cluster stats; `null` when pages < `min_nodes_for_communities` (default 30) |
+
+### communities
+
+Louvain community detection run on the undirected wiki graph. Present only when
+`page_count >= graph.min_nodes_for_communities`.
+
+| Field | Description |
+|-------|-------------|
+| `count` | Number of distinct knowledge clusters found |
+| `largest` | Size of the biggest cluster (node count) |
+| `smallest` | Size of the smallest cluster |
+| `isolated` | Slugs in communities of size ≤ 2 — weakly connected pages; sorted alphabetically |
+
+`isolated` pages are the highest-priority candidates for new links. Run
+`wiki_suggest(slug: "<isolated-slug>")` to find the best connections.
 
 ## MCP Tool Definition
 

--- a/docs/specifications/tools/suggest.md
+++ b/docs/specifications/tools/suggest.md
@@ -25,13 +25,16 @@ frontmatter field to use based on `x-graph-edges` declarations.
 
 ### Strategies
 
-Three strategies are combined:
+Four strategies are combined:
 
 1. **Tag overlap** — pages sharing tags. Score = shared / total.
 2. **Graph neighborhood** — pages within 2 hops not directly linked.
    Score = 1 / hops.
 3. **BM25 similarity** — input page's title + summary as query.
    Score = normalized BM25.
+4. **Community peers** — pages in the same Louvain community not already linked.
+   Score = 0.4, reason = "same knowledge cluster". Suppressed when
+   `node_count < min_nodes_for_communities`.
 
 Results are merged, deduplicated, ranked by max score, filtered by
 `suggest.min_score`, and capped to limit.
@@ -85,6 +88,8 @@ JSON (`--format json`):
 |-----|---------|-------------|
 | `suggest.default_limit` | `5` | Max suggestions returned |
 | `suggest.min_score` | `0.1` | Minimum score threshold |
+| `graph.min_nodes_for_communities` | `30` | Suppress community strategy below this node count |
+| `graph.community_suggestions_limit` | `2` | Max extra results from the community strategy |
 
 Overridable per wiki.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,10 @@ pub struct GraphConfig {
     pub r#type: Vec<String>,
     #[serde(default)]
     pub output: String,
+    #[serde(default = "default_min_nodes_for_communities")]
+    pub min_nodes_for_communities: usize,
+    #[serde(default = "default_community_suggestions_limit")]
+    pub community_suggestions_limit: usize,
 }
 
 impl Default for GraphConfig {
@@ -101,8 +105,18 @@ impl Default for GraphConfig {
             depth: 3,
             r#type: Vec::new(),
             output: String::new(),
+            min_nodes_for_communities: default_min_nodes_for_communities(),
+            community_suggestions_limit: default_community_suggestions_limit(),
         }
     }
+}
+
+fn default_min_nodes_for_communities() -> usize {
+    30
+}
+
+fn default_community_suggestions_limit() -> usize {
+    2
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -272,10 +272,7 @@ pub fn compute_communities(graph: &WikiGraph, min_nodes: usize) -> Option<Commun
 }
 
 /// Returns slug → community id map, or `None` when below threshold.
-pub fn node_community_map(
-    graph: &WikiGraph,
-    min_nodes: usize,
-) -> Option<HashMap<String, usize>> {
+pub fn node_community_map(graph: &WikiGraph, min_nodes: usize) -> Option<HashMap<String, usize>> {
     let local_nodes: Vec<NodeIndex> = {
         let mut v: Vec<NodeIndex> = graph
             .node_indices()

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -91,6 +91,240 @@ pub fn compute_metrics(graph: &WikiGraph) -> GraphMetrics {
     }
 }
 
+// ── Community detection (Louvain) ─────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommunityStats {
+    pub count: usize,
+    pub largest: usize,
+    pub smallest: usize,
+    pub isolated: Vec<String>,
+}
+
+/// Build undirected adjacency by symmetrizing the directed graph. External nodes excluded.
+fn build_adjacency(graph: &WikiGraph) -> HashMap<NodeIndex, HashSet<NodeIndex>> {
+    let mut adj: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::new();
+    for idx in graph.node_indices() {
+        if !graph[idx].external {
+            adj.entry(idx).or_default();
+        }
+    }
+    for edge in graph.edge_indices() {
+        let (a, b) = graph.edge_endpoints(edge).unwrap();
+        if graph[a].external || graph[b].external {
+            continue;
+        }
+        adj.entry(a).or_default().insert(b);
+        adj.entry(b).or_default().insert(a);
+    }
+    adj
+}
+
+/// Louvain phase 1: assign each node to its best neighboring community.
+/// Returns community assignments map (node -> community id) and whether any moves occurred.
+fn louvain_phase1(
+    adj: &HashMap<NodeIndex, HashSet<NodeIndex>>,
+    community: &mut HashMap<NodeIndex, usize>,
+    degrees: &HashMap<NodeIndex, usize>,
+    m: usize,
+) -> bool {
+    if m == 0 {
+        return false;
+    }
+    let m_f = m as f64;
+
+    let mut sorted_nodes: Vec<NodeIndex> = adj.keys().copied().collect();
+    // Sort by slug for determinism — we need the graph ref here; use NodeIndex raw id as proxy
+    // (caller guarantees deterministic ordering via node insertion order from sorted-slug pass)
+    sorted_nodes.sort_by_key(|n| n.index());
+
+    let mut moved = false;
+
+    loop {
+        let mut any_move = false;
+        for &node in &sorted_nodes {
+            let current_c = *community.get(&node).unwrap();
+            let k_i = *degrees.get(&node).unwrap_or(&0) as f64;
+
+            // Gather neighboring communities and k_i_in for each
+            let mut neighbor_c_edges: HashMap<usize, usize> = HashMap::new();
+            for &nb in adj.get(&node).into_iter().flatten() {
+                let nb_c = *community.get(&nb).unwrap();
+                *neighbor_c_edges.entry(nb_c).or_default() += 1;
+            }
+
+            // sigma_tot per community (sum of degrees)
+            let mut sigma_tot: HashMap<usize, f64> = HashMap::new();
+            for (&n2, &c2) in community.iter() {
+                if n2 == node {
+                    continue;
+                }
+                let d = *degrees.get(&n2).unwrap_or(&0) as f64;
+                *sigma_tot.entry(c2).or_default() += d;
+            }
+
+            // Find best community
+            let mut best_c = current_c;
+            let mut best_gain = 0.0_f64;
+
+            for (&c, &k_i_in) in &neighbor_c_edges {
+                if c == current_c {
+                    continue;
+                }
+                let st = *sigma_tot.get(&c).unwrap_or(&0.0);
+                let gain = (k_i_in as f64) / m_f - st * k_i / (2.0 * m_f * m_f);
+                if gain > best_gain {
+                    best_gain = gain;
+                    best_c = c;
+                }
+            }
+
+            if best_c != current_c {
+                community.insert(node, best_c);
+                any_move = true;
+                moved = true;
+            }
+        }
+        if !any_move {
+            break;
+        }
+    }
+    moved
+}
+
+/// Run Louvain on `graph`. Returns `None` when `graph.node_count() < min_nodes`.
+/// Processes non-external nodes only, in sorted-slug order for determinism.
+pub fn compute_communities(graph: &WikiGraph, min_nodes: usize) -> Option<CommunityStats> {
+    // Only count non-external nodes
+    let local_nodes: Vec<NodeIndex> = {
+        let mut v: Vec<NodeIndex> = graph
+            .node_indices()
+            .filter(|&idx| !graph[idx].external)
+            .collect();
+        v.sort_by_key(|&idx| graph[idx].slug.clone());
+        v
+    };
+
+    if local_nodes.len() < min_nodes {
+        return None;
+    }
+
+    let adj = build_adjacency(graph);
+
+    // Degree per node (undirected, local only)
+    let degrees: HashMap<NodeIndex, usize> =
+        local_nodes.iter().map(|&n| (n, adj[&n].len())).collect();
+
+    let m: usize = adj.values().map(|s| s.len()).sum::<usize>() / 2;
+
+    // Initial assignment: each node in its own community
+    let mut community: HashMap<NodeIndex, usize> = local_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, &n)| (n, i))
+        .collect();
+
+    louvain_phase1(&adj, &mut community, &degrees, m);
+
+    // Normalize community ids to contiguous 0..k
+    let mut id_remap: HashMap<usize, usize> = HashMap::new();
+    let mut next_id = 0usize;
+    for &n in &local_nodes {
+        let c = *community.get(&n).unwrap();
+        id_remap.entry(c).or_insert_with(|| {
+            let id = next_id;
+            next_id += 1;
+            id
+        });
+    }
+    for val in community.values_mut() {
+        *val = *id_remap.get(val).unwrap();
+    }
+
+    let count = next_id;
+
+    // Compute sizes
+    let mut sizes: HashMap<usize, usize> = HashMap::new();
+    for &c in community.values() {
+        *sizes.entry(c).or_default() += 1;
+    }
+
+    let largest = sizes.values().copied().max().unwrap_or(0);
+    let smallest = sizes.values().copied().min().unwrap_or(0);
+
+    // Isolated: slugs in communities of size <= 2, sorted
+    let mut isolated: Vec<String> = local_nodes
+        .iter()
+        .filter(|&&n| {
+            let c = *community.get(&n).unwrap();
+            *sizes.get(&c).unwrap_or(&0) <= 2
+        })
+        .map(|&n| graph[n].slug.clone())
+        .collect();
+    isolated.sort();
+
+    Some(CommunityStats {
+        count,
+        largest,
+        smallest,
+        isolated,
+    })
+}
+
+/// Returns slug → community id map, or `None` when below threshold.
+pub fn node_community_map(
+    graph: &WikiGraph,
+    min_nodes: usize,
+) -> Option<HashMap<String, usize>> {
+    let local_nodes: Vec<NodeIndex> = {
+        let mut v: Vec<NodeIndex> = graph
+            .node_indices()
+            .filter(|&idx| !graph[idx].external)
+            .collect();
+        v.sort_by_key(|&idx| graph[idx].slug.clone());
+        v
+    };
+
+    if local_nodes.len() < min_nodes {
+        return None;
+    }
+
+    let adj = build_adjacency(graph);
+    let degrees: HashMap<NodeIndex, usize> =
+        local_nodes.iter().map(|&n| (n, adj[&n].len())).collect();
+    let m: usize = adj.values().map(|s| s.len()).sum::<usize>() / 2;
+
+    let mut community: HashMap<NodeIndex, usize> = local_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, &n)| (n, i))
+        .collect();
+
+    louvain_phase1(&adj, &mut community, &degrees, m);
+
+    // Normalize
+    let mut id_remap: HashMap<usize, usize> = HashMap::new();
+    let mut next_id = 0usize;
+    for &n in &local_nodes {
+        let c = *community.get(&n).unwrap();
+        id_remap.entry(c).or_insert_with(|| {
+            let id = next_id;
+            next_id += 1;
+            id
+        });
+    }
+
+    Some(
+        local_nodes
+            .iter()
+            .map(|&n| {
+                let c = *id_remap.get(community.get(&n).unwrap()).unwrap();
+                (graph[n].slug.clone(), c)
+            })
+            .collect(),
+    )
+}
+
 // ── build_graph ───────────────────────────────────────────────────────────────
 
 /// Build the concept graph from the tantivy index. No file I/O.

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::engine::EngineState;
-use crate::graph::{self, GraphFilter};
+use crate::graph::{self, CommunityStats, GraphFilter};
 use crate::search;
 use tantivy::schema::Value;
 
@@ -33,6 +33,7 @@ pub struct WikiStats {
     pub graph_density: f64,
     pub staleness: StalenessBuckets,
     pub index: IndexHealth,
+    pub communities: Option<CommunityStats>,
 }
 
 pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
@@ -64,6 +65,9 @@ pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
         &space.type_registry,
     )?;
     let metrics = graph::compute_metrics(&wiki_graph);
+    let resolved = space.resolved_config(&engine.config);
+    let communities =
+        graph::compute_communities(&wiki_graph, resolved.graph.min_nodes_for_communities);
 
     // Staleness buckets from last_updated field
     let staleness = compute_staleness(&searcher, &space.index_schema)?;
@@ -86,6 +90,7 @@ pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
         graph_density: (metrics.density * 100.0).round() / 100.0,
         staleness,
         index,
+        communities,
     })
 }
 

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -192,6 +192,42 @@ pub fn suggest(
         }
     }
 
+    // Strategy 4: Community peers (same Louvain community, not already linked)
+    if let Some(community_map) = graph::node_community_map(
+        &wiki_graph,
+        resolved.graph.min_nodes_for_communities,
+    ) && let Some(&my_community) = community_map.get(slug.as_str())
+    {
+        let mut peers: Vec<&str> = community_map
+            .keys()
+            .filter(|s| {
+                let ns: &str = s;
+                community_map.get(ns).copied() == Some(my_community)
+                    && ns != slug.as_str()
+                    && !existing_links.contains(ns)
+                    && !candidates.contains_key(ns)
+            })
+            .map(|s| s.as_str())
+            .collect();
+        peers.sort_unstable();
+        for (added, node_slug) in peers.into_iter().enumerate() {
+            if added >= resolved.graph.community_suggestions_limit {
+                break;
+            }
+            let doc = find_doc_by_slug(&searcher, is, node_slug)?;
+            candidates.insert(
+                node_slug.to_string(),
+                CandidateScore {
+                    slug: node_slug.to_string(),
+                    title: doc.title.clone(),
+                    page_type: doc.page_type.clone(),
+                    score: 0.4,
+                    reason: "same knowledge cluster".to_string(),
+                },
+            );
+        }
+    }
+
     // Rank, filter, cap
     let mut ranked: Vec<CandidateScore> = candidates.into_values().collect();
     ranked.sort_by(|a, b| {

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -193,10 +193,9 @@ pub fn suggest(
     }
 
     // Strategy 4: Community peers (same Louvain community, not already linked)
-    if let Some(community_map) = graph::node_community_map(
-        &wiki_graph,
-        resolved.graph.min_nodes_for_communities,
-    ) && let Some(&my_community) = community_map.get(slug.as_str())
+    if let Some(community_map) =
+        graph::node_community_map(&wiki_graph, resolved.graph.min_nodes_for_communities)
+        && let Some(&my_community) = community_map.get(slug.as_str())
     {
         let mut peers: Vec<&str> = community_map
             .keys()

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -706,9 +706,7 @@ fn add_cluster(
     fs::create_dir_all(wiki_root.join(prefix)).unwrap();
     fs::write(
         wiki_root.join(&hub),
-        &format!(
-            "---\ntitle: \"{prefix} hub\"\ntype: concept\nstatus: active\n---\n\nHub.\n"
-        ),
+        format!("---\ntitle: \"{prefix} hub\"\ntype: concept\nstatus: active\n---\n\nHub.\n"),
     )
     .unwrap();
     for i in 1..size {
@@ -721,7 +719,7 @@ fn add_cluster(
         };
         fs::write(
             wiki_root.join(format!("{slug}.md")),
-            &format!(
+            format!(
                 "---\ntitle: \"{prefix} node {i}\"\ntype: concept\nstatus: active\n---\n\n{link}"
             ),
         )
@@ -842,5 +840,8 @@ fn compute_communities_deterministic() {
     let s2 = compute_communities(&g, 30).unwrap();
 
     assert_eq!(s1.count, s2.count, "count must be deterministic");
-    assert_eq!(s1.isolated, s2.isolated, "isolated list must be deterministic");
+    assert_eq!(
+        s1.isolated, s2.isolated,
+        "isolated list must be deterministic"
+    );
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -692,3 +692,155 @@ fn render_mermaid_external_node_has_class_def() {
         "external node should have :::external class"
     );
 }
+
+// ── compute_communities ───────────────────────────────────────────────────────
+
+/// Build a dense cluster: `size` nodes all linked to node 0.
+fn add_cluster(
+    wiki_root: &Path,
+    prefix: &str,
+    size: usize,
+    hub_links: bool, // if true, all link to the hub; otherwise form a chain
+) {
+    let hub = format!("{prefix}/node-00.md");
+    fs::create_dir_all(wiki_root.join(prefix)).unwrap();
+    fs::write(
+        wiki_root.join(&hub),
+        &format!(
+            "---\ntitle: \"{prefix} hub\"\ntype: concept\nstatus: active\n---\n\nHub.\n"
+        ),
+    )
+    .unwrap();
+    for i in 1..size {
+        let slug = format!("{prefix}/node-{i:02}");
+        let link = if hub_links {
+            format!("See [[{prefix}/node-00]].\n")
+        } else {
+            let prev = i - 1;
+            format!("See [[{prefix}/node-{prev:02}]].\n")
+        };
+        fs::write(
+            wiki_root.join(format!("{slug}.md")),
+            &format!(
+                "---\ntitle: \"{prefix} node {i}\"\ntype: concept\nstatus: active\n---\n\n{link}"
+            ),
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn compute_communities_three_dense_clusters() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    // 3 clusters of 10 nodes each (30 total, all linked to their cluster hub)
+    add_cluster(&wiki_root, "clust-a", 10, true);
+    add_cluster(&wiki_root, "clust-b", 10, true);
+    add_cluster(&wiki_root, "clust-c", 10, true);
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    let stats = compute_communities(&g, 30).expect("should compute at 30 nodes");
+    assert_eq!(stats.count, 3, "should find 3 communities");
+    assert!(stats.isolated.is_empty(), "no isolated nodes expected");
+}
+
+#[test]
+fn compute_communities_below_threshold_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    // 29 nodes (below default threshold of 30)
+    add_cluster(&wiki_root, "clust-a", 10, true);
+    add_cluster(&wiki_root, "clust-b", 10, true);
+    add_cluster(&wiki_root, "clust-c", 9, true);
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    assert!(
+        compute_communities(&g, 30).is_none(),
+        "should be None below threshold"
+    );
+}
+
+#[test]
+fn compute_communities_isolated_pair_appears_in_isolated_list() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    // One big cluster of 30 nodes + 2 nodes only linked to each other
+    add_cluster(&wiki_root, "main", 30, true);
+    fs::create_dir_all(wiki_root.join("orphans")).unwrap();
+    fs::write(
+        wiki_root.join("orphans/alpha.md"),
+        "---\ntitle: \"Alpha\"\ntype: concept\nstatus: active\n---\n\nSee [[orphans/beta]].\n",
+    )
+    .unwrap();
+    fs::write(
+        wiki_root.join("orphans/beta.md"),
+        "---\ntitle: \"Beta\"\ntype: concept\nstatus: active\n---\n\nSee [[orphans/alpha]].\n",
+    )
+    .unwrap();
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    let stats = compute_communities(&g, 30).expect("should compute at ≥ 30 nodes");
+    assert!(
+        stats.isolated.contains(&"orphans/alpha".to_string()),
+        "orphans/alpha should be isolated"
+    );
+    assert!(
+        stats.isolated.contains(&"orphans/beta".to_string()),
+        "orphans/beta should be isolated"
+    );
+}
+
+#[test]
+fn compute_communities_deterministic() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    add_cluster(&wiki_root, "clust-a", 15, true);
+    add_cluster(&wiki_root, "clust-b", 15, true);
+
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let g = build_graph(
+        &mgr.searcher().unwrap(),
+        &is,
+        &default_filter(),
+        &registry(),
+    )
+    .unwrap();
+
+    let s1 = compute_communities(&g, 30).unwrap();
+    let s2 = compute_communities(&g, 30).unwrap();
+
+    assert_eq!(s1.count, s2.count, "count must be deterministic");
+    assert_eq!(s1.isolated, s2.isolated, "isolated list must be deterministic");
+}


### PR DESCRIPTION
Louvain clustering on petgraph DiGraph; communities in wiki_stats; strategy 4 in wiki_suggest; spec docs + graph guide. No new dependencies. Closes #22 imp-08.

## Changes

- `src/config.rs`: Added `min_nodes_for_communities` (default 30) and `community_suggestions_limit` (default 2) to `GraphConfig`
- `src/graph.rs`: `CommunityStats` struct, `build_adjacency`, Louvain phase 1 (sorted-slug order for determinism), `compute_communities`, `node_community_map`
- `src/ops/stats.rs`: `communities: Option<CommunityStats>` field in `WikiStats`
- `src/ops/suggest.rs`: Strategy 4 — community peers, score 0.4, reason "same knowledge cluster"
- `tests/graph.rs`: 4 new tests (3-cluster detection, below-threshold None, isolated pair, determinism)
- Spec docs: stats.md, suggest.md, global-config.md, wiki-toml.md
- New guide: docs/guides/graph.md + README.md row