### PR TITLE
fix/testing: MCP validation suite, stats hang fix, integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,63 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: "Which suite to run"
+        required: false
+        default: "both"
+        type: choice
+        options: [both, engine, mcp]
+
+env:
+  CARGO_TERM_COLOR: always
+  LLM_WIKI_TEST_DIR: /tmp/llm-wiki-testing
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.95"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Install mcptools
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' }}
+        run: |
+          LATEST=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+            https://github.com/f/mcptools/releases/latest \
+            | grep -oE '[^/]+$' | sed 's/^v//')
+          curl -fsSL \
+            "https://github.com/f/mcptools/releases/download/v${LATEST}/mcp_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin mcp
+          mcp --version
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Setup test environment
+        run: |
+          LLM_WIKI_BIN=./target/debug/llm-wiki \
+          bash ./docs/testing/scripts/setup-test-env.sh --dir "$LLM_WIKI_TEST_DIR"
+
+      - name: Run engine validation
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'engine' }}
+        run: |
+          LLM_WIKI_BIN=./target/debug/llm-wiki \
+          LLM_WIKI_CONFIG="$LLM_WIKI_TEST_DIR/config.toml" \
+          bash ./docs/testing/scripts/validate-engine.sh
+
+      - name: Run MCP validation
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' }}
+        run: |
+          LLM_WIKI_BIN=./target/debug/llm-wiki \
+          LLM_WIKI_CONFIG="$LLM_WIKI_TEST_DIR/config.toml" \
+          bash ./docs/testing/scripts/validate-mcp.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--config <path>` global flag to override the config file path
 - `LLM_WIKI_CONFIG` environment variable as a fallback config path override
+- **MCP validation suite** — `docs/testing/scripts/validate-mcp.sh`; end-to-end MCP coverage via mcptools stdio transport (52 tests across 11 sections mirroring the CLI suite); `lib/mcp-helpers.sh` with `run_mcp` / `run_mcp_json` helpers
 
 ### Fixed
 - `llm-wiki stats` and any command using community detection hung indefinitely — `louvain_phase1` could oscillate forever when node moves mid-pass altered `sigma_tot` for subsequent nodes; capped at `n × 10` passes
 - `SpaceIndexManager::status()` now uses `ReloadPolicy::Manual` to avoid spawning a competing file_watcher thread against the open `IndexReader`
+- `wiki_graph` MCP tool now returns the rendered graph text (mermaid/dot/llms) instead of a bare stats report
+- `validate-engine.sh` and `validate-mcp.sh` reset inbox fixtures and clear logs before each run for idempotent sequential execution
 
 ## [0.2.0] — Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-- `--config <path>` global flag to override the config file path
-- `LLM_WIKI_CONFIG` environment variable as a fallback config path override
-- **MCP validation suite** — `docs/testing/scripts/validate-mcp.sh`; end-to-end MCP coverage via mcptools stdio transport (52 tests across 11 sections mirroring the CLI suite); `lib/mcp-helpers.sh` with `run_mcp` / `run_mcp_json` helpers
-
-### Fixed
-- `llm-wiki stats` and any command using community detection hung indefinitely — `louvain_phase1` could oscillate forever when node moves mid-pass altered `sigma_tot` for subsequent nodes; capped at `n × 10` passes
-- `SpaceIndexManager::status()` now uses `ReloadPolicy::Manual` to avoid spawning a competing file_watcher thread against the open `IndexReader`
-- `wiki_graph` MCP tool now returns the rendered graph text (mermaid/dot/llms) instead of a bare stats report
-- `validate-engine.sh` and `validate-mcp.sh` reset inbox fixtures and clear logs before each run for idempotent sequential execution
-
 ## [0.2.0] — Unreleased
 
 ### Added
@@ -44,6 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Integration test fixtures** — `tests/fixtures/` with two wiki spaces (`research`, `notes`), 8 pre-built pages, and 5 inbox source documents covering paper, article, note, data, redaction, cross-wiki, and contradiction scenarios
 - **Engine validation script** — `docs/testing/scripts/validate-engine.sh`; end-to-end CLI coverage of all 19+ tools including every v0.2.0 feature; pass/fail/skip report
 - **Skills validation guide** — `docs/testing/validate-skills.md`; 12 interactive scenarios for validating the Claude plugin against the test fixtures
+- **MCP validation suite** — `docs/testing/scripts/validate-mcp.sh`; end-to-end MCP coverage via mcptools stdio transport (52 tests across 11 sections mirroring the CLI suite); `lib/mcp-helpers.sh` with `run_mcp` / `run_mcp_json` helpers
+- `--config <path>` global flag to override the config file path
+- `LLM_WIKI_CONFIG` environment variable as a fallback config path override
+
+### Fixed
+
+- `llm-wiki stats` and any command using community detection hung indefinitely — `louvain_phase1` could oscillate forever when node moves mid-pass altered `sigma_tot` for subsequent nodes; capped at `n × 10` passes
+- `SpaceIndexManager::status()` now uses `ReloadPolicy::Manual` to avoid spawning a competing file_watcher thread against the open `IndexReader`
+- `wiki_graph` MCP tool now returns the rendered graph text (mermaid/dot/llms) instead of a bare stats report
+- `validate-engine.sh` and `validate-mcp.sh` reset inbox fixtures and clear logs before each run for idempotent sequential execution
 
 ## [0.1.1] — 2026-04-26
 

--- a/docs/guides/ci-cd.md
+++ b/docs/guides/ci-cd.md
@@ -159,6 +159,25 @@ Generate a concept graph as a build artifact or commit it to the repo:
           llm-wiki graph --format dot --output wiki/graph.dot --wiki ci
 ```
 
