### PR TITLE
fix: reload IndexReader after writer.commit() in serve mode (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `llm-wiki stats` and any command using community detection hung indefinitely — `louvain_phase1` could oscillate forever when node moves mid-pass altered `sigma_tot` for subsequent nodes; capped at `n × 10` passes
 - `SpaceIndexManager::status()` now uses `ReloadPolicy::Manual` to avoid spawning a competing file_watcher thread against the open `IndexReader`
+- **IndexReader stale after rebuild in serve mode** — `rebuild()` opened a fresh `Index::open_or_create()` instance; with `ReloadPolicy::Manual`, `writer.commit()` only notifies readers on the same instance, so the held reader stayed frozen; added `reload_reader()` helper called after every `writer.commit()` in `rebuild()`, `update()`, `delete_by_type()`, and `rebuild_types()`; fixes `wiki_search` / `wiki_list` / `wiki_graph` returning stale results after `wiki_index_rebuild` in `llm-wiki serve`
 - `wiki_graph` MCP tool now returns the rendered graph text (mermaid/dot/llms) instead of a bare stats report
 - `validate-engine.sh` and `validate-mcp.sh` reset inbox fixtures and clear logs before each run for idempotent sequential execution
 

--- a/docs/implementation/tantivy.md
+++ b/docs/implementation/tantivy.md
@@ -156,15 +156,19 @@ watcher threads compete on the same file. Each reload writes a new `meta.json`,
 which the other watcher detects, triggering another reload — an infinite loop
 that deadlocks the process.
 
-`Manual` skips the file_watcher entirely. The reader is refreshed explicitly
-after a write by calling `reader.reload()?` — which happens automatically
-inside `writer.commit()` via tantivy's internal bookkeeping.
+`Manual` skips the file_watcher entirely. The reader must be explicitly
+reloaded after every write by calling `reader.reload()`. In llm-wiki this
+is done via `reload_reader()` called after each `writer.commit()`.
+
+Note: `writer.commit()` only notifies readers opened on the **same** `Index`
+instance. `rebuild()` uses a separate `Index::open_or_create()` instance, so
+an explicit `reload_reader()` call is required regardless.
 
 For llm-wiki, `Manual` is always correct:
 - **CLI commands** are one-shot; they never need live reload.
-- **`llm-wiki serve`** rebuilds the full engine on `wiki_rebuild` —
-  `WikiEngine::build()` creates a fresh `SpaceIndexManager` with a new reader.
-- **`llm-wiki watch`** routes detected changes through the same rebuild path.
+- **`llm-wiki serve`** keeps a long-lived reader; `reload_reader()` after each
+  write ensures all tools see the latest index without restarting.
+- **`llm-wiki watch`** routes detected changes through the same write paths.
 
 ### Reader lifecycle
 
@@ -172,9 +176,9 @@ For llm-wiki, `Manual` is always correct:
 WikiEngine::build()
   └─ mount_space()
        ├─ index_manager.status()     ← Manual reader, temporary, dropped immediately
-       ├─ index_manager.rebuild()    ← writer.commit() refreshes the live reader implicitly
+       ├─ index_manager.rebuild()    ← writer.commit() + reload_reader()
        └─ index_manager.open()       ← creates the long-lived Manual reader in inner.index_reader
-              └─ held until engine is dropped
+              └─ held until engine is dropped; refreshed after every write via reload_reader()
 ```
 
 Every `searcher()` call is `inner.index_reader.searcher()` — a cheap arc clone.

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -162,6 +162,19 @@ impl SpaceIndexManager {
             .map(|r| r.searcher())
     }
 
+    /// Reload the held IndexReader so searchers see the latest commit.
+    /// No-op if the reader is not yet open. Safe to call after every write.
+    fn reload_reader(&self) -> Result<()> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("index lock poisoned"))?;
+        if let Some(ref r) = inner.index_reader {
+            r.reload()?;
+        }
+        Ok(())
+    }
+
     /// Get a writer from the held index, or open from disk if not held.
     fn writer(&self) -> Result<IndexWriter> {
         let inner = self
@@ -249,6 +262,7 @@ impl SpaceIndexManager {
         }
 
         writer.commit()?;
+        self.reload_reader()?;
 
         let commit = git::current_head(repo_root).unwrap_or_default();
         let state = IndexState {
@@ -319,6 +333,7 @@ impl SpaceIndexManager {
         }
 
         writer.commit()?;
+        self.reload_reader()?;
         Ok(UpdateReport { updated, deleted })
     }
 
@@ -386,6 +401,7 @@ impl SpaceIndexManager {
         let f_type = is.field("type");
         writer.delete_term(Term::from_field_text(f_type, type_name));
         writer.commit()?;
+        self.reload_reader()?;
         Ok(())
     }
 
@@ -490,6 +506,7 @@ impl SpaceIndexManager {
         }
 
         writer.commit()?;
+        self.reload_reader()?;
 
         // Update state.toml
         let commit = git::current_head(repo_root).unwrap_or_default();

--- a/tests/index_manager.rs
+++ b/tests/index_manager.rs
@@ -824,3 +824,88 @@ fn staleness_kind_detects_type_modification() {
         other => panic!("expected TypesChanged, got {other:?}"),
     }
 }
+
+// ── reader reload ─────────────────────────────────────────────────────────────
+
+#[test]
+fn rebuild_refreshes_reader_immediately() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/before.md",
+        &concept_page("Before", "initial body"),
+    );
+
+    // build_index calls rebuild() + open() — establishes the held reader
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let reg = registry();
+
+    // Add a new page and commit it
+    write_page(
+        &wiki_root,
+        "concepts/after.md",
+        &concept_page("AfterRebuild", "new body"),
+    );
+    git::commit(dir.path(), "add after").unwrap();
+
+    // Second rebuild — no open() called afterward
+    mgr.rebuild(&wiki_root, dir.path(), &is, &reg).unwrap();
+
+    // The held reader must see the new page without calling open() again
+    let searcher = mgr.searcher().unwrap();
+    let results = search::search(
+        "AfterRebuild",
+        &search::SearchOptions::default(),
+        &searcher,
+        "test",
+        &is,
+    )
+    .unwrap();
+    assert!(
+        results.results.iter().any(|r| r.title == "AfterRebuild"),
+        "held reader must see new page after rebuild() without calling open() again"
+    );
+}
+
+#[test]
+fn update_refreshes_reader_immediately() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+    write_page(
+        &wiki_root,
+        "concepts/base.md",
+        &concept_page("Base", "initial body"),
+    );
+
+    // build_index calls rebuild() + open() — establishes the held reader
+    let mgr = build_index(dir.path(), &wiki_root);
+    let is = schema();
+    let reg = registry();
+
+    // Add a new page
+    write_page(
+        &wiki_root,
+        "concepts/fresh.md",
+        &concept_page("FreshPage", "fresh body"),
+    );
+
+    // update() — no open() called afterward
+    mgr.update(&wiki_root, dir.path(), None, &is, &reg).unwrap();
+
+    // The held reader must see the new page via mgr.searcher() (not open_searcher)
+    let searcher = mgr.searcher().unwrap();
+    let results = search::search(
+        "FreshPage",
+        &search::SearchOptions::default(),
+        &searcher,
+        "test",
+        &is,
+    )
+    .unwrap();
+    assert!(
+        results.results.iter().any(|r| r.title == "FreshPage"),
+        "held reader must see new page after update() without calling open() again"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `reload_reader()` helper to `SpaceIndexManager` — called after every `writer.commit()` in `rebuild()`, `update()`, `delete_by_type()`, and `rebuild_types()`
- Fixes stale search results after `wiki_index_rebuild` in `llm-wiki serve`: `rebuild()` opens a fresh `Index::open_or_create()` instance; with `ReloadPolicy::Manual`, the held reader stayed frozen until engine restart
- Corrects the `ReloadPolicy::Manual` spec in `docs/implementation/tantivy.md` (was incorrectly stating `writer.commit()` refreshes readers implicitly)
- Adds two regression tests: `rebuild_refreshes_reader_immediately` and `update_refreshes_reader_immediately`

## Test plan

- [x] `cargo test -- reader_immediately` — both regression tests pass
- [x] `cargo test` — full suite green (30 index_manager tests)
- [x] Start `llm-wiki serve`, call `wiki_index_rebuild`, then `wiki_search` — results reflect rebuilt index without restart