+## Integration Test Workflow
+
+A manual workflow at `.github/workflows/integration.yml` runs the full
+end-to-end validation suite (CLI + MCP) against a real binary. Trigger it
+from the Actions tab → **Integration Tests** → **Run workflow**.
+
+```
+suite: both | engine | mcp   (default: both)
+```
+
+The workflow:
+1. Builds the debug binary (`cargo build --locked`)
+2. Installs `mcptools` (latest release, Linux amd64) when MCP suite is selected
+3. Runs `setup-test-env.sh` to create a fresh environment at `/tmp/llm-wiki-testing`
+4. Runs `validate-engine.sh` and/or `validate-mcp.sh`
+
+Use this after merging features that touch MCP handlers, graph rendering, or
+ingest logic — areas not covered by unit tests alone.
+
 ## Environment Notes
 
 - llm-wiki writes its space registry to `~/.llm-wiki/config.toml` by default

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -51,6 +51,7 @@ active `release/` branch if one is open.
 - [ ] Formatted: `cargo fmt -- --check`
 - [ ] No lint issues: `cargo clippy --all-targets -- -D warnings`
 - [ ] No vulnerabilities: `cargo audit`
+- [ ] Integration tests green: trigger **Integration Tests** workflow (`suite: both`) on the release branch
 
 ### Documentation pass
 - [ ] All improvement spec files have `status: implemented` and tasks checked

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -67,6 +67,10 @@ source ./docs/testing/scripts/clean-test-env.sh
 
 ## Quick start — MCP server
 
+The MCP suite uses **stdio transport** via `mcptools` — no server process to
+start or stop. Each `mcp call` launches the binary as a subprocess, performs
+the MCP handshake, and exits.
+
 ```bash
 # 1. Build the binary (if not already done)
 cargo build --release
@@ -74,23 +78,26 @@ cargo build --release
 # 2. Create the test environment and export env vars (if not already done)
 source ./docs/testing/scripts/setup-test-env.sh
 
-# 3. Run all MCP validations (starts server on port 8087, tears down after)
+# 3. Run all MCP validations
 LLM_WIKI_BIN=./target/release/llm-wiki \
 ./docs/testing/scripts/validate-mcp.sh
 
 # 4. Run a single section (e.g. search only)
 LLM_WIKI_BIN=./target/release/llm-wiki \
 ./docs/testing/scripts/validate-mcp.sh --section 03
-
-# 5. Use a different port
-LLM_WIKI_BIN=./target/release/llm-wiki \
-./docs/testing/scripts/validate-mcp.sh --port 9090
 ```
 
 `source` is required for `setup-test-env.sh` and `clean-test-env.sh` so
 that `LLM_WIKI_TEST_DIR` and `LLM_WIKI_CONFIG` are exported/unset in
 your current shell. Running them directly also works but won't affect the
 parent shell's environment.
+
+## GitHub Actions
+
+A `workflow_dispatch` workflow is available at
+`.github/workflows/integration.yml`. Trigger it manually from the Actions
+tab with a choice of suite (`both` / `engine` / `mcp`). It builds the binary,
+installs mcptools, sets up the test environment, and runs the selected suite.
 
 ## Skills validation
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,6 +1,35 @@
 # Testing
 
-End-to-end validation for the llm-wiki CLI and Claude plugin.
+End-to-end validation for the llm-wiki CLI, MCP server, and Claude plugin.
+
+## Prerequisites
+
+### CLI validation
+
+| Tool | Install |
+|------|---------|
+| `jq` | `brew install jq` · `apt install jq` |
+| `git` | system |
+
+### MCP validation
+
+The MCP validation scripts require **mcptools** — a Go CLI for calling MCP servers.
+It handles the session protocol (initialize handshake, streamable HTTP) so the
+scripts only need to call tools by name.
+
+```bash
+# macOS — Homebrew (recommended)
+brew tap f/mcptools && brew install mcp
+
+# Any platform — direct binary download
+# https://github.com/f/mcptools/releases
+# Download the archive for your platform, extract, place `mcp` on PATH
+
+# Verify
+mcp --version
+```
+
+> `mcptools` is a single Go binary. No Node.js, no Python required.
 
 ## Scripts
 
@@ -8,11 +37,14 @@ End-to-end validation for the llm-wiki CLI and Claude plugin.
 |--------|---------|
 | `scripts/setup-test-env.sh` | Create the persistent test environment and export env vars |
 | `scripts/clean-test-env.sh` | Remove the test environment and unset env vars |
-| `scripts/validate-engine.sh` | Orchestrate all validation sections |
-| `scripts/sections/NN-*.sh` | One validation section per file (sourced by the orchestrator) |
+| `scripts/validate-engine.sh` | CLI validation — all sections |
+| `scripts/validate-mcp.sh` | MCP HTTP server validation — all sections |
+| `scripts/sections/NN-*.sh` | CLI section scripts (sourced by validate-engine.sh) |
+| `scripts/mcp/NN-*.sh` | MCP section scripts (sourced by validate-mcp.sh) |
 | `scripts/lib/helpers.sh` | Shared `pass`/`fail`/`run`/`run_json` helpers |
+| `scripts/lib/mcp-helpers.sh` | MCP-specific `run_mcp`/`run_mcp_json` helpers |
 
-## Quick start
+## Quick start — CLI
 
 ```bash
 # 1. Build the binary
@@ -21,18 +53,38 @@ cargo build --release
 # 2. Create the test environment and export env vars
 source ./docs/testing/scripts/setup-test-env.sh
 
-# 3. Run all validations
+# 3. Run all CLI validations
 LLM_WIKI_BIN=./target/release/llm-wiki \
 ./docs/testing/scripts/validate-engine.sh
 
-# 4. Inspect results in ~/llm-wiki-testing/ (see layout below)
-
-# 5. Run a single section (e.g. ingest only)
+# 4. Run a single section (e.g. ingest only)
 LLM_WIKI_BIN=./target/release/llm-wiki \
 ./docs/testing/scripts/validate-engine.sh --section 05
 
-# 6. Clean up when done
+# 5. Clean up when done
 source ./docs/testing/scripts/clean-test-env.sh
+```
+
+## Quick start — MCP server
+
+```bash
+# 1. Build the binary (if not already done)
+cargo build --release
+
+# 2. Create the test environment and export env vars (if not already done)
+source ./docs/testing/scripts/setup-test-env.sh
+
+# 3. Run all MCP validations (starts server on port 8087, tears down after)
+LLM_WIKI_BIN=./target/release/llm-wiki \
+./docs/testing/scripts/validate-mcp.sh
+
+# 4. Run a single section (e.g. search only)
+LLM_WIKI_BIN=./target/release/llm-wiki \
+./docs/testing/scripts/validate-mcp.sh --section 03
+
+# 5. Use a different port
+LLM_WIKI_BIN=./target/release/llm-wiki \
+./docs/testing/scripts/validate-mcp.sh --port 9090
 ```
 
 `source` is required for `setup-test-env.sh` and `clean-test-env.sh` so

--- a/docs/testing/scripts/lib/mcp-helpers.sh
+++ b/docs/testing/scripts/lib/mcp-helpers.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# mcp-helpers.sh — shared helpers for MCP validation scripts
+# Do not execute directly. Source after helpers.sh.
+#
+# Requires: MCP_SERVER (array) — the command to launch the MCP server via stdio.
+# Set by validate-mcp.sh:
+#   MCP_SERVER=("$CLI" --config "$CONFIG" serve)
+#
+# mcptools (mcp) handles the stdio session internally — one subprocess per call.
+# Response shape: {"content":[{"text":"...","type":"text"}]}
+
+# Extract the text field from an mcptools JSON response.
+_mcp_text() {
+    echo "$1" | jq -r '.content[0].text // empty' 2>/dev/null
+}
+
+# run_mcp <desc> <pattern> <tool> [params_json]
+# Calls tool via mcptools stdio, checks text content matches pattern (grep -q).
+run_mcp() {
+    local desc="$1" pattern="$2" tool="$3" params="${4:-EMPTY}"
+    [ "$params" = "EMPTY" ] && params="{}"
+    local raw text
+    if raw=$(mcp call "$tool" -p "$params" -f json "${MCP_SERVER[@]}" 2>&1); then
+        text=$(_mcp_text "$raw")
+        if [ -z "$pattern" ] || echo "$text" | grep -q "$pattern"; then
+            pass "$desc"
+        else
+            fail "$desc" "output did not match: $pattern"
+            echo "    output: $(echo "$text" | head -3)"
+        fi
+    else
+        fail "$desc" "mcp call failed"
+        echo "    output: $(echo "$raw" | head -3)"
+    fi
+}
+
+# run_mcp_json <desc> <jq_filter> <expected> <tool> [params_json]
+# Calls tool, parses text content as JSON, applies jq filter, checks result.
+run_mcp_json() {
+    local desc="$1" filter="$2" expected="$3" tool="$4" params="${5:-EMPTY}"
+    [ "$params" = "EMPTY" ] && params="{}"
+    local raw text actual
+    if raw=$(mcp call "$tool" -p "$params" -f json "${MCP_SERVER[@]}" 2>&1); then
+        text=$(_mcp_text "$raw")
+        actual=$(echo "$text" | jq -r "$filter" 2>/dev/null || echo "jq-error")
+        if [ "$actual" = "$expected" ]; then
+            pass "$desc"
+        else
+            fail "$desc" "expected '$expected', got '$actual'"
+            echo "    text: $(echo "$text" | head -3)"
+        fi
+    else
+        fail "$desc" "mcp call failed"
+        echo "    output: $(echo "$raw" | head -3)"
+    fi
+}

--- a/docs/testing/scripts/mcp/01-spaces.sh
+++ b/docs/testing/scripts/mcp/01-spaces.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+section "1. Spaces (MCP)"
+
+run_mcp      "spaces_list returns wikis"              "research" \
+             wiki_spaces_list
+
+run_mcp_json "spaces_list contains research entry"   \
+             '[.[] | select(.name=="research")] | length > 0' "true" \
+             wiki_spaces_list
+
+run_mcp      "spaces_set_default research"            "research" \
+             wiki_spaces_set_default '{"name":"research"}'

--- a/docs/testing/scripts/mcp/02-index.sh
+++ b/docs/testing/scripts/mcp/02-index.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+section "2. Index (MCP)"
+
+run_mcp_json "index_rebuild returns pages_indexed"   \
+             '.pages_indexed > 0' "true" \
+             wiki_index_rebuild '{"wiki":"research"}'
+
+run_mcp_json "index_status has built timestamp"      \
+             '.built | type' "string" \
+             wiki_index_status '{"wiki":"research"}'
+
+run_mcp_json "index_status queryable true"           \
+             '.queryable' "true" \
+             wiki_index_status '{"wiki":"research"}'

--- a/docs/testing/scripts/mcp/03-search.sh
+++ b/docs/testing/scripts/mcp/03-search.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+section "3. Search & List (MCP)"
+
+run_mcp      "search returns results"                "mixture-of-experts" \
+             wiki_search '{"query":"mixture of experts"}'
+
+run_mcp_json "search json results array not empty"  \
+             '.results | length > 0' "true" \
+             wiki_search '{"query":"mixture of experts","format":"json"}'
+
+run_mcp      "search with type filter"              "concept" \
+             wiki_search '{"query":"attention","type":"concept"}'
+
+run_mcp      "search llms format"                   "wiki://" \
+             wiki_search '{"query":"transformer","format":"llms"}'
+
+run_mcp_json "list json total > 0"                  \
+             '.total > 0' "true" \
+             wiki_list '{"format":"json"}'
+
+run_mcp_json "list json pages array"                \
+             '.pages | type' "array" \
+             wiki_list '{"format":"json"}'
+
+run_mcp      "list with type filter returns concept" "concept" \
+             wiki_list '{"type":"concept"}'
+
+run_mcp_json "list type filter json all concepts"   \
+             '.pages | map(select(.type != "concept")) | length == 0' "true" \
+             wiki_list '{"type":"concept","format":"json"}'

--- a/docs/testing/scripts/mcp/04-content.sh
+++ b/docs/testing/scripts/mcp/04-content.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+section "4. Content (MCP)"
+
+run_mcp      "content_read returns page body"        "Mixture of Experts" \
+             wiki_content_read '{"uri":"concepts/mixture-of-experts"}'
+
+run_mcp      "content_read includes frontmatter"     "type:" \
+             wiki_content_read '{"uri":"concepts/mixture-of-experts"}'
+
+run_mcp      "content_read with backlinks"           "backlinks" \
+             wiki_content_read '{"uri":"concepts/mixture-of-experts","backlinks":true}'
+
+run_mcp      "content_read via wiki:// URI"          "Mixture of Experts" \
+             wiki_content_read '{"uri":"wiki://research/concepts/mixture-of-experts"}'
+
+# content_write and content_new mutate the wiki — skip to preserve test state
+skip "content_write" "mutates wiki state"
+skip "content_new"   "mutates wiki state"
+skip "content_commit" "mutates wiki state"

--- a/docs/testing/scripts/mcp/05-ingest.sh
+++ b/docs/testing/scripts/mcp/05-ingest.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+section "5. Ingest (MCP)"
+
+run_mcp_json "ingest dry run pages_validated >= 0"   \
+             '.pages_validated >= 0' "true" \
+             wiki_ingest '{"path":"inbox/01-paper-switch-transformer.md","dry_run":true}'
+
+run_mcp_json "ingest dry run has warnings array"     \
+             '.warnings | type' "array" \
+             wiki_ingest '{"path":"inbox/01-paper-switch-transformer.md","dry_run":true}'
+
+run_mcp_json "ingest dry run unchanged_count >= 0"   \
+             '.unchanged_count >= 0' "true" \
+             wiki_ingest '{"path":"inbox/01-paper-switch-transformer.md","dry_run":true}'
+
+run_mcp_json "ingest with redact dry run succeeds"   \
+             '.pages_validated >= 0' "true" \
+             wiki_ingest '{"path":"inbox/03-note-with-secrets.md","dry_run":true,"redact":true}'

--- a/docs/testing/scripts/mcp/06-lint.sh
+++ b/docs/testing/scripts/mcp/06-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+section "6. Lint (MCP)"
+
+run_mcp      "lint returns findings"                 "error\|warning" \
+             wiki_lint
+
+run_mcp      "lint broken-link rule"                 "broken-link" \
+             wiki_lint '{"rules":["broken-link"]}'
+
+run_mcp      "lint orphan rule"                      "orphan" \
+             wiki_lint '{"rules":["orphan"]}'
+
+run_mcp_json "lint json findings array"              \
+             '.findings | type' "array" \
+             wiki_lint '{"format":"json"}'
+
+run_mcp_json "lint broken-link finds does-not-exist" \
+             '[.findings[] | select(.rule=="broken-link")] | length > 0' "true" \
+             wiki_lint '{"rules":["broken-link"],"format":"json"}'
+
+run_mcp_json "lint orphan finds orphan-concept"      \
+             '[.findings[] | select(.slug=="concepts/orphan-concept")] | length > 0' "true" \
+             wiki_lint '{"rules":["orphan"],"format":"json"}'
+
+run_mcp      "lint with wiki param"                  "error\|warning" \
+             wiki_lint '{"wiki":"research"}'

--- a/docs/testing/scripts/mcp/07-graph.sh
+++ b/docs/testing/scripts/mcp/07-graph.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+section "7. Graph (MCP)"
+
+run_mcp      "graph mermaid output"                  "graph LR\|graph TD\|flowchart" \
+             wiki_graph
+
+run_mcp      "graph dot output"                      "digraph" \
+             wiki_graph '{"format":"dot"}'
+
+run_mcp      "graph llms output"                     "nodes\|edges\|type groups" \
+             wiki_graph '{"format":"llms"}'
+
+run_mcp      "graph type filter"                     "" \
+             wiki_graph '{"type":"concept"}'
+
+run_mcp      "graph root and depth"                  "" \
+             wiki_graph '{"root":"concepts/mixture-of-experts","depth":2}'
+
+run_mcp      "graph cross-wiki includes notes wiki"  "" \
+             wiki_graph '{"cross_wiki":true}'

--- a/docs/testing/scripts/mcp/08-stats.sh
+++ b/docs/testing/scripts/mcp/08-stats.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+section "8. Stats (MCP)"
+
+run_mcp      "stats returns wiki name"               "research" \
+             wiki_stats
+
+run_mcp_json "stats json pages > 0"                  \
+             '.pages > 0' "true" \
+             wiki_stats '{"format":"json"}'
+
+run_mcp_json "stats json orphans >= 0"               \
+             '.orphans >= 0' "true" \
+             wiki_stats '{"format":"json"}'
+
+run_mcp_json "stats communities present (threshold=5)" \
+             '.communities != null' "true" \
+             wiki_stats '{"format":"json"}'

--- a/docs/testing/scripts/mcp/09-suggest.sh
+++ b/docs/testing/scripts/mcp/09-suggest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+section "9. Suggest (MCP)"
+
+run_mcp      "suggest returns results"               "" \
+             wiki_suggest '{"slug":"concepts/mixture-of-experts"}'
+
+run_mcp_json "suggest json is array"                 \
+             'type' "array" \
+             wiki_suggest '{"slug":"concepts/mixture-of-experts","format":"json"}'
+
+run_mcp_json "suggest results have slug field"       \
+             '.[0].slug | type' "string" \
+             wiki_suggest '{"slug":"concepts/mixture-of-experts","format":"json"}'
+
+run_mcp_json "suggest community peers (length >= 0)" \
+             '[.[] | select(.reason | test("cluster"))] | length >= 0' "true" \
+             wiki_suggest '{"slug":"concepts/mixture-of-experts","format":"json"}'

--- a/docs/testing/scripts/mcp/10-export.sh
+++ b/docs/testing/scripts/mcp/10-export.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+section "10. Export (MCP)"
+
+run_mcp_json "export llms-txt pages_written > 0"    \
+             '.pages_written > 0' "true" \
+             wiki_export '{"path":"mcp-export-test.txt","format":"llms-txt","wiki":"research"}'
+
+run_mcp_json "export llms-full pages_written > 0"   \
+             '.pages_written > 0' "true" \
+             wiki_export '{"path":"mcp-export-full.txt","format":"llms-full","wiki":"research"}'
+
+run_mcp_json "export json has path string"           \
+             '.path | type' "string" \
+             wiki_export '{"path":"mcp-export.json","format":"json","wiki":"research"}'
+
+run_mcp_json "export json bytes > 0"                 \
+             '.bytes > 0' "true" \
+             wiki_export '{"path":"mcp-export.json","format":"json","wiki":"research"}'

--- a/docs/testing/scripts/mcp/11-schema.sh
+++ b/docs/testing/scripts/mcp/11-schema.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+section "11. Schema & History (MCP)"
+
+run_mcp_json "schema list returns array"             \
+             'type' "array" \
+             wiki_schema '{"action":"list","wiki":"research"}'
+
+run_mcp_json "schema list contains concept type"     \
+             '[.[] | select(.name=="concept")] | length > 0' "true" \
+             wiki_schema '{"action":"list","wiki":"research"}'
+
+run_mcp      "schema show concept type"              "title\|summary\|confidence" \
+             wiki_schema '{"action":"show","type":"concept","wiki":"research"}'
+
+run_mcp_json "history json entries array"            \
+             '.entries | type' "array" \
+             wiki_history '{"slug":"concepts/mixture-of-experts","wiki":"research","format":"json"}'
+
+run_mcp_json "history has at least one commit"       \
+             '.entries | length > 0' "true" \
+             wiki_history '{"slug":"concepts/mixture-of-experts","wiki":"research","format":"json"}'

--- a/docs/testing/scripts/setup-test-env.sh
+++ b/docs/testing/scripts/setup-test-env.sh
@@ -39,13 +39,21 @@ done
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-green() { printf '\033[32m%s\033[0m\n' "$*"; }
-red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
 
 if ! command -v "$BINARY" &>/dev/null && [ ! -x "$BINARY" ]; then
     red "ERROR: '$BINARY' not found."
     echo "Build with 'cargo build --release' and set LLM_WIKI_BIN or add to PATH."
     return 1 2>/dev/null || exit 1
+fi
+
+if ! command -v mcp &>/dev/null; then
+    yellow "WARNING: 'mcp' (mcptools) not found — MCP server validation will not work."
+    echo "Install with:"
+    echo "  brew tap f/mcptools && brew install mcp"
+    echo "  or download from https://github.com/f/mcptools/releases"
 fi
 
 # ── Main ─────────────────────────────────────────────────────────────────────

--- a/docs/testing/scripts/validate-engine.sh
+++ b/docs/testing/scripts/validate-engine.sh
@@ -64,8 +64,9 @@ echo "llm-wiki validate-engine.sh"
 echo "binary:   $($BINARY --version 2>/dev/null || echo unknown)"
 echo "test dir: $TEST_DIR"
 
-# Re-copy inbox fixtures so each run starts with a clean inbox
+# Re-copy inbox fixtures and clear logs so each run starts from a clean state
 \cp -f "$FIXTURES"/inbox/* "$RESEARCH_ROOT/wiki/inbox/"
+rm -f "$TEST_DIR/logs"/*.log 2>/dev/null || true
 
 CLI="$BINARY --config $CONFIG_FILE"
 

--- a/docs/testing/scripts/validate-mcp.sh
+++ b/docs/testing/scripts/validate-mcp.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# validate-mcp.sh — end-to-end MCP validation for llm-wiki via mcptools stdio
+#
+# Usage:
+#   LLM_WIKI_BIN=./target/release/llm-wiki \
+#   ./docs/testing/scripts/validate-mcp.sh [--section NN]
+#
+# Requires:
+#   mcp (mcptools)     — brew tap f/mcptools && brew install mcp
+#   LLM_WIKI_TEST_DIR  — path to test dir (default: ~/llm-wiki-testing)
+#   LLM_WIKI_CONFIG    — path to config.toml (default: $LLM_WIKI_TEST_DIR/config.toml)
+#   LLM_WIKI_BIN       — path to llm-wiki binary (default: llm-wiki)
+#
+# Setup first:
+#   source ./docs/testing/scripts/setup-test-env.sh
+
+set -uo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_FIXTURES="$(cd "$_SCRIPT_DIR/../../.." && pwd)/tests/fixtures"
+
+# ── Load helpers ──────────────────────────────────────────────────────────────
+
+source "$_SCRIPT_DIR/lib/helpers.sh"
+source "$_SCRIPT_DIR/lib/mcp-helpers.sh"
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+CLI="${LLM_WIKI_BIN:-llm-wiki}"
+TEST_DIR="${LLM_WIKI_TEST_DIR:-$HOME/llm-wiki-testing}"
+CONFIG="${LLM_WIKI_CONFIG:-$TEST_DIR/config.toml}"
+RESEARCH_ROOT="$TEST_DIR/wikis/research"
+SECTION_FILTER=""
+
+# MCP_SERVER is passed to every `mcp call` invocation as the stdio server command
+MCP_SERVER=("$CLI" --config "$CONFIG" serve)
+export MCP_SERVER
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --section) SECTION_FILTER="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+
+echo "llm-wiki validate-mcp.sh"
+echo "binary:   $("$CLI" --version 2>/dev/null || echo unknown)"
+echo "test dir: $TEST_DIR"
+echo
+
+if ! command -v mcp &>/dev/null; then
+    red "ERROR: 'mcp' (mcptools) not found — cannot run MCP validation."
+    echo "Install with:"
+    echo "  brew tap f/mcptools && brew install mcp"
+    echo "  or download from https://github.com/f/mcptools/releases"
+    exit 1
+fi
+
+if [ ! -f "$CONFIG" ]; then
+    red "ERROR: config not found at $CONFIG"
+    echo "Run: source ./docs/testing/scripts/setup-test-env.sh"
+    exit 1
+fi
+
+# Reset inbox fixtures and clear logs for a clean idempotent run
+\cp -f "$_FIXTURES"/inbox/* "$RESEARCH_ROOT/wiki/inbox/" 2>/dev/null || true
+rm -f "$TEST_DIR/logs"/*.log 2>/dev/null || true
+
+# Rebuild index so all sections start from a known clean state
+"$CLI" --config "$CONFIG" index rebuild --wiki research > /dev/null 2>&1
+"$CLI" --config "$CONFIG" index rebuild --wiki notes    > /dev/null 2>&1
+
+# ── Counters ──────────────────────────────────────────────────────────────────
+
+PASS=0; FAIL=0; SKIP=0
+export PASS FAIL SKIP
+
+# ── Run sections ──────────────────────────────────────────────────────────────
+
+run_section() {
+    local num="$1" file="$2"
+    if [ -n "$SECTION_FILTER" ] && [ "$SECTION_FILTER" != "$num" ]; then
+        return
+    fi
+    # shellcheck disable=SC1090
+    source "$file"
+}
+
+run_section "01" "$_SCRIPT_DIR/mcp/01-spaces.sh"
+run_section "02" "$_SCRIPT_DIR/mcp/02-index.sh"
+run_section "03" "$_SCRIPT_DIR/mcp/03-search.sh"
+run_section "04" "$_SCRIPT_DIR/mcp/04-content.sh"
+run_section "05" "$_SCRIPT_DIR/mcp/05-ingest.sh"
+run_section "06" "$_SCRIPT_DIR/mcp/06-lint.sh"
+run_section "07" "$_SCRIPT_DIR/mcp/07-graph.sh"
+run_section "08" "$_SCRIPT_DIR/mcp/08-stats.sh"
+run_section "09" "$_SCRIPT_DIR/mcp/09-suggest.sh"
+run_section "10" "$_SCRIPT_DIR/mcp/10-export.sh"
+run_section "11" "$_SCRIPT_DIR/mcp/11-schema.sh"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo
+echo "────────────────────────────────────────"
+printf "Results: "
+printf '\033[32m%s\033[0m' "$PASS passed"
+printf " | "
+[ "$FAIL" -gt 0 ] && printf '\033[31m%s\033[0m' "$FAIL failed" || printf "%s failed" "$FAIL"
+printf " | "
+printf '\033[33m%s\033[0m' "$SKIP skipped"
+echo
+echo "────────────────────────────────────────"
+
+[ "$FAIL" -eq 0 ]

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -333,8 +333,7 @@ pub fn handle_graph(server: &McpServer, args: &Map<String, Value>) -> ToolHandle
     )
     .map_err(|e| format!("{e}"))?;
 
-    let s = serde_json::to_string_pretty(&result.report).map_err(|e| format!("{e}"))?;
-    ok_text(s)
+    ok_text(result.rendered)
 }
 
 // ── History ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Fix `llm-wiki stats` hang** — `louvain_phase1` oscillated infinitely on small graphs; capped at `n × 10` passes. Also fixes `ReloadPolicy::Manual` in `status()` to prevent competing file_watcher threads.
- **Fix `wiki_graph` MCP tool** — was returning a bare stats report (`{nodes, edges}`); now returns the rendered graph text (mermaid/dot/llms).
- **Fix section 16 validation** — ingest `--format json` log lines corrupted JSON output captured via `2>&1`; wrapped in `bash -c "... 2>/dev/null"`.
- **MCP validation suite** — `validate-mcp.sh` with 52 tests across 11 sections, stdio transport via `mcptools`, `lib/mcp-helpers.sh` helpers.
- **Idempotent validation runs** — both `validate-engine.sh` and `validate-mcp.sh` reset inbox fixtures and clear logs before running.
- **Integration test workflow** — `.github/workflows/integration.yml`, `workflow_dispatch` with `suite: both|engine|mcp`.
- **Docs** — testing README, ci-cd guide, release checklist updated.

## Test plan

- [x] `cargo test` passes
- [x] `cargo fmt --check` / `cargo clippy` clean
- [x] `validate-engine.sh` — all sections green
- [x] `validate-mcp.sh` — 52 passed, 0 failed, 3 skipped
- [x] Trigger **Integration Tests** workflow on this branch (`suite: both`)