### PR TITLE
feat: add wiki_resolve tool and expose path in content_new + LintFinding (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`wiki_resolve` tool** — resolves a slug or `wiki://` URI to its local filesystem path (`slug`, `wiki`, `wiki_root`, `path`, `exists`, `bundle`); enables direct file writes without MCP content round-trips (tool count: 21 → 22)
+- **`wiki_content_new` returns JSON** — response now includes `uri`, `slug`, `path`, `wiki_root`, `bundle`; LLM gets the local path immediately after page creation with no follow-up `wiki_resolve` call
+- **`LintFinding.path` field** — every lint finding now includes the absolute filesystem path to the offending file; enables direct `Edit` without a follow-up resolve call
+
 - **Privacy redaction** — `wiki_ingest` accepts `redact: true`; 6 built-in patterns (GitHub PAT, OpenAI key, Anthropic key, AWS access key, Bearer token, email); per-wiki `[redact]` in `wiki.toml` (disable built-ins, add custom patterns); `redacted: Vec<RedactionReport>` in `IngestReport`; body-only, lossy by design
 - **Incremental validation** — `wiki_ingest` now validates only git-changed files since the last indexed commit; `unchanged_count` added to `IngestReport`; `dry_run: true` continues to validate all files; fallback to full validation when `last_commit` is absent or git errors
 - **`wiki_lint` tool** — 5 deterministic index-based lint rules (`orphan`, `broken-link`, `missing-fields`, `stale`, `unknown-type`); JSON report with `findings`, `errors`, `warnings`, `total`; `lint` CLI subcommand exits non-zero on any `error` finding; `[lint]` config section with `stale_days` and `stale_confidence_threshold`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`confidence: 0.5` in page scaffold** — `wiki_content_new` emits the field by default
 - **`format: "llms"` on existing tools** — `wiki_list`, `wiki_search`, `wiki_graph` accept `format: "llms"`; produces LLM-optimised output (type-grouped pages with summaries, compact search results, natural language graph description) directly in the tool response
 - **`wiki_export` tool** — new MCP tool and `llm-wiki export` CLI command; writes full wiki to a file (no pagination); formats: `llms-txt` (default), `llms-full` (with bodies), `json`; path relative to wiki root; response is a confirmation report
-- **Lint guide** — `docs/guides/lint.md` covering all 5 rules, fix guidance, CI usage, and stale rule tuning
+- **Lint guide** — `docs/guides/lint.md` covering all 5 rules, fix guidance, CI usage, and stale rule tuning; `path` field documented in finding example
 - **Redaction guide** — `docs/guides/redaction.md` covering built-in patterns, per-wiki config, and lossy-by-design warning
 - **Search ranking guide** — `docs/guides/search-ranking.md` covering the formula, status map, per-wiki overrides, and custom status examples
 - **Graph guide** — `docs/guides/graph.md` covering community detection, cross-cluster suggestions, and threshold tuning
+- **Writing content guide** — `docs/guides/writing-content.md`; direct write pattern (`wiki_content_new` → write to `path` → `wiki_ingest`); `wiki_resolve` usage; backlinks; tool selection table
+- **Guides README reorganized** — grouped by audience: Getting started / Writing and managing content / Configuration and integration / Search, graph, and output / Operations
+- **Diagram #4 updated** — LLM Ingest Workflow diagram updated to show `wiki_list(format: "llms")`, `wiki_content_new` direct write, and post-ingest `wiki_lint` steps
+- **Rustdoc pass** — all public items in the crate now have `///` documentation; zero `missing_docs` warnings
 - **Graph community detection** — Louvain clustering on `petgraph::DiGraph`; `communities` field in `wiki_stats` output (`count`, `largest`, `smallest`, `isolated` slugs); suppressed below `graph.min_nodes_for_communities` (default 30); deterministic via sorted-slug processing order
 - **Community-aware suggestions** — strategy 4 in `wiki_suggest`: pages in the same Louvain community not already linked; score 0.4, reason `"same knowledge cluster"`; `graph.community_suggestions_limit` (default 2)
 - **Cross-wiki links** — `wiki://name/slug` URIs as first-class link targets in frontmatter edge fields and body `[[wikilinks]]`; `ParsedLink` enum in `links.rs`; external placeholder nodes in single-wiki graph (dashed border); `build_graph_cross_wiki` for unified multi-wiki graph; `cross_wiki: bool` param on `wiki_graph` MCP tool and `--cross-wiki` CLI flag

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # llm-wiki
 
-A headless wiki engine for agents. 19 MCP tools. One Rust binary. No LLM inside.
+A headless wiki engine for agents. 22 MCP tools. One Rust binary. No LLM inside.
 
 **Build knowledge that compounds — not answers that evaporate.**
 
@@ -43,11 +43,13 @@ through skills, not the binary.
 ```
 LLM agent
   │
+  ├── wiki_list(format: "llms")             → all pages grouped by type
   ├── wiki_search("mixture of experts")     → ranked results + facets
-  ├── wiki_content_read("concepts/moe")     → full page + frontmatter
+  ├── wiki_content_read("concepts/moe")     → full page + backlinks
   ├── wiki_graph(root: "concepts/moe")      → typed graph in Mermaid/DOT
   ├── wiki_suggest("concepts/moe")          → pages worth linking
-  ├── wiki_content_write(...)               → write synthesized knowledge
+  ├── wiki_content_new("concepts/new-page") → scaffold + returns local path
+  ├── [write directly to path]              → no MCP round-trip
   └── wiki_ingest(path: "concepts/")        → validate, index, commit
 ```
 
@@ -108,7 +110,7 @@ llm-wiki serve
 ```
 
 Connect your agent or editor — VS Code, Cursor, Windsurf, Zed, Claude Code —
-via the MCP config. The 19 tools are immediately available.
+via the MCP config. The 22 tools are immediately available.
 
 → [Getting started guide](docs/guides/getting-started.md) · [IDE integration](docs/guides/ide-integration.md)
 
@@ -122,7 +124,8 @@ via the MCP config. The 19 tools are immediately available.
 | `wiki_list` | Paginated page listing with filters; `format: "llms"` for LLM-readable output |
 | `wiki_content_read` | Read a page with optional backlinks |
 | `wiki_content_write` | Write a page (validates frontmatter against type schema) |
-| `wiki_content_new` | Scaffold a new page from its type template |
+| `wiki_content_new` | Scaffold a new page; returns local `path` for direct writes |
+| `wiki_resolve` | Resolve a slug or `wiki://` URI to its local filesystem path |
 | `wiki_ingest` | Validate a path, update the index, commit to git |
 | `wiki_graph` | Typed concept graph — Mermaid, DOT, or natural-language `llms` format |
 | `wiki_suggest` | Find pages worth linking by tag overlap, graph distance, BM25 similarity |

--- a/docs/decisions/0.2.0/local-path-content.md
+++ b/docs/decisions/0.2.0/local-path-content.md
@@ -1,0 +1,88 @@
+# Local Path in Content Tools
+
+## Decision
+
+Add a `wiki_resolve` tool and expose filesystem paths in `wiki_content_new`
+and `wiki_lint` responses. Drop the proposed `wiki_ingest` pages array.
+
+For `wiki_content_new`: change `ops::content_new` to return a
+`ContentNewResult` struct (`uri`, `slug`, `path`, `wiki_root`, `bundle`)
+instead of a bare URI string.
+
+For `wiki_lint`: add `pub path: String` to `LintFinding`; thread
+`wiki_root: &Path` through all 5 rule function signatures; resolve slug → path
+at each of the 6 construction sites.
+
+## Context
+
+Every `wiki_content_read` / `wiki_content_write` round-trip sends full page
+content through MCP. Claude Code has direct filesystem access (`Write`, `Edit`,
+`Read`). If the engine exposes the resolved local path, the LLM can write
+content directly to disk and call `wiki_ingest` once to validate — removing
+the content round-trip entirely.
+
+Three changes were evaluated. A fourth (`wiki_ingest` pages array) was proposed
+in the initial spec but was dropped after reviewing actual skill workflows.
+
+## Rationale
+
+### `wiki_resolve` — implement as specced
+
+`WikiUri::resolve` and `resolve_read_target` are already public and used
+identically in every content handler. The new tool is a thin wrapper with no
+novel logic. For a not-yet-existing slug, the would-be flat path is returned
+(`<wiki_root>/<slug>.md`) — consistent with `wiki_content_new` default behaviour.
+
+### `wiki_content_new` — return struct from ops layer (Option A)
+
+Three options were considered:
+
+- **Option A**: change `ops::content_new` to return `ContentNewResult`
+- **Option B**: keep ops returning `String`, compute path in the MCP handler
+- **Option C**: return `(String, bool)` tuple from ops
+
+Option A was chosen. All path data (`wiki_root`, `slug`, `bundle`) is in scope
+inside `content_new` — the ops layer is the natural owner of this computation.
+Option B would call `WikiUri::resolve` twice (inside `content_new` and again in
+the handler). Option C uses an unreadable tuple. API breakage is acceptable;
+the sole caller is the MCP handler.
+
+### `wiki_lint` — thread `wiki_root` into rule functions (Option A)
+
+Three options were considered:
+
+- **Option A**: pass `wiki_root: &Path` into each rule function, compute path at construction
+- **Option B**: annotate findings post-collection in `run_lint`
+- **Option C**: compute path in the MCP handler
+
+Option A was chosen. `LintFinding` should be self-contained — any consumer
+(CLI, MCP, future transports) gets the path without extra context. The 2 stat
+calls per finding (`Slug::resolve` probes flat then bundle) are acceptable for
+a lint run. API breakage is acceptable.
+
+### `wiki_ingest` pages array — dropped
+
+The initial spec proposed adding `path` per entry in an ingest pages array.
+This was dropped after reviewing actual skill workflows: in every skill
+(`ingest`, `content`, `crystallize`), the LLM calls `wiki_ingest` *after*
+writing files whose paths it already holds. Returning the paths in the response
+is redundant — no follow-up action needs them. Furthermore, `IngestReport` has
+no `pages` array today; adding one would require a non-trivial struct change for
+zero practical gain.
+
+### Tools not changed
+
+`wiki_search`, `wiki_list`, `wiki_suggest`, `wiki_graph`, `wiki_stats`,
+`wiki_history`: bulk results or no direct edit intent follows. Adding `path`
+to every result row costs more tokens than it saves.
+
+## Consequences
+
+- `ops::content_new` return type changes from `Result<String>` to
+  `Result<ContentNewResult>`; the MCP handler serialises the struct as JSON.
+- `LintFinding` gains a `path: String` field; all 5 rule function signatures
+  gain a `wiki_root: &Path` parameter; 6 construction sites updated.
+- `wiki_resolve` raises the tool count from 21 to 22.
+- `wiki_ingest` response and `IngestReport` are unchanged.
+- Skills (`content`, `ingest`) adopt the direct write pattern using
+  `wiki_resolve` + native file tools.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,6 +19,7 @@ Decisions made during improvement design phase.
 | Decision | Summary |
 | -------- | ------- |
 | [llms-format-on-existing-tools](0.2.0/llms-format-on-existing-tools.md) | `format: "llms"` added to `wiki_list`/`wiki_search`/`wiki_graph`; `wiki_export` writes a file (default `llms.txt` at wiki root), response is a report not content |
+| [local-path-content](0.2.0/local-path-content.md) | `wiki_resolve` tool + `path` in `wiki_content_new` response + `path` in `LintFinding`; `wiki_ingest` pages array dropped as redundant |
 
 ### Graph
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -102,13 +102,17 @@ References:
 
 ## 4. LLM Ingest Workflow
 
-The full LLM-driven ingest loop via MCP tools.
+The full LLM-driven ingest loop via MCP tools, using the direct write pattern.
 
 ```mermaid
 sequenceDiagram
     participant LLM
     participant Engine as wiki engine
+    participant Disk as filesystem
     participant Repo as git repo
+
+    LLM->>Engine: wiki_list(format: "llms")
+    Engine-->>LLM: all pages grouped by type
 
     LLM->>Engine: wiki_search("topic")
     Engine-->>LLM: related pages
@@ -116,19 +120,26 @@ sequenceDiagram
     LLM->>Engine: wiki_content_read(hub page)
     Engine-->>LLM: current knowledge
 
-    Note over LLM: reads wiki.toml<br/>reads inbox file<br/>synthesizes pages
+    Note over LLM: reads inbox file<br/>synthesizes pages<br/>plans extraction
 
-    LLM->>Engine: wiki_content_write("concepts/topic.md", content)
-    Engine-->>LLM: ok
+    LLM->>Engine: wiki_content_new("concepts/topic")
+    Engine-->>LLM: { uri, slug, path, wiki_root, bundle }
+
+    LLM->>Disk: write content to path
+    Disk-->>LLM: ok
 
     LLM->>Engine: wiki_ingest("concepts/topic.md")
     Engine->>Repo: validate → index → commit (if auto_commit)
     Engine-->>LLM: IngestReport
+
+    LLM->>Engine: wiki_lint(rules: "broken-link,orphan")
+    Engine-->>LLM: findings (if any)
 ```
 
 References:
 - [ingest-pipeline.md](specifications/engine/ingest-pipeline.md)
 - [content-operations.md](specifications/tools/content-operations.md)
+- [writing-content.md](guides/writing-content.md)
 
 ## 5. Epistemic Model
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,18 +3,41 @@
 User-facing documentation for installing, configuring, and integrating
 llm-wiki.
 
+## Getting started
+
 | Guide                                    | Description                                                       |
 | ---------------------------------------- | ----------------------------------------------------------------- |
 | [getting-started.md](getting-started.md) | End-to-end walkthrough: install → create → write → search → graph |
 | [installation.md](installation.md)       | Install llm-wiki (script, cargo, homebrew, asdf)                  |
-| [configuration.md](configuration.md)     | Common settings, per-wiki overrides, troubleshooting              |
 | [ide-integration.md](ide-integration.md) | Connect to VS Code, Cursor, Windsurf, Zed, Claude Code            |
-| [multi-wiki.md](multi-wiki.md)           | Manage multiple wikis, cross-wiki search, wiki:// URIs            |
-| [custom-types.md](custom-types.md)       | Add custom page types with JSON Schema                            |
-| [search-ranking.md](search-ranking.md)   | Tune search ranking: status multipliers, custom statuses, per-wiki overrides |
-| [llms-format.md](llms-format.md)         | LLM-optimized output: when and how to use `format: "llms"` and `wiki_export` |
-| [lint.md](lint.md)                       | Catch broken links, orphans, missing fields, stale pages, and unknown types  |
+
+## Writing and managing content
+
+| Guide                                    | Description                                                                  |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| [writing-content.md](writing-content.md) | Create and update pages: direct write pattern, wiki_resolve, backlinks       |
+| [custom-types.md](custom-types.md)       | Add custom page types with JSON Schema                                       |
 | [redaction.md](redaction.md)             | Scrub secrets from page bodies before commit with `redact: true`             |
-| [graph.md](graph.md)                     | Community detection, cross-cluster suggestions, threshold tuning  |
-| [ci-cd.md](ci-cd.md)                     | Schema validation, index rebuild, and ingest in CI pipelines      |
-| [release.md](release.md)                 | Release process and distribution channels                         |
+| [lint.md](lint.md)                       | Catch broken links, orphans, missing fields, stale pages, and unknown types  |
+
+## Configuration and integration
+
+| Guide                                      | Description                                                                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------- |
+| [configuration.md](configuration.md)       | Common settings, per-wiki overrides, troubleshooting                         |
+| [multi-wiki.md](multi-wiki.md)             | Manage multiple wikis, cross-wiki search, wiki:// URIs                       |
+| [ci-cd.md](ci-cd.md)                       | Schema validation, index rebuild, and ingest in CI pipelines                 |
+
+## Search, graph, and output
+
+| Guide                                      | Description                                                                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------- |
+| [search-ranking.md](search-ranking.md)     | Tune search ranking: status multipliers, custom statuses, per-wiki overrides |
+| [llms-format.md](llms-format.md)           | LLM-optimized output: when and how to use `format: "llms"` and `wiki_export` |
+| [graph.md](graph.md)                       | Community detection, cross-cluster suggestions, threshold tuning             |
+
+## Operations
+
+| Guide                  | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| [release.md](release.md) | Release process and distribution channels              |

--- a/docs/guides/lint.md
+++ b/docs/guides/lint.md
@@ -39,7 +39,8 @@ wiki quality.
   "slug": "concepts/moe",
   "rule": "broken-link",
   "severity": "error",
-  "message": "broken link in body_links: concepts/ghost"
+  "message": "broken link in body_links: concepts/ghost",
+  "path": "/home/user/wikis/research/wiki/concepts/moe.md"
 }
 ```
 
@@ -49,6 +50,7 @@ wiki quality.
 | `rule` | Which rule fired |
 | `severity` | `error` or `warning` |
 | `message` | What was found and where |
+| `path` | Absolute filesystem path of the offending file — use for direct `Edit` without a follow-up resolve call |
 
 The full response includes a summary header:
 

--- a/docs/guides/writing-content.md
+++ b/docs/guides/writing-content.md
@@ -1,0 +1,167 @@
+---
+title: "Writing Content"
+summary: "How to create and update wiki pages: direct write pattern, wiki_resolve, wiki_content_write, and backlinks."
+status: active
+last_updated: "2026-04-28"
+---
+
+# Writing Content
+
+There are two main patterns for writing wiki content: the **direct write
+pattern** (recommended for new pages) and the **read-modify-write pattern**
+(for updates to existing pages).
+
+## Creating a new page
+
+The recommended flow for creating a page avoids an extra MCP round-trip by
+writing the file directly to disk using the path returned by
+`wiki_content_new`.
+
+```
+1. wiki_content_new(uri: "concepts/my-topic", name: "My Topic")
+   → returns { uri, slug, path, wiki_root, bundle }
+
+2. Write content directly to `path`
+   (Bash write, Edit, or any file write tool)
+
+3. wiki_ingest(path: "concepts/my-topic.md", wiki: "research")
+   → validates frontmatter, updates index, commits
+```
+
+Why not `wiki_content_write`? `wiki_content_new` scaffolds the frontmatter
+and returns the exact filesystem path. Writing directly to that path and then
+calling `wiki_ingest` keeps the page canonical without an extra MCP read
+round-trip to confirm the path.
+
+### `wiki_content_new` response
+
+```json
+{
+  "uri": "wiki://research/concepts/my-topic",
+  "slug": "concepts/my-topic",
+  "path": "/home/user/wikis/research/wiki/concepts/my-topic.md",
+  "wiki_root": "/home/user/wikis/research/wiki",
+  "bundle": false
+}
+```
+
+For a bundle page (`bundle: true`), `path` points to the `index.md` inside
+the created directory.
+
+## Resolving an existing page path
+
+When you want to write directly to an existing page without reading its
+content first, use `wiki_resolve`:
+
+```
+wiki_resolve(uri: "concepts/scaling-laws", wiki: "research")
+→ {
+    "slug": "concepts/scaling-laws",
+    "wiki": "research",
+    "wiki_root": "/home/user/wikis/research/wiki",
+    "path": "/home/user/wikis/research/wiki/concepts/scaling-laws.md",
+    "exists": true,
+    "bundle": false
+  }
+```
+
+Then write directly to `path` and call `wiki_ingest` to re-validate and
+re-index.
+
+`wiki_resolve` also works for non-existent slugs — `exists: false` — so you
+can check whether a page exists before creating it.
+
+## Updating an existing page
+
+For updates where you need to read the current content first:
+
+```
+1. wiki_content_read(uri: "concepts/scaling-laws")
+   → current content as string
+
+2. Modify content in session
+
+3. wiki_content_write(uri: "concepts/scaling-laws", content: "...")
+   → writes to wiki tree
+
+4. wiki_ingest(path: "concepts/scaling-laws.md")
+   → validates, indexes, commits
+```
+
+`wiki_content_write` resolves the slug to a path internally — it's equivalent
+to resolving and writing directly, but returns a minimal confirmation rather
+than path information.
+
+## Using wiki_content_write
+
+`wiki_content_write` is the simplest write tool: it takes a slug/URI and
+content, writes the file, and returns a confirmation. Use it when you already
+have the full replacement content in session and don't need the path for
+further operations.
+
+```json
+// Parameters
+{
+  "uri": "concepts/scaling-laws",
+  "content": "---\ntype: concept\n...\n---\n\n# Scaling Laws\n...",
+  "wiki": "research"   // optional, uses default
+}
+```
+
+The response is a plain confirmation string. For path information, prefer
+`wiki_content_new` (new pages) or `wiki_resolve` (existing pages).
+
+## Creating sections
+
+Sections are structural pages (folders in the wiki tree with their own
+`index.md`). Create them with `wiki_content_new(section: true)`:
+
+```
+wiki_content_new(uri: "concepts/transformers", section: true)
+```
+
+The section page is scaffolded at `concepts/transformers/index.md`. Child
+pages live at `concepts/transformers/<slug>.md`.
+
+## Backlinks
+
+`wiki_content_read` can return incoming links — all pages that reference the
+target slug in their body or frontmatter edge fields:
+
+```
+wiki_content_read(uri: "concepts/scaling-laws", backlinks: true)
+→ {
+    "content": "...",
+    "backlinks": [
+      { "slug": "sources/chinchilla-2022", "title": "Chinchilla" },
+      { "slug": "concepts/mixture-of-experts", "title": "Mixture of Experts" }
+    ]
+  }
+```
+
+Backlinks are useful for understanding what depends on a page before updating
+or deleting it.
+
+## Choosing the right tool
+
+| Goal | Tool |
+|------|------|
+| Create a new page with scaffolded frontmatter | `wiki_content_new` → write to `path` → `wiki_ingest` |
+| Get the path of an existing page without reading content | `wiki_resolve` |
+| Update an existing page (need to read first) | `wiki_content_read` → modify → `wiki_content_write` |
+| Simple overwrite of known content | `wiki_content_write` |
+| Check what links to a page | `wiki_content_read(backlinks: true)` |
+| Commit staged changes | `wiki_content_commit` |
+
+## After writing
+
+Always call `wiki_ingest` after writing content directly to disk (via `path`).
+If you used `wiki_content_write`, the file is written but not yet indexed or
+committed — call `wiki_ingest` to complete the pipeline.
+
+```
+wiki_ingest(path: "concepts/my-topic.md", wiki: "research")
+```
+
+Run `wiki_lint(rules: "broken-link,orphan")` after creating multiple pages in
+a session to catch dead references introduced by new content.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 title: "Roadmap"
 summary: "Release history and version planning for llm-wiki."
 status: ready
-last_updated: "2026-04-27"
+last_updated: "2026-04-28"
 ---
 
 # Roadmap
@@ -24,8 +24,8 @@ last_updated: "2026-04-27"
 | ----------- | ----------------------------------------------------------------------------- |
 | Type system | `confidence: 0.0–1.0` field; `claims[].confidence` as float                  |
 | Search      | Lifecycle-aware ranking; flat `[search.status]` multiplier map                |
-| Content     | Backlinks on `wiki_content_read`; incremental validation (git-diff scoped)    |
-| Lint        | `wiki_lint` tool with 5 rules; `broken-cross-wiki-link` rule                  |
+| Content     | Backlinks on `wiki_content_read`; incremental validation (git-diff scoped); `wiki_resolve` tool; `wiki_content_new` returns `path` + `wiki_root` |
+| Lint        | `wiki_lint` tool with 5 rules; `broken-cross-wiki-link` rule; `path` field on every finding |
 | Redaction   | `redact:` flag on `wiki_ingest`; built-in and custom patterns                 |
 | Graph       | Louvain community detection; `wiki://` cross-wiki edges; `--cross-wiki` flag  |
 | Export      | `wiki_export` + `llms` format on list, search, and graph                      |

--- a/docs/specifications/tools/content-operations.md
+++ b/docs/specifications/tools/content-operations.md
@@ -1,12 +1,13 @@
 ---
 title: "Content Operations"
-summary: "read, write, new, commit."
+summary: "read, write, new, commit, resolve."
 read_when:
   - Reading or writing wiki pages
   - Creating new pages or sections
   - Committing changes to git
+  - Resolving a slug to its local filesystem path
 status: ready
-last_updated: "2026-04-27"
+last_updated: "2026-04-28"
 ---
 
 # Content Operations
@@ -19,6 +20,7 @@ All content operations live under `llm-wiki content`:
 | `content write` | `wiki_content_write` | Write a file into the wiki tree |
 | `content new` | `wiki_content_new` | Create a page or section with scaffolded frontmatter |
 | `content commit` | `wiki_content_commit` | Commit pending changes to git |
+| — | `wiki_resolve` | Resolve a slug or URI to its local filesystem path |
 
 None of these tools validate or index — that's what `wiki_ingest` does.
 Only `content commit` and `wiki_ingest` (when `auto_commit` is true)
@@ -97,6 +99,21 @@ llm-wiki content new <slug|uri>
 Creates a page by default, or a section with `--section`. Does not
 commit.
 
+The MCP response is JSON (not plain text):
+
+```json
+{
+  "uri":       "wiki://research/concepts/new-page",
+  "slug":      "concepts/new-page",
+  "path":      "/path/to/wiki/concepts/new-page.md",
+  "wiki_root": "/path/to/wiki",
+  "bundle":    false
+}
+```
+
+`path` is the resolved filesystem path of the created file. Use it to write
+content directly with native file tools before calling `wiki_ingest`.
+
 Pages get scaffolded frontmatter (title derived from slug, type
 defaults to `page`, status `draft`). If a body template exists at
 `schemas/<type>.md`, it is appended after the frontmatter. Otherwise
@@ -118,6 +135,44 @@ Accepts a bare slug or `wiki://` URI. When a `wiki://` URI is used,
 `--wiki` is ignored.
 
 Missing parent sections are created automatically with their `index.md`.
+
+## wiki_resolve
+
+MCP tool only (no CLI equivalent).
+
+```json
+wiki_resolve(uri: "concepts/mixture-of-experts", wiki?: "research")
+→ {
+    "slug":      "concepts/mixture-of-experts",
+    "wiki":      "research",
+    "wiki_root": "/path/to/wiki",
+    "path":      "/path/to/wiki/concepts/mixture-of-experts.md",
+    "exists":    true,
+    "bundle":    false
+  }
+```
+
+Resolves a slug or `wiki://` URI to its local filesystem path without reading
+the file. Use before writing content directly to disk.
+
+| Field | Description |
+|-------|-------------|
+| `slug` | Canonical slug (no extension) |
+| `wiki` | Wiki name |
+| `wiki_root` | Absolute path to the wiki directory |
+| `path` | Absolute path to the file (flat `.md` or `index.md` for bundles) |
+| `exists` | `true` if the file exists on disk |
+| `bundle` | `true` if the page is a bundle (`path` ends with `index.md`) |
+
+For a not-yet-existing slug, `exists` is `false` and `path` is the would-be
+flat path (`<wiki_root>/<slug>.md`). The direct write pattern:
+
+```
+1. wiki_resolve(uri)                      → get local path + wiki_root
+2. Write / Edit file at path directly     → no MCP content round-trip
+3. wiki_ingest(path: "<slug>", dry_run: true)  → validate frontmatter
+4. wiki_ingest(path: "<slug>")            → commit
+```
 
 ## content commit
 

--- a/docs/specifications/tools/lint.md
+++ b/docs/specifications/tools/lint.md
@@ -36,14 +36,18 @@ Returns a JSON object:
   "warnings": 1,
   "findings": [
     {
-      "slug": "concepts/moe",
-      "rule": "broken-link",
+      "slug":     "concepts/moe",
+      "rule":     "broken-link",
       "severity": "error",
-      "message": "broken link in body_links: concepts/ghost"
+      "message":  "broken link in body_links: concepts/ghost",
+      "path":     "/path/to/wiki/concepts/moe.md"
     }
   ]
 }
 ```
+
+Each finding includes `path` — the absolute filesystem path to the offending
+file. Use it to `Edit` the file directly without a follow-up `wiki_resolve` call.
 
 Empty `findings` array = clean wiki. CLI exits non-zero when any
 `error` finding exists.

--- a/docs/testing/scripts/mcp/04-content.sh
+++ b/docs/testing/scripts/mcp/04-content.sh
@@ -13,7 +13,27 @@ run_mcp      "content_read with backlinks"           "backlinks" \
 run_mcp      "content_read via wiki:// URI"          "Mixture of Experts" \
              wiki_content_read '{"uri":"wiki://research/concepts/mixture-of-experts"}'
 
-# content_write and content_new mutate the wiki — skip to preserve test state
-skip "content_write" "mutates wiki state"
-skip "content_new"   "mutates wiki state"
+run_mcp_json "wiki_resolve existing slug has exists:true" \
+             '.exists' "true" \
+             wiki_resolve '{"uri":"concepts/mixture-of-experts"}'
+
+run_mcp_json "wiki_resolve existing slug has .md path" \
+             '.path | endswith(".md")' "true" \
+             wiki_resolve '{"uri":"concepts/mixture-of-experts"}'
+
+run_mcp_json "wiki_resolve non-existing slug has exists:false" \
+             '.exists' "false" \
+             wiki_resolve '{"uri":"concepts/does-not-exist-xyz"}'
+
+run_mcp_json "wiki_resolve non-existing slug returns would-be path" \
+             '.path | endswith(".md")' "true" \
+             wiki_resolve '{"uri":"concepts/does-not-exist-xyz"}'
+
+run_mcp_json "wiki_resolve returns slug and wiki_root" \
+             '.slug | length > 0' "true" \
+             wiki_resolve '{"uri":"concepts/mixture-of-experts"}'
+
+# content_write, content_new, and content_commit mutate the wiki — skip to preserve test state
+skip "content_write"  "mutates wiki state"
+skip "content_new"    "mutates wiki state"
 skip "content_commit" "mutates wiki state"

--- a/docs/testing/scripts/mcp/06-lint.sh
+++ b/docs/testing/scripts/mcp/06-lint.sh
@@ -24,3 +24,11 @@ run_mcp_json "lint orphan finds orphan-concept"      \
 
 run_mcp      "lint with wiki param"                  "error\|warning" \
              wiki_lint '{"wiki":"research"}'
+
+run_mcp_json "lint findings have non-empty path"     \
+             '[.findings[] | select(.path == "" or .path == null)] | length == 0' "true" \
+             wiki_lint '{"rules":["broken-link"],"format":"json"}'
+
+run_mcp_json "lint finding path ends with .md"       \
+             '[.findings[] | select(.path | endswith(".md") | not)] | length == 0' "true" \
+             wiki_lint '{"rules":["broken-link"],"format":"json"}'

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -11,11 +11,17 @@ pub use server::serve_acp;
 
 // ── Session ───────────────────────────────────────────────────────────────────
 
+/// An active ACP session tracking identity and execution state.
 pub struct AcpSession {
+    /// Unique session identifier assigned at creation.
     pub id: String,
+    /// Optional human-readable label for the session.
     pub label: Option<String>,
+    /// Wiki name associated with the session, if any.
     pub wiki: Option<String>,
+    /// Unix timestamp (milliseconds) when the session was created.
     pub created_at: u64,
+    /// ID of the currently executing tool run, if any.
     pub active_run: Option<String>,
 }
 
@@ -48,6 +54,7 @@ fn extract_prompt_text(req: &PromptRequest) -> String {
         .join(" ")
 }
 
+/// Generate a unique tool-run ID from workflow name, step name, and current timestamp.
 pub fn make_tool_id(workflow: &str, step: &str) -> String {
     format!(
         "{workflow}-{step}-{}",

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -20,6 +20,7 @@ use super::helpers::{clear_active_run, resolve_wiki_name, send_text, session_cwd
 use super::research::run_research;
 use super::{AcpSession, Sessions, dispatch_workflow, extract_prompt_text};
 
+/// Start the ACP (Agent Client Protocol) server on stdio.
 pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
     let sessions: Sessions = Arc::new(std::sync::Mutex::new(HashMap::new()));
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+/// Root CLI entry point — parses subcommands and global flags.
 #[derive(Parser)]
 #[command(
     name = "llm-wiki",
@@ -7,6 +8,7 @@ use clap::{Parser, Subcommand};
     about = "Git-backed wiki engine with MCP server"
 )]
 pub struct Cli {
+    /// The subcommand to execute.
     #[command(subcommand)]
     pub command: Commands,
 
@@ -20,20 +22,24 @@ pub struct Cli {
     pub config: Option<std::path::PathBuf>,
 }
 
+/// Top-level subcommands available from the `llm-wiki` CLI.
 #[derive(Subcommand)]
 pub enum Commands {
     /// Manage wiki spaces
     Spaces {
+        /// The spaces subcommand.
         #[command(subcommand)]
         action: SpacesAction,
     },
     /// Read and write configuration
     Config {
+        /// The config subcommand.
         #[command(subcommand)]
         action: ConfigAction,
     },
     /// Content operations (read, write, new, commit)
     Content {
+        /// The content subcommand.
         #[command(subcommand)]
         action: ContentAction,
     },
@@ -118,6 +124,7 @@ pub enum Commands {
     },
     /// Manage the tantivy search index
     Index {
+        /// The index subcommand.
         #[command(subcommand)]
         action: IndexAction,
     },
@@ -166,6 +173,7 @@ pub enum Commands {
     },
     /// Inspect and manage type schemas
     Schema {
+        /// The schema subcommand.
         #[command(subcommand)]
         action: SchemaAction,
     },
@@ -204,11 +212,13 @@ pub enum Commands {
     },
     /// Inspect and manage server logs
     Logs {
+        /// The logs subcommand.
         #[command(subcommand)]
         action: LogsAction,
     },
 }
 
+/// Subcommands for `llm-wiki logs`.
 #[derive(Subcommand)]
 pub enum LogsAction {
     /// Show recent log entries
@@ -223,6 +233,7 @@ pub enum LogsAction {
     Clear,
 }
 
+/// Subcommands for `llm-wiki spaces`.
 #[derive(Subcommand)]
 pub enum SpacesAction {
     /// Create a new wiki repository
@@ -265,6 +276,7 @@ pub enum SpacesAction {
     },
 }
 
+/// Subcommands for `llm-wiki config`.
 #[derive(Subcommand)]
 pub enum ConfigAction {
     /// Print a config value
@@ -299,6 +311,7 @@ pub enum ConfigAction {
     },
 }
 
+/// Subcommands for `llm-wiki content`.
 #[derive(Subcommand)]
 pub enum ContentAction {
     /// Read a page or asset by slug or wiki:// URI
@@ -353,6 +366,7 @@ pub enum ContentAction {
     },
 }
 
+/// Subcommands for `llm-wiki index`.
 #[derive(Subcommand)]
 pub enum IndexAction {
     /// Rebuild the search index from committed Markdown
@@ -372,6 +386,7 @@ pub enum IndexAction {
     },
 }
 
+/// Subcommands for `llm-wiki schema`.
 #[derive(Subcommand)]
 pub enum SchemaAction {
     /// List all registered types

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,36 +5,51 @@ use serde::{Deserialize, Serialize};
 
 // ── Section structs ───────────────────────────────────────────────────────────
 
+/// The `[global]` section of the global config file.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GlobalSection {
+    /// Name of the wiki used when no `--wiki` flag is given.
     #[serde(default)]
     pub default_wiki: String,
 }
 
+/// A registered wiki entry in the `[[wikis]]` array of the global config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WikiEntry {
+    /// Short identifier used in `wiki://` URIs and the `--wiki` flag.
     pub name: String,
+    /// Absolute path to the wiki repository root on disk.
     pub path: String,
+    /// Optional one-line description shown in `spaces list`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional git remote URL for the wiki repository.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote: Option<String>,
 }
 
+/// Default values for CLI flags that can be overridden per-wiki via `wiki.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Defaults {
+    /// Maximum number of search results returned (default: 10).
     #[serde(default = "default_search_top_k")]
     pub search_top_k: u32,
+    /// Whether to include BM25 excerpts in search output (default: true).
     #[serde(default = "default_true")]
     pub search_excerpt: bool,
+    /// Whether to include section index pages in search results (default: false).
     #[serde(default)]
     pub search_sections: bool,
+    /// Page display mode: `"flat"` or `"hierarchical"` (default: `"flat"`).
     #[serde(default = "default_page_mode")]
     pub page_mode: String,
+    /// Number of pages returned per `list` call (default: 20).
     #[serde(default = "default_list_page_size")]
     pub list_page_size: u32,
+    /// Default output format: `"text"` or `"json"` (default: `"text"`).
     #[serde(default = "default_output_format")]
     pub output_format: String,
+    /// Maximum number of tag facet values to return (default: 10).
     #[serde(default = "default_facets_top_tags")]
     pub facets_top_tags: u32,
 }
@@ -53,20 +68,27 @@ impl Default for Defaults {
     }
 }
 
+/// `[read]` section — controls how pages are read back.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ReadConfig {
+    /// Strip frontmatter from `content read` output when true (default: false).
     #[serde(default)]
     pub no_frontmatter: bool,
 }
 
+/// `[index]` section — Tantivy index configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexConfig {
+    /// Automatically rebuild the index on startup when stale (default: false).
     #[serde(default)]
     pub auto_rebuild: bool,
+    /// Automatically recover a corrupt index by rebuilding (default: true).
     #[serde(default = "default_true")]
     pub auto_recovery: bool,
+    /// Tantivy index writer memory budget in megabytes (default: 50).
     #[serde(default = "default_memory_budget_mb")]
     pub memory_budget_mb: u32,
+    /// Tantivy tokenizer name (default: `"en_stem"`).
     #[serde(default = "default_tokenizer")]
     pub tokenizer: String,
 }
@@ -85,12 +107,16 @@ impl Default for IndexConfig {
 /// Graph rendering and community detection configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphConfig {
+    /// Default graph output format: `"mermaid"`, `"dot"`, or `"llms"` (default: `"mermaid"`).
     #[serde(default = "default_graph_format")]
     pub format: String,
+    /// Default hop depth for subgraph extraction (default: 3).
     #[serde(default = "default_graph_depth")]
     pub depth: u32,
+    /// Page types to include when no `--type` flag is given (empty = all).
     #[serde(default)]
     pub r#type: Vec<String>,
+    /// Default output file path for graph commands (empty = stdout).
     #[serde(default)]
     pub output: String,
     /// Minimum local node count before Louvain community detection runs (default 30).
@@ -122,20 +148,28 @@ fn default_community_suggestions_limit() -> usize {
     2
 }
 
+/// `[serve]` section — HTTP and ACP server configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServeConfig {
+    /// Enable the HTTP transport by default (default: false).
     #[serde(default)]
     pub http: bool,
+    /// TCP port for the HTTP server (default: 8080).
     #[serde(default = "default_http_port")]
     pub http_port: u16,
+    /// Hostnames accepted by the HTTP server (default: localhost variants).
     #[serde(default = "default_http_allowed_hosts")]
     pub http_allowed_hosts: Vec<String>,
+    /// Enable the ACP transport by default (default: false).
     #[serde(default)]
     pub acp: bool,
+    /// Maximum automatic restart attempts after a server crash (default: 10).
     #[serde(default = "default_max_restarts")]
     pub max_restarts: u32,
+    /// Seconds to wait between restart attempts (default: 1).
     #[serde(default = "default_restart_backoff")]
     pub restart_backoff: u32,
+    /// Interval in seconds between ACP heartbeat pings (default: 60).
     #[serde(default = "default_heartbeat_secs")]
     pub heartbeat_secs: u32,
 }
@@ -154,8 +188,10 @@ impl Default for ServeConfig {
     }
 }
 
+/// `[validation]` section — frontmatter validation strictness.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationConfig {
+    /// How strictly unknown types are treated: `"loose"` (warn) or `"strict"` (error) (default: `"loose"`).
     #[serde(default = "default_type_strictness")]
     pub type_strictness: String,
 }
@@ -168,14 +204,19 @@ impl Default for ValidationConfig {
     }
 }
 
+/// `[logging]` section — structured log file configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoggingConfig {
+    /// Directory where log files are written (default: `~/.llm-wiki/logs`).
     #[serde(default = "default_log_path")]
     pub log_path: String,
+    /// Log rotation policy: `"daily"` or `"never"` (default: `"daily"`).
     #[serde(default = "default_log_rotation")]
     pub log_rotation: String,
+    /// Maximum number of log files to retain before pruning (default: 7).
     #[serde(default = "default_log_max_files")]
     pub log_max_files: u32,
+    /// Log line format: `"text"` or `"json"` (default: `"text"`).
     #[serde(default = "default_log_format")]
     pub log_format: String,
 }
@@ -191,8 +232,10 @@ impl Default for LoggingConfig {
     }
 }
 
+/// `[ingest]` section — controls ingest commit behaviour.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IngestConfig {
+    /// Automatically commit ingested files to git after validation (default: true).
     #[serde(default = "default_true")]
     pub auto_commit: bool,
 }
@@ -203,10 +246,13 @@ impl Default for IngestConfig {
     }
 }
 
+/// `[history]` section — git log / history command defaults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryConfig {
+    /// Enable `--follow` rename tracking in git log (default: true).
     #[serde(default = "default_true")]
     pub follow: bool,
+    /// Default maximum number of history entries to return (default: 10).
     #[serde(default = "default_history_limit")]
     pub default_limit: u32,
 }
@@ -220,8 +266,10 @@ impl Default for HistoryConfig {
     }
 }
 
+/// `[watch]` section — filesystem watcher configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WatchConfig {
+    /// Debounce delay in milliseconds before triggering ingest after a file change (default: 500).
     #[serde(default = "default_debounce_ms")]
     pub debounce_ms: u32,
 }
@@ -232,10 +280,13 @@ impl Default for WatchConfig {
     }
 }
 
+/// `[suggest]` section — related-page suggestion defaults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SuggestConfig {
+    /// Default maximum number of suggestions to return (default: 5).
     #[serde(default = "default_suggest_limit")]
     pub default_limit: u32,
+    /// Minimum relevance score for a suggestion to be included (default: 0.1).
     #[serde(default = "default_suggest_min_score")]
     pub min_score: f32,
 }
@@ -249,8 +300,10 @@ impl Default for SuggestConfig {
     }
 }
 
+/// `[search]` section — BM25 score multipliers by page status.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchConfig {
+    /// Map of status value → score multiplier applied to BM25 results.
     #[serde(default = "default_search_status")]
     pub status: std::collections::HashMap<String, f32>,
 }
@@ -294,55 +347,79 @@ impl Default for LintConfig {
     }
 }
 
+/// A user-defined redaction rule added to the built-in patterns.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CustomPattern {
+    /// Unique name used in redaction reports.
     pub name: String,
+    /// Regex pattern to match sensitive text.
     pub pattern: String,
+    /// Replacement string substituted for matched text (e.g. `"[REDACTED]"`).
     pub replacement: String,
 }
 
+/// `[redact]` section — sensitive-data redaction configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RedactConfig {
+    /// Built-in pattern names to disable (e.g. `["aws-key"]`).
     #[serde(default)]
     pub disable: Vec<String>,
+    /// Additional user-defined redaction patterns.
     #[serde(default)]
     pub patterns: Vec<CustomPattern>,
 }
 
 // ── Composite configs ─────────────────────────────────────────────────────────
 
+/// Root structure for `~/.llm-wiki/config.toml` — the global configuration file.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct GlobalConfig {
+    /// `[global]` section.
     #[serde(default)]
     pub global: GlobalSection,
+    /// `[[wikis]]` array — registered wiki spaces.
     #[serde(default)]
     pub wikis: Vec<WikiEntry>,
+    /// `[defaults]` section — CLI flag defaults.
     #[serde(default)]
     pub defaults: Defaults,
+    /// `[read]` section.
     #[serde(default)]
     pub read: ReadConfig,
+    /// `[index]` section.
     #[serde(default)]
     pub index: IndexConfig,
+    /// `[graph]` section.
     #[serde(default)]
     pub graph: GraphConfig,
+    /// `[serve]` section.
     #[serde(default)]
     pub serve: ServeConfig,
+    /// `[validation]` section.
     #[serde(default)]
     pub validation: ValidationConfig,
+    /// `[ingest]` section.
     #[serde(default)]
     pub ingest: IngestConfig,
+    /// `[history]` section.
     #[serde(default)]
     pub history: HistoryConfig,
+    /// `[suggest]` section.
     #[serde(default)]
     pub suggest: SuggestConfig,
+    /// `[search]` section.
     #[serde(default)]
     pub search: SearchConfig,
+    /// `[lint]` section.
     #[serde(default)]
     pub lint: LintConfig,
+    /// `[logging]` section.
     #[serde(default)]
     pub logging: LoggingConfig,
+    /// `[watch]` section.
     #[serde(default)]
     pub watch: WatchConfig,
+    /// `[redact]` section.
     #[serde(default)]
     pub redact: RedactConfig,
 }
@@ -350,53 +427,84 @@ pub struct GlobalConfig {
 /// A type entry in `[types.<name>]` of `wiki.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypeEntry {
+    /// Relative path to the JSON Schema file for this type.
     pub schema: String,
+    /// Human-readable description of the type.
     pub description: String,
 }
 
+/// Per-wiki configuration loaded from `<wiki-root>/wiki.toml`.
+///
+/// Fields present here override the corresponding `GlobalConfig` sections.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct WikiConfig {
+    /// Wiki display name (informational; used in export headers).
     #[serde(default)]
     pub name: String,
+    /// One-line description of the wiki.
     #[serde(default)]
     pub description: String,
+    /// `[types.<name>]` custom type registrations for this wiki.
     #[serde(default)]
     pub types: std::collections::HashMap<String, TypeEntry>,
+    /// Per-wiki override for `[defaults]`.
     #[serde(default)]
     pub defaults: Option<Defaults>,
+    /// Per-wiki override for `[read]`.
     #[serde(default)]
     pub read: Option<ReadConfig>,
+    /// Per-wiki override for `[validation]`.
     #[serde(default)]
     pub validation: Option<ValidationConfig>,
+    /// Per-wiki override for `[ingest]`.
     #[serde(default)]
     pub ingest: Option<IngestConfig>,
+    /// Per-wiki override for `[graph]`.
     #[serde(default)]
     pub graph: Option<GraphConfig>,
+    /// Per-wiki override for `[history]`.
     #[serde(default)]
     pub history: Option<HistoryConfig>,
+    /// Per-wiki override for `[suggest]`.
     #[serde(default)]
     pub suggest: Option<SuggestConfig>,
+    /// Per-wiki override for `[search]`.
     #[serde(default)]
     pub search: Option<SearchConfig>,
+    /// Per-wiki override for `[lint]`.
     #[serde(default)]
     pub lint: Option<LintConfig>,
+    /// Per-wiki override for `[redact]`.
     #[serde(default)]
     pub redact: Option<RedactConfig>,
 }
 
+/// Fully merged config for a specific wiki — global settings overlaid with per-wiki overrides.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedConfig {
+    /// Resolved defaults section.
     pub defaults: Defaults,
+    /// Resolved read section.
     pub read: ReadConfig,
+    /// Resolved index section (always from global).
     pub index: IndexConfig,
+    /// Resolved graph section.
     pub graph: GraphConfig,
+    /// Resolved serve section (always from global).
     pub serve: ServeConfig,
+    /// Resolved ingest section.
     pub ingest: IngestConfig,
+    /// Resolved validation section.
     pub validation: ValidationConfig,
+    /// Resolved history section.
     pub history: HistoryConfig,
+    /// Resolved suggest section.
     pub suggest: SuggestConfig,
+    /// Resolved search section (merged: per-wiki entries override global entries).
     pub search: SearchConfig,
+    /// Resolved lint section.
     pub lint: LintConfig,
+    /// Resolved redact section.
     pub redact: RedactConfig,
 }
 
@@ -487,6 +595,7 @@ fn default_stale_confidence_threshold() -> f32 {
 }
 // ── Functions ─────────────────────────────────────────────────────────────────
 
+/// Merge global and per-wiki config into a `ResolvedConfig` for a specific wiki.
 pub fn resolve(global: &GlobalConfig, per_wiki: &WikiConfig) -> ResolvedConfig {
     ResolvedConfig {
         defaults: per_wiki
@@ -533,6 +642,7 @@ pub fn resolve(global: &GlobalConfig, per_wiki: &WikiConfig) -> ResolvedConfig {
     }
 }
 
+/// Load the global config from a TOML file. Returns default config if the file is absent.
 pub fn load_global(path: &Path) -> Result<GlobalConfig> {
     if !path.exists() {
         return Ok(GlobalConfig::default());
@@ -544,6 +654,7 @@ pub fn load_global(path: &Path) -> Result<GlobalConfig> {
     Ok(config)
 }
 
+/// Load per-wiki config from `<wiki_root>/wiki.toml`. Returns default config if absent.
 pub fn load_wiki(wiki_root: &Path) -> Result<WikiConfig> {
     let path = wiki_root.join("wiki.toml");
     if !path.exists() {
@@ -556,6 +667,7 @@ pub fn load_wiki(wiki_root: &Path) -> Result<WikiConfig> {
     Ok(config)
 }
 
+/// Serialize and write the global config to `path`, creating parent dirs if needed.
 pub fn save_global(config: &GlobalConfig, path: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -565,6 +677,7 @@ pub fn save_global(config: &GlobalConfig, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Serialize and write the per-wiki config to `<wiki_root>/wiki.toml`.
 pub fn save_wiki(config: &WikiConfig, wiki_root: &Path) -> Result<()> {
     let path = wiki_root.join("wiki.toml");
     let content = toml::to_string_pretty(config)?;
@@ -572,6 +685,7 @@ pub fn save_wiki(config: &WikiConfig, wiki_root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Set a dot-notation config key on a `GlobalConfig` in place. Errors on unknown keys.
 pub fn set_global_config_value(global: &mut GlobalConfig, key: &str, value: &str) -> Result<()> {
     match key {
         "global.default_wiki" => global.global.default_wiki = value.into(),
@@ -616,6 +730,7 @@ pub fn set_global_config_value(global: &mut GlobalConfig, key: &str, value: &str
     Ok(())
 }
 
+/// Read a dot-notation config key from `ResolvedConfig`/`GlobalConfig`. Returns `"unknown key"` for unrecognized keys.
 pub fn get_config_value(resolved: &ResolvedConfig, global: &GlobalConfig, key: &str) -> String {
     match key {
         "global.default_wiki" => global.global.default_wiki.clone(),
@@ -656,6 +771,7 @@ pub fn get_config_value(resolved: &ResolvedConfig, global: &GlobalConfig, key: &
     }
 }
 
+/// Set a dot-notation config key on a `WikiConfig` in place. Errors on global-only or unknown keys.
 pub fn set_wiki_config_value(wiki_cfg: &mut WikiConfig, key: &str, value: &str) -> Result<()> {
     match key {
         "defaults.search_top_k" => {

--- a/src/default_schemas.rs
+++ b/src/default_schemas.rs
@@ -44,8 +44,11 @@ pub fn embedded_body_template(type_name: &str) -> Option<&'static str> {
 
 /// A default type entry extracted from `x-wiki-types` in a schema.
 pub struct DefaultTypeEntry {
+    /// The type identifier (e.g. `"concept"`, `"paper"`).
     pub type_name: String,
+    /// Relative path to the schema file that defines this type (e.g. `"schemas/concept.json"`).
     pub schema_file: String,
+    /// Human-readable description of the type.
     pub description: String,
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -14,15 +14,22 @@ use crate::type_registry::SpaceTypeRegistry;
 
 /// All runtime state for a single mounted wiki space.
 pub struct SpaceContext {
+    /// Registered name of this wiki space.
     pub name: String,
+    /// Absolute path to the `wiki/` subdirectory containing Markdown pages.
     pub wiki_root: PathBuf,
+    /// Absolute path to the git repository root (parent of `wiki/`).
     pub repo_root: PathBuf,
+    /// Type registry compiled from the wiki's schema files.
     pub type_registry: SpaceTypeRegistry,
+    /// Tantivy index schema for this space.
     pub index_schema: IndexSchema,
+    /// Lifecycle manager for the Tantivy search index.
     pub index_manager: SpaceIndexManager,
 }
 
 impl SpaceContext {
+    /// Load and resolve the per-wiki config merged with `global`.
     pub fn resolved_config(&self, global: &GlobalConfig) -> ResolvedConfig {
         let wiki_cfg = config::load_wiki(&self.repo_root).unwrap_or_default();
         config::resolve(global, &wiki_cfg)
@@ -33,27 +40,35 @@ impl SpaceContext {
 
 /// Shared mutable state protected by [`WikiEngine`]'s `RwLock`.
 pub struct EngineState {
+    /// Loaded global configuration.
     pub config: GlobalConfig,
+    /// Absolute path to the global config file on disk.
     pub config_path: PathBuf,
+    /// Directory that holds per-wiki index state (parent of the config file).
     pub state_dir: PathBuf,
+    /// Map from wiki name to its mounted `SpaceContext`.
     pub spaces: HashMap<String, Arc<SpaceContext>>,
 }
 
 impl EngineState {
+    /// Return the configured default wiki name.
     pub fn default_wiki_name(&self) -> &str {
         &self.config.global.default_wiki
     }
 
+    /// Look up a mounted wiki space by name. Errors if not mounted.
     pub fn space(&self, name: &str) -> Result<&Arc<SpaceContext>> {
         self.spaces
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("wiki \"{name}\" is not mounted"))
     }
 
+    /// Return `explicit` if given, otherwise the default wiki name.
     pub fn resolve_wiki_name<'a>(&'a self, explicit: Option<&'a str>) -> &'a str {
         explicit.unwrap_or(self.default_wiki_name())
     }
 
+    /// Return the index directory path for a wiki by name.
     pub fn index_path_for(&self, wiki_name: &str) -> PathBuf {
         self.state_dir.join("indexes").join(wiki_name)
     }
@@ -65,10 +80,12 @@ impl EngineState {
 ///
 /// Cheap to clone (`Arc` inside). Safe to share across async tasks.
 pub struct WikiEngine {
+    /// Shared engine state protected by a reader-writer lock.
     pub state: Arc<RwLock<EngineState>>,
 }
 
 impl WikiEngine {
+    /// Build a `WikiEngine` from the global config at `config_path`, mounting all registered wikis.
     pub fn build(config_path: &Path) -> Result<Self> {
         let config = config::load_global(config_path)?;
         let state_dir = config_path.parent().unwrap_or(Path::new(".")).to_path_buf();
@@ -101,6 +118,7 @@ impl WikiEngine {
         })
     }
 
+    /// Incrementally update the index from git changes since the last indexed commit.
     pub fn refresh_index(&self, wiki_name: &str) -> Result<UpdateReport> {
         let engine = self
             .state
@@ -126,6 +144,7 @@ impl WikiEngine {
         Ok(report)
     }
 
+    /// Rebuild the search index from scratch by walking the wiki tree.
     pub fn rebuild_index(&self, wiki_name: &str) -> Result<IndexReport> {
         let engine = self
             .state

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -24,23 +24,29 @@ use crate::slug::Slug;
 /// A parsed markdown page — untyped frontmatter + body.
 #[derive(Debug, Clone)]
 pub struct ParsedPage {
+    /// Parsed YAML frontmatter key-value pairs.
     pub frontmatter: BTreeMap<String, Value>,
+    /// Markdown body text after the closing `---` delimiter.
     pub body: String,
 }
 
 impl ParsedPage {
+    /// Return the `title` frontmatter value, if present.
     pub fn title(&self) -> Option<&str> {
         self.frontmatter.get("title").and_then(|v| v.as_str())
     }
 
+    /// Return the `type` frontmatter value, if present.
     pub fn page_type(&self) -> Option<&str> {
         self.frontmatter.get("type").and_then(|v| v.as_str())
     }
 
+    /// Return the `status` frontmatter value, if present.
     pub fn status(&self) -> Option<&str> {
         self.frontmatter.get("status").and_then(|v| v.as_str())
     }
 
+    /// Return the `tags` list from frontmatter; empty if absent.
     pub fn tags(&self) -> Vec<&str> {
         self.frontmatter
             .get("tags")
@@ -49,12 +55,14 @@ impl ParsedPage {
             .unwrap_or_default()
     }
 
+    /// Return the `superseded_by` frontmatter value, if present.
     pub fn superseded_by(&self) -> Option<&str> {
         self.frontmatter
             .get("superseded_by")
             .and_then(|v| v.as_str())
     }
 
+    /// Return a YAML sequence field as a `Vec<&str>`; empty if absent or not a sequence.
     pub fn string_list(&self, key: &str) -> Vec<&str> {
         self.frontmatter
             .get(key)

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use git2::{Delta, Repository, Signature};
 use serde::{Deserialize, Serialize};
 
+/// Initialise a new git repository at `path`.
 pub fn init_repo(path: &Path) -> Result<()> {
     Repository::init(path)
         .with_context(|| format!("failed to init git repo at {}", path.display()))?;
@@ -80,9 +81,12 @@ pub fn current_head(repo_root: &Path) -> Option<String> {
 
 // ── Change detection ──────────────────────────────────────────────────────────
 
+/// A file that changed between git tree states.
 #[derive(Debug, Clone)]
 pub struct ChangedFile {
+    /// Repository-relative path of the changed file.
     pub path: PathBuf,
+    /// Git delta status (Added, Modified, Deleted, etc.).
     pub status: Delta,
 }
 
@@ -182,11 +186,16 @@ pub fn collect_changed_files(
 
 // ── Page history ──────────────────────────────────────────────────────────────
 
+/// A single entry from `git log` for a wiki page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryEntry {
+    /// Full commit SHA-1 hash.
     pub hash: String,
+    /// ISO-8601 author date string.
     pub date: String,
+    /// Commit subject line.
     pub message: String,
+    /// Author name.
     pub author: String,
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -20,42 +20,63 @@ use crate::type_registry::SpaceTypeRegistry;
 /// A node in the concept graph representing one wiki page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PageNode {
+    /// Slug identifying this page within its wiki.
     pub slug: String,
+    /// Display title of the page.
     pub title: String,
+    /// Frontmatter type of the page.
     pub r#type: String,
     /// True for cross-wiki placeholder nodes not present in the local index.
     #[serde(default)]
     pub external: bool,
 }
 
+/// A directed edge in the wiki concept graph with a relation label.
 #[derive(Debug, Clone)]
 pub struct LabeledEdge {
+    /// Relation label (e.g. `"links-to"`, `"cites"`, `"supersedes"`).
     pub relation: String,
 }
 
+/// Directed graph type used for the wiki concept graph.
 pub type WikiGraph = DiGraph<PageNode, LabeledEdge>;
 
+/// Filtering parameters for graph construction and subgraph extraction.
 #[derive(Debug, Clone, Default)]
 pub struct GraphFilter {
+    /// Root slug for subgraph extraction (None = full graph).
     pub root: Option<String>,
+    /// Maximum hop depth from root (None = use config default).
     pub depth: Option<usize>,
+    /// Page types to include (empty = all types).
     pub types: Vec<String>,
+    /// Edge relation label to filter on (None = all relations).
     pub relation: Option<String>,
 }
 
+/// Summary of a completed graph build or render operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphReport {
+    /// Total number of nodes in the graph.
     pub nodes: usize,
+    /// Total number of edges in the graph.
     pub edges: usize,
+    /// Rendered graph content (Mermaid, DOT, or LLM text).
     pub output: String,
 }
 
+/// Health metrics computed from a built wiki graph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphMetrics {
+    /// Total number of nodes.
     pub nodes: usize,
+    /// Total number of edges.
     pub edges: usize,
+    /// Number of nodes with no incoming or outgoing edges.
     pub orphans: usize,
+    /// Mean edge count per node (edges × 2 / nodes).
     pub avg_connections: f64,
+    /// Graph density: edges / (nodes × (nodes − 1)).
     pub density: f64,
 }
 
@@ -734,6 +755,7 @@ pub fn render_llms(graph: &WikiGraph) -> String {
 
 // ── render_mermaid ────────────────────────────────────────────────────────────
 
+/// Render the wiki graph as a Mermaid `graph LR` diagram.
 pub fn render_mermaid(graph: &WikiGraph) -> String {
     let mut out = String::from("graph LR\n");
 
@@ -799,6 +821,7 @@ fn mermaid_id(slug: &str) -> String {
 
 // ── render_dot ────────────────────────────────────────────────────────────────
 
+/// Render the wiki graph as a Graphviz DOT `digraph`.
 pub fn render_dot(graph: &WikiGraph) -> String {
     let mut out = String::from("digraph wiki {\n");
 
@@ -841,6 +864,7 @@ pub fn render_dot(graph: &WikiGraph) -> String {
 
 // ── wrap_graph_md ─────────────────────────────────────────────────────────────
 
+/// Wrap rendered graph content in a YAML frontmatter + code-fence Markdown document.
 pub fn wrap_graph_md(rendered: &str, format: &str, filter: &GraphFilter) -> String {
     let now = Utc::now().to_rfc3339();
     let root = filter.root.as_deref().unwrap_or("");
@@ -869,6 +893,7 @@ pub fn wrap_graph_md(rendered: &str, format: &str, filter: &GraphFilter) -> Stri
 
 // ── subgraph ──────────────────────────────────────────────────────────────────
 
+/// Extract a BFS subgraph rooted at `root_slug` up to `depth` hops in both directions.
 pub fn subgraph(graph: &WikiGraph, root_slug: &str, depth: usize) -> WikiGraph {
     let root_idx = match graph
         .node_indices()

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -20,50 +20,79 @@ use crate::type_registry::SpaceTypeRegistry;
 
 // ── Return types ──────────────────────────────────────────────────────────────
 
+/// Result of a full index rebuild.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexReport {
+    /// Name of the wiki that was indexed.
     pub wiki: String,
+    /// Number of pages successfully added to the index.
     pub pages_indexed: usize,
+    /// Number of files that were skipped due to read errors or invalid paths.
     pub skipped: usize,
+    /// Wall-clock time taken for the rebuild in milliseconds.
     pub duration_ms: u64,
 }
 
+/// Result of an incremental index update.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UpdateReport {
+    /// Number of pages added or re-indexed.
     pub updated: usize,
+    /// Number of pages removed from the index.
     pub deleted: usize,
 }
 
+/// Current health snapshot of a wiki's search index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexStatus {
+    /// Wiki name.
     pub wiki: String,
+    /// Absolute path to the search-index directory.
     pub path: String,
+    /// ISO-8601 timestamp of the last successful build, or None if never built.
     pub built: Option<String>,
+    /// Number of pages in the index.
     pub pages: usize,
+    /// Number of section pages in the index.
     pub sections: usize,
+    /// True if the index is behind the current HEAD commit or schema.
     pub stale: bool,
+    /// True if the index directory can be opened by Tantivy.
     pub openable: bool,
+    /// True if the index can be queried (reader opened successfully).
     pub queryable: bool,
 }
 
+/// Classification of index staleness used to choose the cheapest rebuild strategy.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StalenessKind {
+    /// Index matches current HEAD and schema — no rebuild needed.
     Current,
+    /// HEAD commit changed but schema is unchanged — incremental update sufficient.
     CommitChanged,
+    /// Only specific type schemas changed — partial rebuild of those types sufficient.
     TypesChanged(Vec<String>),
+    /// Schema changed in a way that requires a full rebuild.
     FullRebuildNeeded,
 }
 
 // ── state.toml ────────────────────────────────────────────────────────────────
 
+/// Persisted state written to `state.toml` alongside the Tantivy index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexState {
+    /// SHA-256 hash of the combined type registry, used for schema staleness detection.
     #[serde(default)]
     pub schema_hash: String,
+    /// ISO-8601 timestamp of when the index was last successfully built.
     pub built: String,
+    /// Number of pages in the index at last build.
     pub pages: usize,
+    /// Number of section pages in the index at last build.
     pub sections: usize,
+    /// Git HEAD commit hash at the time of the last build.
     pub commit: String,
+    /// Per-type content hashes at last build (type name → hash).
     #[serde(default)]
     pub types: std::collections::HashMap<String, String>,
 }
@@ -75,6 +104,7 @@ struct IndexInner {
     index_reader: Option<IndexReader>,
 }
 
+/// Tantivy index lifecycle manager for a single wiki space.
 pub struct SpaceIndexManager {
     wiki_name: String,
     index_path: PathBuf,
@@ -82,6 +112,7 @@ pub struct SpaceIndexManager {
 }
 
 impl SpaceIndexManager {
+    /// Create a new `SpaceIndexManager` for `wiki_name` with its index stored at `index_path`.
     pub fn new(wiki_name: impl Into<String>, index_path: impl Into<PathBuf>) -> Self {
         Self {
             wiki_name: wiki_name.into(),
@@ -93,10 +124,12 @@ impl SpaceIndexManager {
         }
     }
 
+    /// Return the absolute path to the index directory.
     pub fn index_path(&self) -> &Path {
         &self.index_path
     }
 
+    /// Return the wiki name this manager is associated with.
     pub fn wiki_name(&self) -> &str {
         &self.wiki_name
     }
@@ -193,6 +226,7 @@ impl SpaceIndexManager {
         }
     }
 
+    /// Return the git commit hash recorded in `state.toml` at the last index build, if any.
     pub fn last_commit(&self) -> Option<String> {
         let state_path = self.index_path.join("state.toml");
         let content = std::fs::read_to_string(&state_path).ok()?;
@@ -204,6 +238,7 @@ impl SpaceIndexManager {
         }
     }
 
+    /// Rebuild the full index by walking all Markdown files under `wiki_root`.
     pub fn rebuild(
         &self,
         wiki_root: &Path,
@@ -286,6 +321,7 @@ impl SpaceIndexManager {
         })
     }
 
+    /// Incrementally update the index for files changed since `last_indexed_commit`.
     pub fn update(
         &self,
         wiki_root: &Path,
@@ -337,6 +373,7 @@ impl SpaceIndexManager {
         Ok(UpdateReport { updated, deleted })
     }
 
+    /// Return the current index health status (staleness, page count, openability).
     pub fn status(&self, repo_root: &Path) -> Result<IndexStatus> {
         let state_path = self.index_path.join("state.toml");
         let search_dir = self.index_path.join("search-index");
@@ -396,6 +433,7 @@ impl SpaceIndexManager {
         })
     }
 
+    /// Delete all index documents whose `type` field equals `type_name`.
     pub fn delete_by_type(&self, is: &IndexSchema, type_name: &str) -> Result<()> {
         let mut writer = self.writer()?;
         let f_type = is.field("type");

--- a/src/index_schema.rs
+++ b/src/index_schema.rs
@@ -16,7 +16,9 @@ use crate::default_schemas;
 /// Schema content is kept — only the compiled tantivy schema and a
 /// field name → Field handle map.
 pub struct IndexSchema {
+    /// Compiled Tantivy schema.
     pub schema: Schema,
+    /// Map from field name to Tantivy `Field` handle.
     pub fields: HashMap<String, Field>,
     keyword_fields: HashSet<String>,
     numeric_fields: HashSet<String>,
@@ -75,14 +77,17 @@ impl IndexSchema {
         Ok(builder.finish())
     }
 
+    /// Return true if `name` is stored as a keyword (STRING | STORED | FAST) field.
     pub fn is_keyword(&self, name: &str) -> bool {
         self.keyword_fields.contains(name)
     }
 
+    /// Return true if `name` is stored as a numeric (f64 FAST) field.
     pub fn is_numeric(&self, name: &str) -> bool {
         self.numeric_fields.contains(name)
     }
 
+    /// Get a field handle by name. Panics if the field doesn't exist.
     pub fn field(&self, name: &str) -> Field {
         self.fields[name]
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -17,9 +17,12 @@ pub fn normalize_line_endings(input: &str) -> String {
     input.replace("\r\n", "\n").replace('\r', "\n")
 }
 
+/// Options controlling an ingest run.
 #[derive(Debug, Clone, Default)]
 pub struct IngestOptions {
+    /// Validate only — do not write to disk or commit.
     pub dry_run: bool,
+    /// Automatically commit validated files to git.
     pub auto_commit: bool,
     /// When `Some`, only files in this set are validated; others increment `unchanged_count`.
     /// When `None`, all files are validated.
@@ -28,18 +31,26 @@ pub struct IngestOptions {
     pub redact: Option<RedactConfig>,
 }
 
+/// Result of an ingest operation.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct IngestReport {
+    /// Number of Markdown pages that passed validation.
     pub pages_validated: usize,
+    /// Number of non-Markdown asset files discovered.
     pub assets_found: usize,
+    /// Validation warning messages (non-fatal).
     pub warnings: Vec<String>,
+    /// Git commit hash produced after ingest, or empty string if no commit was made.
     pub commit: String,
+    /// Number of files skipped because they were not in `changed_paths`.
     #[serde(default)]
     pub unchanged_count: usize,
+    /// Redaction reports for any files that had secrets removed.
     #[serde(default)]
     pub redacted: Vec<RedactionReport>,
 }
 
+/// Walk `path` (file or directory), validate, optionally redact, commit, and return a report.
 pub fn ingest(
     path: &Path,
     options: &IngestOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,25 +2,47 @@
 //! MCP and ACP transports. The CLI is the primary interface; this crate also
 //! exposes the engine internals for embedding or testing.
 
+/// ACP (Agent Client Protocol) transport and session handling.
 pub mod acp;
+/// CLI argument structs and subcommand enums.
 pub mod cli;
+/// Global and per-wiki configuration types and loaders.
 pub mod config;
+/// Embedded default JSON schemas and body templates.
 pub mod default_schemas;
+/// Central wiki engine — mounts spaces and manages indexes.
 pub mod engine;
+/// Frontmatter parsing, scaffolding, and serialization helpers.
 pub mod frontmatter;
+/// Git commit, history, and change-detection helpers.
 pub mod git;
+/// Concept graph construction, community detection, and renderers.
 pub mod graph;
+/// Tantivy index lifecycle manager for a single wiki space.
 pub mod index_manager;
+/// Tantivy schema builder and field classification.
 pub mod index_schema;
+/// File ingestion, validation, and optional redaction.
 pub mod ingest;
+/// Wikilink and cross-wiki link extraction and classification.
 pub mod links;
+/// Markdown page read/write, asset, and scaffolding helpers.
 pub mod markdown;
+/// MCP server and tool handlers.
 pub mod mcp;
+/// High-level operations called by CLI and server handlers.
 pub mod ops;
+/// Full-text BM25 search and paginated list operations.
 pub mod search;
+/// HTTP and stdio server entry points.
 pub mod server;
+/// Slug validation, resolution, and URI parsing.
 pub mod slug;
+/// Builds SpaceTypeRegistry and IndexSchema from schema files.
 pub mod space_builder;
+/// Wiki space creation, registration, and management.
 pub mod spaces;
+/// Per-wiki type registry — schema compilation and validation.
 pub mod type_registry;
+/// Filesystem watcher for auto-ingest on file save.
 pub mod watch;

--- a/src/links.rs
+++ b/src/links.rs
@@ -10,10 +10,16 @@ pub enum ParsedLink {
     /// Bare slug resolved within the current wiki.
     Local(String),
     /// `wiki://name/slug` URI resolved in another mounted wiki.
-    CrossWiki { wiki: String, slug: String },
+    CrossWiki {
+        /// Name of the target wiki in the `wiki://` URI.
+        wiki: String,
+        /// Slug within the target wiki.
+        slug: String,
+    },
 }
 
 impl ParsedLink {
+    /// Parse a raw link string into a `ParsedLink`, classifying `wiki://` URIs as `CrossWiki`.
     pub fn parse(s: &str) -> Self {
         if let Some(rest) = s.strip_prefix("wiki://")
             && let Some(slash) = rest.find('/')
@@ -26,6 +32,7 @@ impl ParsedLink {
         ParsedLink::Local(s.to_string())
     }
 
+    /// Return the slug portion of the link (local slug, or the slug segment of a cross-wiki URI).
     pub fn as_raw(&self) -> &str {
         match self {
             ParsedLink::Local(s) => s,

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ fn main() -> Result<()> {
                 } else {
                     let manager = WikiEngine::build(&config_path)?;
                     let engine = manager.state.read().map_err(|_| anyhow::anyhow!("lock"))?;
-                    let result_uri = ops::content_new(
+                    let result = ops::content_new(
                         &engine,
                         &uri,
                         cli.wiki.as_deref(),
@@ -208,7 +208,7 @@ fn main() -> Result<()> {
                         name.as_deref(),
                         r#type.as_deref(),
                     )?;
-                    println!("Created: {result_uri}");
+                    println!("Created: {}", result.uri);
                 }
             }
             ContentAction::Commit {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -11,6 +11,7 @@ use super::helpers::*;
 
 // ── Spaces ────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_spaces_create` — create a new wiki repository and register it.
 pub fn handle_spaces_create(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let path = arg_str_req(args, "path")?;
     let name = arg_str_req(args, "name")?;
@@ -44,6 +45,7 @@ pub fn handle_spaces_create(server: &McpServer, args: &Map<String, Value>) -> To
     ok_text(json)
 }
 
+/// Handle `wiki_spaces_list` — list registered wiki spaces.
 pub fn handle_spaces_list(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let name = arg_str(args, "name");
@@ -52,6 +54,7 @@ pub fn handle_spaces_list(server: &McpServer, args: &Map<String, Value>) -> Tool
     ok_text(s)
 }
 
+/// Handle `wiki_spaces_remove` — unregister (and optionally delete) a wiki space.
 pub fn handle_spaces_remove(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let name = arg_str_req(args, "name")?;
     let delete = arg_bool(args, "delete");
@@ -64,6 +67,7 @@ pub fn handle_spaces_remove(server: &McpServer, args: &Map<String, Value>) -> To
     ok_text(format!("Removed wiki \"{name}\""))
 }
 
+/// Handle `wiki_spaces_set_default` — set the default wiki space.
 pub fn handle_spaces_set_default(
     server: &McpServer,
     args: &Map<String, Value>,
@@ -80,6 +84,7 @@ pub fn handle_spaces_set_default(
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_config` — get, set, or list configuration values.
 pub fn handle_config(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let action = arg_str_req(args, "action")?;
     let engine = server.engine();
@@ -110,6 +115,7 @@ pub fn handle_config(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
 
 // ── Content ───────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_content_read` — read a page or list its co-located assets.
 pub fn handle_content_read(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let uri = arg_str_req(args, "uri")?;
     let engine = server.engine();
@@ -151,6 +157,7 @@ pub fn handle_content_read(server: &McpServer, args: &Map<String, Value>) -> Too
     }
 }
 
+/// Handle `wiki_content_write` — write content to a wiki page by slug or URI.
 pub fn handle_content_write(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let uri = arg_str_req(args, "uri")?;
     let content = arg_str_req(args, "content")?;
@@ -166,6 +173,7 @@ pub fn handle_content_write(server: &McpServer, args: &Map<String, Value>) -> To
     ))
 }
 
+/// Handle `wiki_content_new` — create a new page or section with scaffolded frontmatter.
 pub fn handle_content_new(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let uri = arg_str_req(args, "uri")?;
     let section = arg_bool(args, "section");
@@ -197,6 +205,7 @@ pub fn handle_content_new(server: &McpServer, args: &Map<String, Value>) -> Tool
     ok_text(s)
 }
 
+/// Handle `wiki_resolve` — resolve a slug or URI to its filesystem path.
 pub fn handle_resolve(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let uri = arg_str_req(args, "uri")?;
     let engine = server.engine();
@@ -229,6 +238,7 @@ pub fn handle_resolve(server: &McpServer, args: &Map<String, Value>) -> ToolHand
     ok_text(s)
 }
 
+/// Handle `wiki_content_commit` — commit pending changes to git.
 pub fn handle_content_commit(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
@@ -246,6 +256,7 @@ pub fn handle_content_commit(server: &McpServer, args: &Map<String, Value>) -> T
 
 // ── Search ────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_search` — BM25 full-text search across a wiki.
 pub fn handle_search(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let query = arg_str_req(args, "query")?;
     let cross_wiki = arg_bool(args, "cross_wiki");
@@ -277,6 +288,7 @@ pub fn handle_search(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
 
 // ── List ──────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_list` — paginated page listing with optional type/status filters.
 pub fn handle_list(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
@@ -302,6 +314,7 @@ pub fn handle_list(server: &McpServer, args: &Map<String, Value>) -> ToolHandler
 
 // ── Ingest ────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_ingest` — validate, redact, commit, and index files in the wiki tree.
 pub fn handle_ingest(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let path = arg_str_req(args, "path")?;
     let dry_run = arg_bool(args, "dry_run");
@@ -334,6 +347,7 @@ pub fn handle_ingest(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
 
 // ── Index ─────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_index_rebuild` — rebuild the tantivy search index from scratch.
 pub fn handle_index_rebuild(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let wiki_name = {
         let engine = server.engine();
@@ -345,6 +359,7 @@ pub fn handle_index_rebuild(server: &McpServer, args: &Map<String, Value>) -> To
     ok_text(s)
 }
 
+/// Handle `wiki_index_status` — report health and staleness of the search index.
 pub fn handle_index_status(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
@@ -356,6 +371,7 @@ pub fn handle_index_status(server: &McpServer, args: &Map<String, Value>) -> Too
 
 // ── Graph ─────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_graph` — build and render the concept graph.
 pub fn handle_graph(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
@@ -380,6 +396,7 @@ pub fn handle_graph(server: &McpServer, args: &Map<String, Value>) -> ToolHandle
 
 // ── History ───────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_history` — return git commit history for a page slug.
 pub fn handle_history(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let slug = arg_str_req(args, "slug")?;
     let limit = arg_usize(args, "limit");
@@ -393,6 +410,7 @@ pub fn handle_history(server: &McpServer, args: &Map<String, Value>) -> ToolHand
     ok_text(s)
 }
 
+/// Handle `wiki_stats` — return aggregate health and coverage stats for a wiki.
 pub fn handle_stats(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
@@ -401,6 +419,7 @@ pub fn handle_stats(server: &McpServer, args: &Map<String, Value>) -> ToolHandle
     ok_text(s)
 }
 
+/// Handle `wiki_lint` — run deterministic lint rules and return findings.
 pub fn handle_lint(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let engine = server.engine();
     let wiki_name = resolve_wiki_name(&engine, args)?;
@@ -412,6 +431,7 @@ pub fn handle_lint(server: &McpServer, args: &Map<String, Value>) -> ToolHandler
     ok_text(s)
 }
 
+/// Handle `wiki_suggest` — suggest related pages to link from a given slug.
 pub fn handle_suggest(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let slug = arg_str_req(args, "slug")?;
     let limit = arg_usize(args, "limit");
@@ -423,6 +443,7 @@ pub fn handle_suggest(server: &McpServer, args: &Map<String, Value>) -> ToolHand
     ok_text(s)
 }
 
+/// Handle `wiki_schema` — list, show, add, remove, or validate type schemas.
 pub fn handle_schema(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let action = arg_str(args, "action").ok_or("action is required")?;
     let engine = server.engine();
@@ -506,6 +527,7 @@ pub fn handle_schema(server: &McpServer, args: &Map<String, Value>) -> ToolHandl
 
 // ── Export ────────────────────────────────────────────────────────────────────
 
+/// Handle `wiki_export` — export the full wiki to llms.txt, llms-full, or JSON.
 pub fn handle_export(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
     let wiki = arg_str_req(args, "wiki")?;
     let engine = server.engine();

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1,7 +1,10 @@
+use std::path::PathBuf;
+
 use rmcp::model::Content;
 use serde_json::{Map, Value};
 
 use crate::ops;
+use crate::slug::{ReadTarget, WikiUri, resolve_read_target};
 
 use super::McpServer;
 use super::helpers::*;
@@ -126,7 +129,6 @@ pub fn handle_content_read(server: &McpServer, args: &Map<String, Value>) -> Too
     {
         ops::ContentReadResult::Page(content) => {
             if include_backlinks {
-                use crate::slug::WikiUri;
                 let wiki_name = engine.resolve_wiki_name(wiki_flag.as_deref()).to_string();
                 let (_entry, slug) = WikiUri::resolve(&uri, wiki_flag.as_deref(), &engine.config)
                     .map_err(|e| format!("{e}"))?;
@@ -174,7 +176,7 @@ pub fn handle_content_new(server: &McpServer, args: &Map<String, Value>) -> Tool
     let engine = server.engine();
     let wiki_flag = arg_str(args, "wiki");
 
-    let result_uri = ops::content_new(
+    let result = ops::content_new(
         &engine,
         &uri,
         wiki_flag.as_deref(),
@@ -184,7 +186,47 @@ pub fn handle_content_new(server: &McpServer, args: &Map<String, Value>) -> Tool
         type_.as_deref(),
     )
     .map_err(|e| format!("{e}"))?;
-    ok_text(result_uri)
+    let s = serde_json::to_string_pretty(&serde_json::json!({
+        "uri":       result.uri,
+        "slug":      result.slug,
+        "path":      result.path,
+        "wiki_root": result.wiki_root,
+        "bundle":    result.bundle,
+    }))
+    .map_err(|e| format!("{e}"))?;
+    ok_text(s)
+}
+
+pub fn handle_resolve(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {
+    let uri = arg_str_req(args, "uri")?;
+    let engine = server.engine();
+    let wiki_flag = arg_str(args, "wiki");
+
+    let (entry, slug) =
+        WikiUri::resolve(&uri, wiki_flag.as_deref(), &engine.config).map_err(|e| format!("{e}"))?;
+    let wiki_root = PathBuf::from(&entry.path).join("wiki");
+
+    let (path, exists, bundle) = match resolve_read_target(slug.as_str(), &wiki_root) {
+        Ok(ReadTarget::Page(p)) => {
+            let bundle = p.ends_with("index.md");
+            (p, true, bundle)
+        }
+        _ => {
+            let p = wiki_root.join(format!("{}.md", slug.as_str()));
+            (p, false, false)
+        }
+    };
+
+    let s = serde_json::to_string_pretty(&serde_json::json!({
+        "slug":      slug.as_str(),
+        "wiki":      entry.name,
+        "wiki_root": wiki_root,
+        "path":      path,
+        "exists":    exists,
+        "bundle":    bundle,
+    }))
+    .map_err(|e| format!("{e}"))?;
+    ok_text(s)
 }
 
 pub fn handle_content_commit(server: &McpServer, args: &Map<String, Value>) -> ToolHandlerResult {

--- a/src/mcp/helpers.rs
+++ b/src/mcp/helpers.rs
@@ -8,41 +8,53 @@ use crate::slug::Slug;
 
 // ── ToolResult ────────────────────────────────────────────────────────────────
 
+/// The unified return value from an MCP tool call.
 pub struct ToolResult {
+    /// MCP content blocks to return to the client.
     pub content: Vec<Content>,
+    /// True if the tool call encountered an error.
     pub is_error: bool,
+    /// `wiki://` URIs whose resource content has changed (triggers `resources/updated`).
     pub notify_uris: Vec<String>,
+    /// True if the resource list has changed (triggers `resources/list_changed`).
     pub notify_resources_changed: bool,
 }
 
 // ── Handler result type ───────────────────────────────────────────────────────
 
+/// Return type for individual MCP tool handler functions: `(content, notify_uris)` or an error string.
 pub type ToolHandlerResult = Result<(Vec<Content>, Vec<String>), String>;
 
+/// Wrap a plain text string as a successful `ToolHandlerResult` with no URI notifications.
 pub fn ok_text(text: String) -> ToolHandlerResult {
     Ok((vec![Content::text(text)], vec![]))
 }
 
+/// Wrap an error message as an MCP content block with `"error: "` prefix.
 pub fn err_text(msg: String) -> Vec<Content> {
     vec![Content::text(format!("error: {msg}"))]
 }
 
 // ── Argument helpers ──────────────────────────────────────────────────────────
 
+/// Extract an optional string argument by key from tool call arguments.
 pub fn arg_str(args: &Map<String, Value>, key: &str) -> Option<String> {
     args.get(key)
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
 
+/// Extract a required string argument by key, returning an error string if absent.
 pub fn arg_str_req(args: &Map<String, Value>, key: &str) -> Result<String, String> {
     arg_str(args, key).ok_or_else(|| format!("missing required parameter: {key}"))
 }
 
+/// Extract a boolean argument by key; returns `false` if absent or not a boolean.
 pub fn arg_bool(args: &Map<String, Value>, key: &str) -> bool {
     args.get(key).and_then(|v| v.as_bool()).unwrap_or(false)
 }
 
+/// Extract an optional unsigned integer argument by key.
 pub fn arg_usize(args: &Map<String, Value>, key: &str) -> Option<usize> {
     args.get(key).and_then(|v| v.as_u64()).map(|n| n as usize)
 }
@@ -61,6 +73,7 @@ pub fn resolve_wiki_name(
 
 // ── Resource notification helper ──────────────────────────────────────────────
 
+/// Collect `wiki://` URIs for all Markdown files under `path` (file or directory).
 pub fn collect_page_uris(path: &Path, wiki_root: &Path, wiki_name: &str) -> Vec<String> {
     if path.is_file() {
         if path.extension().and_then(|e| e.to_str()) == Some("md")

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,5 +1,8 @@
+/// MCP tool handler functions.
 pub mod handlers;
+/// MCP helper utilities — argument extraction and tool result types.
 pub mod helpers;
+/// MCP tool definitions and dispatch table.
 pub mod tools;
 
 use std::future::Future;
@@ -21,16 +24,20 @@ use crate::slug::{Slug, WikiUri};
 
 // ── McpServer ─────────────────────────────────────────────────────────────────
 
+/// MCP server — dispatches MCP tool calls and resource reads to the wiki engine.
 #[derive(Clone)]
 pub struct McpServer {
+    /// Shared wiki engine handle.
     pub manager: Arc<WikiEngine>,
 }
 
 impl McpServer {
+    /// Create a new `McpServer` wrapping `manager`.
     pub fn new(manager: Arc<WikiEngine>) -> Self {
         Self { manager }
     }
 
+    /// Acquire a read guard on the engine state.
     pub fn engine(&self) -> std::sync::RwLockReadGuard<'_, EngineState> {
         self.manager.state.read().expect("engine lock poisoned")
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -40,6 +40,7 @@ fn opt_int(desc: &str) -> Value {
 
 // ── Tool definitions (22 tools) ───────────────────────────────────────────────
 
+/// Return the complete list of MCP tool definitions for registration.
 pub fn tool_list() -> Vec<Tool> {
     vec![
         Tool::new(
@@ -329,6 +330,7 @@ pub fn tool_list() -> Vec<Tool> {
 
 // ── Dispatch ──────────────────────────────────────────────────────────────────
 
+/// Dispatch a tool call by name to the appropriate handler, catching panics.
 pub fn call(server: &McpServer, name: &str, args: &Map<String, Value>) -> ToolResult {
     let _span = tracing::info_span!("tool_call", tool = name).entered();
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match name {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -38,7 +38,7 @@ fn opt_int(desc: &str) -> Value {
     json!({"type": "integer", "description": desc})
 }
 
-// ── Tool definitions (20 tools) ───────────────────────────────────────────────
+// ── Tool definitions (22 tools) ───────────────────────────────────────────────
 
 pub fn tool_list() -> Vec<Tool> {
     vec![
@@ -297,6 +297,17 @@ pub fn tool_list() -> Vec<Tool> {
             ),
         ),
         Tool::new(
+            "wiki_resolve",
+            "Resolve a slug or wiki:// URI to its local filesystem path. Use before writing content directly to disk.",
+            schema(
+                json!({
+                    "uri": str_prop("Slug or wiki:// URI"),
+                    "wiki": opt_str("Target wiki name (optional, uses default)"),
+                }),
+                &["uri"],
+            ),
+        ),
+        Tool::new(
             "wiki_schema",
             "Inspect and manage type schemas",
             schema(
@@ -339,6 +350,7 @@ pub fn call(server: &McpServer, name: &str, args: &Map<String, Value>) -> ToolRe
         "wiki_history" => handlers::handle_history(server, args),
         "wiki_stats" => handlers::handle_stats(server, args),
         "wiki_lint" => handlers::handle_lint(server, args),
+        "wiki_resolve" => handlers::handle_resolve(server, args),
         "wiki_suggest" => handlers::handle_suggest(server, args),
         "wiki_schema" => handlers::handle_schema(server, args),
         "wiki_export" => handlers::handle_export(server, args),

--- a/src/ops/config.rs
+++ b/src/ops/config.rs
@@ -5,12 +5,14 @@ use anyhow::Result;
 use crate::config::{self, WikiConfig};
 use crate::spaces;
 
+/// Read a single config key from the resolved global config.
 pub fn config_get(config_path: &Path, key: &str) -> Result<String> {
     let g = config::load_global(config_path)?;
     let resolved = config::resolve(&g, &WikiConfig::default());
     Ok(config::get_config_value(&resolved, &g, key))
 }
 
+/// Set a config key in either the global or wiki-level config file.
 pub fn config_set(
     config_path: &Path,
     key: &str,
@@ -35,11 +37,13 @@ pub fn config_set(
     }
 }
 
+/// Serialize the global config to a TOML string.
 pub fn config_list_global(config_path: &Path) -> Result<String> {
     let g = config::load_global(config_path)?;
     Ok(toml::to_string_pretty(&g)?)
 }
 
+/// Return the fully resolved config (global defaults merged with wiki overrides).
 pub fn config_list_resolved(config_path: &Path) -> Result<config::ResolvedConfig> {
     let g = config::load_global(config_path)?;
     Ok(config::resolve(&g, &WikiConfig::default()))

--- a/src/ops/content.rs
+++ b/src/ops/content.rs
@@ -15,12 +15,16 @@ use crate::index_schema::IndexSchema;
 use crate::markdown;
 use crate::slug::{ReadTarget, Slug, WikiUri, resolve_read_target};
 
+/// A page that links to a given target — slug and display title.
 #[derive(Debug, Clone, Serialize)]
 pub struct BacklinkRef {
+    /// Slug of the linking page.
     pub slug: String,
+    /// Title of the linking page.
     pub title: String,
 }
 
+/// Query the index for all pages that contain a link to `target_slug`.
 pub fn backlinks_query(
     searcher: &Searcher,
     is: &IndexSchema,
@@ -61,6 +65,7 @@ pub fn backlinks_query(
     Ok(refs)
 }
 
+/// Return all pages linking to `target_slug` in the named wiki.
 pub fn backlinks_for(
     engine: &EngineState,
     wiki_name: &str,
@@ -71,12 +76,17 @@ pub fn backlinks_for(
     backlinks_query(&searcher, &space.index_schema, target_slug)
 }
 
+/// Result of a content read — page text, asset list, or binary asset.
 pub enum ContentReadResult {
+    /// Page markdown content (possibly with frontmatter stripped).
     Page(String),
+    /// List of co-located asset filenames.
     Assets(Vec<String>),
+    /// The resolved target is a binary file — read it directly from disk.
     Binary,
 }
 
+/// Read a wiki page or list its co-located assets.
 pub fn content_read(
     engine: &EngineState,
     uri: &str,
@@ -111,11 +121,15 @@ pub fn content_read(
     }
 }
 
+/// Result of a content write operation.
 pub struct WriteResult {
+    /// Number of bytes written to disk.
     pub bytes_written: usize,
+    /// Absolute path of the written file.
     pub path: PathBuf,
 }
 
+/// Write content to a wiki page identified by slug or URI.
 pub fn content_write(
     engine: &EngineState,
     uri: &str,
@@ -131,14 +145,21 @@ pub fn content_write(
     })
 }
 
+/// Result of creating a new wiki page or section.
 pub struct ContentNewResult {
+    /// `wiki://` URI for the created page.
     pub uri: String,
+    /// Slug of the created page.
     pub slug: String,
+    /// Absolute filesystem path of the created file.
     pub path: PathBuf,
+    /// Absolute path to the wiki root directory.
     pub wiki_root: PathBuf,
+    /// True if the page was created as a bundle (folder + index.md).
     pub bundle: bool,
 }
 
+/// Create a new wiki page or section with scaffolded frontmatter.
 pub fn content_new(
     engine: &EngineState,
     uri: &str,
@@ -193,6 +214,7 @@ fn resolve_body_template(repo_root: &Path, type_name: &str) -> Option<String> {
     crate::default_schemas::embedded_body_template(type_name).map(|s| s.to_string())
 }
 
+/// Commit specified slugs (or all uncommitted files) to git and return the commit hash.
 pub fn content_commit(
     engine: &EngineState,
     wiki_name: &str,

--- a/src/ops/content.rs
+++ b/src/ops/content.rs
@@ -131,6 +131,14 @@ pub fn content_write(
     })
 }
 
+pub struct ContentNewResult {
+    pub uri: String,
+    pub slug: String,
+    pub path: PathBuf,
+    pub wiki_root: PathBuf,
+    pub bundle: bool,
+}
+
 pub fn content_new(
     engine: &EngineState,
     uri: &str,
@@ -139,7 +147,7 @@ pub fn content_new(
     bundle: bool,
     name: Option<&str>,
     type_: Option<&str>,
-) -> Result<String> {
+) -> Result<ContentNewResult> {
     let (entry, slug) = WikiUri::resolve(uri, wiki_flag, &engine.config)?;
     let repo_root = PathBuf::from(&entry.path);
     let wiki_root = repo_root.join("wiki");
@@ -151,8 +159,8 @@ pub fn content_new(
     };
     let body_template = resolve_body_template(&repo_root, type_name);
 
-    if section {
-        markdown::create_section(&slug, &wiki_root, body_template.as_deref())?;
+    let path = if section {
+        markdown::create_section(&slug, &wiki_root, body_template.as_deref())?
     } else {
         markdown::create_page(
             &slug,
@@ -161,9 +169,16 @@ pub fn content_new(
             name,
             type_,
             body_template.as_deref(),
-        )?;
-    }
-    Ok(format!("wiki://{}/{slug}", entry.name))
+        )?
+    };
+
+    Ok(ContentNewResult {
+        uri: format!("wiki://{}/{slug}", entry.name),
+        slug: slug.as_str().to_string(),
+        path,
+        wiki_root,
+        bundle,
+    })
 }
 
 /// Resolve a body template for a type.

--- a/src/ops/export.rs
+++ b/src/ops/export.rs
@@ -12,25 +12,33 @@ use crate::index_schema::IndexSchema;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/// Options controlling the wiki export operation.
 #[derive(Debug, Clone)]
 pub struct ExportOptions {
+    /// Name of the wiki to export.
     pub wiki: String,
     /// Output path — resolved against wiki root if relative.
     pub path: Option<String>,
+    /// Output format: llms-txt, llms-full, or JSON.
     pub format: ExportFormat,
     /// Whether to include archived pages (default: false).
     pub include_archived: bool,
 }
 
+/// Supported wiki export formats.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum ExportFormat {
+    /// Compact llms.txt listing with titles and summaries.
     #[default]
     LlmsTxt,
+    /// Full llms.txt with complete page bodies.
     LlmsFull,
+    /// JSON array of page entries with metadata and bodies.
     Json,
 }
 
 impl ExportFormat {
+    /// Return the canonical string representation of the format.
     pub fn as_str(&self) -> &'static str {
         match self {
             ExportFormat::LlmsTxt => "llms-txt",
@@ -39,6 +47,7 @@ impl ExportFormat {
         }
     }
 
+    /// Parse a format string; falls back to `LlmsTxt` for unrecognised input.
     pub fn parse(s: &str) -> Self {
         match s {
             "llms-full" => ExportFormat::LlmsFull,
@@ -48,11 +57,16 @@ impl ExportFormat {
     }
 }
 
+/// Summary of a completed wiki export.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportReport {
+    /// Absolute path of the written output file.
     pub path: String,
+    /// Number of pages written to the output.
     pub pages_written: usize,
+    /// Total bytes written.
     pub bytes: usize,
+    /// Name of the format used (e.g. `"llms-txt"`).
     pub format: String,
 }
 
@@ -71,6 +85,7 @@ struct PageEntry {
 
 // ── export ────────────────────────────────────────────────────────────────────
 
+/// Export a wiki to a file in the requested format.
 pub fn export(engine: &EngineState, options: &ExportOptions) -> Result<ExportReport> {
     let space = engine.space(&options.wiki)?;
     let wiki_root = &space.wiki_root;

--- a/src/ops/graph.rs
+++ b/src/ops/graph.rs
@@ -3,21 +3,33 @@ use anyhow::Result;
 use crate::engine::EngineState;
 use crate::graph;
 
+/// Rendered graph output plus the associated report.
 pub struct GraphResult {
+    /// Rendered graph string (Mermaid, DOT, or llms format).
     pub rendered: String,
+    /// Metadata about the generated graph.
     pub report: graph::GraphReport,
 }
 
+/// Parameters for `graph_build`.
 pub struct GraphParams<'a> {
+    /// Output format: `"mermaid"`, `"dot"`, or `"llms"`.
     pub format: Option<&'a str>,
+    /// Slug of the root node for a subgraph traversal.
     pub root: Option<String>,
+    /// Maximum hops from root.
     pub depth: Option<usize>,
+    /// Comma-separated page types to include.
     pub type_filter: Option<&'a str>,
+    /// Filter edges by this relation label.
     pub relation: Option<String>,
+    /// File path to write output to; `None` for returning only.
     pub output: Option<&'a str>,
+    /// If true, merge all mounted wikis into a single graph.
     pub cross_wiki: bool,
 }
 
+/// Build and render the concept graph according to `params`.
 pub fn graph_build(
     engine: &EngineState,
     wiki_name: &str,

--- a/src/ops/history.rs
+++ b/src/ops/history.rs
@@ -5,12 +5,16 @@ use crate::engine::EngineState;
 use crate::git;
 use crate::slug::{Slug, WikiUri};
 
+/// Git history for a single page — slug and log entries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryResult {
+    /// Slug of the page whose history was fetched.
     pub slug: String,
+    /// Ordered list of git commit entries (most recent first).
     pub entries: Vec<git::HistoryEntry>,
 }
 
+/// Return git commit history for a page slug or `wiki://` URI.
 pub fn history(
     engine: &EngineState,
     slug_or_uri: &str,

--- a/src/ops/index.rs
+++ b/src/ops/index.rs
@@ -3,10 +3,12 @@ use anyhow::Result;
 use crate::engine::{EngineState, WikiEngine};
 use crate::index_manager;
 
+/// Tear down and rebuild the tantivy index for the named wiki.
 pub fn index_rebuild(manager: &WikiEngine, wiki_name: &str) -> Result<index_manager::IndexReport> {
     manager.rebuild_index(wiki_name)
 }
 
+/// Return the health and staleness status of the named wiki's index.
 pub fn index_status(engine: &EngineState, wiki_name: &str) -> Result<index_manager::IndexStatus> {
     let space = engine.space(wiki_name)?;
     space.index_manager.status(&space.repo_root)

--- a/src/ops/ingest.rs
+++ b/src/ops/ingest.rs
@@ -7,6 +7,7 @@ use crate::engine::{EngineState, WikiEngine};
 use crate::git;
 use crate::ingest;
 
+/// Ingest a path without redaction; delegates to `ingest_with_redact`.
 pub fn ingest(
     engine: &EngineState,
     manager: &WikiEngine,
@@ -17,6 +18,7 @@ pub fn ingest(
     ingest_with_redact(engine, manager, path, dry_run, false, wiki_name)
 }
 
+/// Ingest a path with optional redaction pass, incremental index refresh, and edge validation.
 pub fn ingest_with_redact(
     engine: &EngineState,
     manager: &WikiEngine,

--- a/src/ops/lint.rs
+++ b/src/ops/lint.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::path::Path;
 
 use anyhow::Result;
 use serde::Serialize;
@@ -11,6 +12,7 @@ use tantivy::{
 
 use crate::engine::EngineState;
 use crate::index_schema::IndexSchema;
+use crate::slug::Slug;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -34,6 +36,7 @@ pub struct LintFinding {
     pub rule: &'static str,
     pub severity: Severity,
     pub message: String,
+    pub path: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -73,34 +76,47 @@ pub fn run_lint(
     let is = &space.index_schema;
     let resolved = space.resolved_config(&engine.config);
     let lint_cfg = &resolved.lint;
+    let wiki_root = &space.wiki_root;
 
     let mut findings: Vec<LintFinding> = Vec::new();
 
     if active_rules.contains("orphan") {
-        findings.extend(rule_orphan(&searcher, is)?);
+        findings.extend(rule_orphan(&searcher, is, wiki_root)?);
     }
     if active_rules.contains("broken-link") || active_rules.contains("broken-cross-wiki-link") {
         let mounted: HashSet<String> = engine.spaces.keys().cloned().collect();
         findings.extend(rule_broken_link(
             &searcher,
             is,
+            wiki_root,
             active_rules.contains("broken-cross-wiki-link"),
             &mounted,
         )?);
     }
     if active_rules.contains("missing-fields") {
-        findings.extend(rule_missing_fields(&searcher, is, &space.type_registry)?);
+        findings.extend(rule_missing_fields(
+            &searcher,
+            is,
+            wiki_root,
+            &space.type_registry,
+        )?);
     }
     if active_rules.contains("stale") {
         findings.extend(rule_stale(
             &searcher,
             is,
+            wiki_root,
             lint_cfg.stale_days,
             lint_cfg.stale_confidence_threshold,
         )?);
     }
     if active_rules.contains("unknown-type") {
-        findings.extend(rule_unknown_type(&searcher, is, &space.type_registry)?);
+        findings.extend(rule_unknown_type(
+            &searcher,
+            is,
+            wiki_root,
+            &space.type_registry,
+        )?);
     }
 
     // Apply severity filter
@@ -130,9 +146,24 @@ pub fn run_lint(
     })
 }
 
+/// Resolve a slug to its filesystem path string. Probes flat then bundle;
+/// falls back to the would-be flat path if the file doesn't exist yet.
+fn slug_path(slug: &str, wiki_root: &Path) -> String {
+    Slug::try_from(slug)
+        .ok()
+        .and_then(|s| s.resolve(wiki_root).ok())
+        .unwrap_or_else(|| wiki_root.join(format!("{slug}.md")))
+        .to_string_lossy()
+        .into_owned()
+}
+
 // ── Rule: orphan ──────────────────────────────────────────────────────────────
 
-fn rule_orphan(searcher: &tantivy::Searcher, is: &IndexSchema) -> Result<Vec<LintFinding>> {
+fn rule_orphan(
+    searcher: &tantivy::Searcher,
+    is: &IndexSchema,
+    wiki_root: &Path,
+) -> Result<Vec<LintFinding>> {
     let f_slug = is.field("slug");
     let f_type = is.field("type");
 
@@ -189,6 +220,7 @@ fn rule_orphan(searcher: &tantivy::Searcher, is: &IndexSchema) -> Result<Vec<Lin
 
         if !all_linked.contains(&slug) {
             findings.push(LintFinding {
+                path: slug_path(&slug, wiki_root),
                 slug,
                 rule: "orphan",
                 severity: Severity::Warning,
@@ -213,6 +245,7 @@ fn slug_exists(searcher: &tantivy::Searcher, is: &IndexSchema, slug: &str) -> Re
 fn rule_broken_link(
     searcher: &tantivy::Searcher,
     is: &IndexSchema,
+    wiki_root: &Path,
     check_cross_wiki: bool,
     mounted_wiki_names: &HashSet<String>,
 ) -> Result<Vec<LintFinding>> {
@@ -258,6 +291,7 @@ fn rule_broken_link(
                         && !mounted_wiki_names.contains(wiki_name)
                     {
                         findings.push(LintFinding {
+                            path: slug_path(&slug, wiki_root),
                             slug: slug.clone(),
                             rule: "broken-cross-wiki-link",
                             severity: Severity::Warning,
@@ -268,6 +302,7 @@ fn rule_broken_link(
                 }
                 if !slug_exists(searcher, is, target)? {
                     findings.push(LintFinding {
+                        path: slug_path(&slug, wiki_root),
                         slug: slug.clone(),
                         rule: "broken-link",
                         severity: Severity::Error,
@@ -286,6 +321,7 @@ fn rule_broken_link(
 fn rule_missing_fields(
     searcher: &tantivy::Searcher,
     is: &IndexSchema,
+    wiki_root: &Path,
     registry: &crate::type_registry::SpaceTypeRegistry,
 ) -> Result<Vec<LintFinding>> {
     let f_slug = is.field("slug");
@@ -326,6 +362,7 @@ fn rule_missing_fields(
             };
             if !present {
                 findings.push(LintFinding {
+                    path: slug_path(&slug, wiki_root),
                     slug: slug.clone(),
                     rule: "missing-fields",
                     severity: Severity::Error,
@@ -343,6 +380,7 @@ fn rule_missing_fields(
 fn rule_stale(
     searcher: &tantivy::Searcher,
     is: &IndexSchema,
+    wiki_root: &Path,
     stale_days: u32,
     stale_confidence_threshold: f32,
 ) -> Result<Vec<LintFinding>> {
@@ -405,6 +443,7 @@ fn rule_stale(
                 format!("last updated {date_str}")
             };
             findings.push(LintFinding {
+                path: slug_path(&slug, wiki_root),
                 slug,
                 rule: "stale",
                 severity: Severity::Warning,
@@ -421,6 +460,7 @@ fn rule_stale(
 fn rule_unknown_type(
     searcher: &tantivy::Searcher,
     is: &IndexSchema,
+    wiki_root: &Path,
     registry: &crate::type_registry::SpaceTypeRegistry,
 ) -> Result<Vec<LintFinding>> {
     let f_slug = is.field("slug");
@@ -446,6 +486,7 @@ fn rule_unknown_type(
         }
         if !registry.is_known(page_type) {
             findings.push(LintFinding {
+                path: slug_path(&slug, wiki_root),
                 slug,
                 rule: "unknown-type",
                 severity: Severity::Error,

--- a/src/ops/lint.rs
+++ b/src/ops/lint.rs
@@ -14,10 +14,13 @@ use crate::engine::EngineState;
 use crate::index_schema::IndexSchema;
 use crate::slug::Slug;
 
+/// Severity level of a lint finding.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
+    /// A definite problem that should be fixed.
     Error,
+    /// A potential issue that may warrant attention.
     Warning,
 }
 
@@ -30,21 +33,33 @@ impl std::fmt::Display for Severity {
     }
 }
 
+/// A single lint finding for a wiki page.
 #[derive(Debug, Clone, Serialize)]
 pub struct LintFinding {
+    /// Slug of the page with the finding.
     pub slug: String,
+    /// Name of the lint rule that produced this finding.
     pub rule: &'static str,
+    /// Severity of the finding.
     pub severity: Severity,
+    /// Human-readable description of the issue.
     pub message: String,
+    /// Filesystem path of the page file.
     pub path: String,
 }
 
+/// Aggregate results of a lint run against a wiki.
 #[derive(Debug, Clone, Serialize)]
 pub struct LintReport {
+    /// Name of the wiki that was linted.
     pub wiki: String,
+    /// Total number of findings (errors + warnings).
     pub total: usize,
+    /// Number of error-severity findings.
     pub errors: usize,
+    /// Number of warning-severity findings.
     pub warnings: usize,
+    /// Individual lint findings, sorted by slug then rule.
     pub findings: Vec<LintFinding>,
 }
 

--- a/src/ops/logs.rs
+++ b/src/ops/logs.rs
@@ -4,11 +4,13 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
 
+/// Return the path to the log directory (sibling of the config file).
 pub fn logs_path(config_path: &Path) -> PathBuf {
     let state_dir = config_path.parent().unwrap_or(Path::new("."));
     state_dir.join("logs")
 }
 
+/// Return the last `lines` lines from the most recent log file.
 pub fn logs_tail(config_path: &Path, lines: usize) -> Result<String> {
     let log_dir = logs_path(config_path);
     if !log_dir.exists() {
@@ -23,6 +25,7 @@ pub fn logs_tail(config_path: &Path, lines: usize) -> Result<String> {
     Ok(all_lines[start..].join("\n"))
 }
 
+/// Delete all log files and return the number removed.
 pub fn logs_clear(config_path: &Path) -> Result<usize> {
     let log_dir = logs_path(config_path);
     if !log_dir.exists() {
@@ -40,6 +43,7 @@ pub fn logs_clear(config_path: &Path) -> Result<usize> {
     Ok(removed)
 }
 
+/// List log file names sorted by name.
 pub fn logs_list(config_path: &Path) -> Result<Vec<String>> {
     let log_dir = logs_path(config_path);
     if !log_dir.exists() {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,5 +1,6 @@
 mod config;
 mod content;
+/// Wiki export operations — llms.txt, llms-full, and JSON export formats.
 pub mod export;
 mod graph;
 mod history;
@@ -7,6 +8,7 @@ mod index;
 mod ingest;
 mod lint;
 mod logs;
+/// Redaction pass — strip PII and confidential values from page bodies.
 pub mod redact;
 mod schema;
 mod search;

--- a/src/ops/redact.rs
+++ b/src/ops/redact.rs
@@ -9,16 +9,21 @@ use crate::config::RedactConfig;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/// A single secret match found during a redaction pass.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RedactionMatch {
+    /// Name of the pattern that triggered the match.
     pub pattern_name: String,
+    /// 1-based line number where the match was found.
     pub line_number: usize,
 }
 
 /// Report of all redaction substitutions applied to a single page body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RedactionReport {
+    /// Slug of the page that was redacted.
     pub slug: String,
+    /// All matches found (and replaced) in this page.
     pub matches: Vec<RedactionMatch>,
 }
 

--- a/src/ops/schema.rs
+++ b/src/ops/schema.rs
@@ -10,13 +10,18 @@ use crate::markdown;
 use crate::search;
 use crate::space_builder;
 
+/// A registered page type with its schema location and description.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SchemaTypeEntry {
+    /// Type identifier (e.g. `"concept"`).
     pub name: String,
+    /// Human-readable description of the type.
     pub description: String,
+    /// Relative path to the JSON Schema file.
     pub schema_path: String,
 }
 
+/// List all registered types in a wiki's type registry.
 pub fn schema_list(engine: &EngineState, wiki_name: &str) -> Result<Vec<SchemaTypeEntry>> {
     let space = engine.space(wiki_name)?;
     Ok(space
@@ -35,6 +40,7 @@ pub fn schema_list(engine: &EngineState, wiki_name: &str) -> Result<Vec<SchemaTy
         .collect())
 }
 
+/// Return the raw JSON Schema content for a named type.
 pub fn schema_show(engine: &EngineState, wiki_name: &str, type_name: &str) -> Result<String> {
     let space = engine.space(wiki_name)?;
     let schema_path = space
@@ -46,6 +52,7 @@ pub fn schema_show(engine: &EngineState, wiki_name: &str, type_name: &str) -> Re
         .with_context(|| format!("failed to read schema: {}", full_path.display()))
 }
 
+/// Return a frontmatter template for a type, derived from its JSON Schema.
 pub fn schema_show_template(
     engine: &EngineState,
     wiki_name: &str,
@@ -56,6 +63,7 @@ pub fn schema_show_template(
     Ok(generate_template(&schema, type_name))
 }
 
+/// Copy a schema file into the wiki and register the type in `wiki.toml`.
 pub fn schema_add(
     engine: &EngineState,
     wiki_name: &str,
@@ -110,15 +118,22 @@ pub fn schema_add(
     Ok(msg)
 }
 
+/// Summary of a `schema remove` operation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SchemaRemoveReport {
+    /// Number of indexed pages with this type that were removed from the index.
     pub pages_removed: usize,
+    /// Number of page files actually deleted from disk.
     pub pages_deleted_from_disk: usize,
+    /// True if the `[types.<name>]` entry was removed from `wiki.toml`.
     pub wiki_toml_updated: bool,
+    /// True if the schema JSON file was deleted.
     pub schema_file_deleted: bool,
+    /// True if this was a dry run (no changes made).
     pub dry_run: bool,
 }
 
+/// Remove a type schema and optionally delete its pages.
 pub fn schema_remove(
     manager: &WikiEngine,
     wiki_name: &str,
@@ -233,6 +248,7 @@ pub fn schema_remove(
     })
 }
 
+/// Validate schema files for one type or all types; returns a list of issue strings.
 pub fn schema_validate(
     engine: &EngineState,
     wiki_name: &str,

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -3,15 +3,23 @@ use anyhow::Result;
 use crate::engine::EngineState;
 use crate::search;
 
+/// Parameters for the `search` operation.
 pub struct SearchParams<'a> {
+    /// Full-text query string.
     pub query: &'a str,
+    /// Restrict results to this frontmatter type.
     pub type_filter: Option<&'a str>,
+    /// When true, omit body excerpts from results.
     pub no_excerpt: bool,
+    /// Maximum number of results to return.
     pub top_k: Option<usize>,
+    /// When true, include section index pages in results.
     pub include_sections: bool,
+    /// When true, search across all mounted wikis.
     pub cross_wiki: bool,
 }
 
+/// Run a BM25 search against the wiki index.
 pub fn search(
     engine: &EngineState,
     wiki_name: &str,
@@ -50,6 +58,7 @@ pub fn search(
     )
 }
 
+/// Return a paginated listing of wiki pages with optional type/status filters.
 pub fn list(
     engine: &EngineState,
     wiki_name: &str,

--- a/src/ops/spaces.rs
+++ b/src/ops/spaces.rs
@@ -6,6 +6,7 @@ use crate::config::{self, GlobalConfig, WikiEntry};
 use crate::engine::WikiEngine;
 use crate::spaces;
 
+/// Create a wiki space and hot-reload it into the running engine.
 pub fn spaces_create(
     path: &Path,
     name: &str,
@@ -33,6 +34,7 @@ pub fn spaces_create(
     Ok(report)
 }
 
+/// List registered wiki spaces, optionally filtered to a single name.
 pub fn spaces_list(config: &GlobalConfig, name: Option<&str>) -> Vec<config::WikiEntry> {
     let all = spaces::load_all(config);
     match name {
@@ -41,6 +43,7 @@ pub fn spaces_list(config: &GlobalConfig, name: Option<&str>) -> Vec<config::Wik
     }
 }
 
+/// Unmount a wiki from the engine and remove it from config.
 pub fn spaces_remove(
     name: &str,
     delete: bool,
@@ -54,6 +57,7 @@ pub fn spaces_remove(
     spaces::remove(name, delete, config_path)
 }
 
+/// Set the default wiki in config and update the running engine.
 pub fn spaces_set_default(
     name: &str,
     config_path: &Path,

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -8,36 +8,54 @@ use crate::graph::{self, CommunityStats, GraphFilter};
 use crate::search;
 use tantivy::schema::Value;
 
+/// Page staleness bucketed by last-updated age.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StalenessBuckets {
+    /// Pages updated within the last 7 days.
     pub fresh: usize,
+    /// Pages updated 7–30 days ago.
     pub stale_7d: usize,
+    /// Pages updated more than 30 days ago (or with no date).
     pub stale_30d: usize,
 }
 
+/// Summary health status of the tantivy search index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexHealth {
+    /// True if the index is out of date relative to the wiki files.
     pub stale: bool,
+    /// ISO-8601 timestamp of the last successful index build, if known.
     pub built: Option<String>,
 }
 
 /// Aggregate statistics for a single wiki space.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WikiStats {
+    /// Name of the wiki.
     pub wiki: String,
+    /// Total number of indexed pages.
     pub pages: usize,
+    /// Number of pages whose type is `"section"`.
     pub sections: usize,
+    /// Page count per frontmatter type.
     pub types: HashMap<String, u64>,
+    /// Page count per frontmatter status.
     pub status: HashMap<String, u64>,
+    /// Number of pages with no incoming links.
     pub orphans: usize,
+    /// Mean number of links per page (rounded to 2 decimal places).
     pub avg_connections: f64,
+    /// Graph density (edges / max-possible-edges, rounded to 2 decimal places).
     pub graph_density: f64,
+    /// Page staleness buckets by last-updated date.
     pub staleness: StalenessBuckets,
+    /// Index health — staleness and last build timestamp.
     pub index: IndexHealth,
     /// Louvain community detection results; `None` when graph is below `min_nodes_for_communities`.
     pub communities: Option<CommunityStats>,
 }
 
+/// Compute aggregate stats for a wiki — page counts, graph metrics, staleness, and index health.
 pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
     let space = engine.space(wiki_name)?;
 

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -9,17 +9,26 @@ use crate::graph::{self, GraphFilter};
 use crate::search;
 use crate::slug::{Slug, WikiUri};
 
+/// A page suggested as a related link for a given slug.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Suggestion {
+    /// Slug of the suggested page.
     pub slug: String,
+    /// `wiki://` URI of the suggested page.
     pub uri: String,
+    /// Display title of the suggested page.
     pub title: String,
+    /// Frontmatter type of the suggested page.
     pub r#type: String,
+    /// Relevance score (higher is more relevant).
     pub score: f32,
+    /// Human-readable reason for the suggestion.
     pub reason: String,
+    /// Index field that triggered the suggestion.
     pub field: String,
 }
 
+/// Return a ranked list of related-page suggestions for a given slug or URI.
 pub fn suggest(
     engine: &EngineState,
     slug_or_uri: &str,

--- a/src/search.rs
+++ b/src/search.rs
@@ -16,39 +16,60 @@ use crate::index_schema::IndexSchema;
 
 // ── Return types ──────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
 /// A single search result with BM25 score and optional highlighted excerpt.
-pub struct PageRef {
-    pub slug: String,
-    pub uri: String,
-    pub title: String,
-    pub score: f32,
-    pub confidence: f32,
-    pub excerpt: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub summary: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Lightweight page metadata returned by listing operations.
-pub struct PageSummary {
+pub struct PageRef {
+    /// Page slug (repository-relative path without extension).
     pub slug: String,
+    /// Fully-qualified `wiki://` URI for the page.
     pub uri: String,
+    /// Page title from frontmatter.
     pub title: String,
-    pub r#type: String,
-    pub status: String,
-    pub tags: Vec<String>,
+    /// Adjusted BM25 score (multiplied by status and confidence).
+    pub score: f32,
+    /// Frontmatter `confidence` value in [0, 1].
     pub confidence: f32,
+    /// HTML-highlighted body excerpt, if requested.
+    pub excerpt: Option<String>,
+    /// Frontmatter `summary` field, if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
 }
 
+/// Lightweight page metadata returned by listing operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageSummary {
+    /// Page slug.
+    pub slug: String,
+    /// Fully-qualified `wiki://` URI.
+    pub uri: String,
+    /// Page title from frontmatter.
+    pub title: String,
+    /// Page type from frontmatter.
+    pub r#type: String,
+    /// Page status from frontmatter.
+    pub status: String,
+    /// Tags from frontmatter.
+    pub tags: Vec<String>,
+    /// Frontmatter `confidence` value in [0, 1].
+    pub confidence: f32,
+    /// Frontmatter `summary` field, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+/// A paginated list of pages with facet counts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PageList {
+    /// Pages in the current page window.
     pub pages: Vec<PageSummary>,
+    /// Total pages matching the filter (across all pages).
     pub total: usize,
+    /// Current 1-based page number.
     pub page: usize,
+    /// Number of items per page.
     pub page_size: usize,
+    /// Facet counts for type, status, and tags.
     #[serde(default, skip_serializing_if = "FacetCounts::is_empty")]
     pub facets: FacetCounts,
 }
@@ -58,34 +79,48 @@ pub struct PageList {
 /// Distribution counts for type, status, and tags.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FacetCounts {
+    /// Count of pages per frontmatter type.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub r#type: HashMap<String, u64>,
+    /// Count of pages per frontmatter status.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub status: HashMap<String, u64>,
+    /// Count of pages per tag.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tags: HashMap<String, u64>,
 }
 
 impl FacetCounts {
+    /// Return true if all three facet maps are empty.
     pub fn is_empty(&self) -> bool {
         self.r#type.is_empty() && self.status.is_empty() && self.tags.is_empty()
     }
 }
 
+/// The full result of a search query including ranked results and facets.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
+    /// Ranked search results.
     pub results: Vec<PageRef>,
+    /// Facet counts for the result set.
     pub facets: FacetCounts,
 }
 
 // ── Options ───────────────────────────────────────────────────────────────────
 
+/// Options for a BM25 search query.
 pub struct SearchOptions {
+    /// Omit HTML excerpt from results when true.
     pub no_excerpt: bool,
+    /// Include section index pages in results when true.
     pub include_sections: bool,
+    /// Maximum number of results to return.
     pub top_k: usize,
+    /// Optional frontmatter type filter.
     pub r#type: Option<String>,
+    /// Maximum tag facet values to return (0 = all).
     pub facets_top_tags: usize,
+    /// Status score multiplier config applied to BM25 scores.
     pub search_config: SearchConfig,
 }
 
@@ -102,11 +137,17 @@ impl Default for SearchOptions {
     }
 }
 
+/// Options for a paginated page list operation.
 pub struct ListOptions {
+    /// Optional frontmatter type filter.
     pub r#type: Option<String>,
+    /// Optional frontmatter status filter.
     pub status: Option<String>,
+    /// 1-based page number.
     pub page: usize,
+    /// Number of items per page.
     pub page_size: usize,
+    /// Maximum tag facet values to return (0 = all).
     pub facets_top_tags: usize,
 }
 
@@ -124,6 +165,7 @@ impl Default for ListOptions {
 
 // ── search ────────────────────────────────────────────────────────────────────
 
+/// Run a BM25 full-text search against a single wiki's index.
 pub fn search(
     query_str: &str,
     options: &SearchOptions,
@@ -296,6 +338,7 @@ pub fn search(
 
 // ── list ──────────────────────────────────────────────────────────────────────
 
+/// Return a paginated list of pages from the index, sorted alphabetically by slug.
 pub fn list(
     options: &ListOptions,
     searcher: &Searcher,
@@ -461,6 +504,7 @@ pub fn list(
 
 // ── search_all ────────────────────────────────────────────────────────────────
 
+/// Search across multiple wikis, merge results by score, and truncate to `top_k`.
 pub fn search_all(
     query_str: &str,
     options: &SearchOptions,

--- a/src/server.rs
+++ b/src/server.rs
@@ -92,6 +92,7 @@ async fn serve_http(
 
 // ── serve (orchestration) ─────────────────────────────────────────────────────
 
+/// Start the wiki server — spawns stdio, HTTP, ACP, and watcher transports as configured.
 pub async fn serve(
     config_path: &std::path::Path,
     http_port: Option<u16>,

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -57,6 +57,7 @@ impl Slug {
         title_case(last)
     }
 
+    /// Return the raw slug string slice.
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/src/spaces.rs
+++ b/src/spaces.rs
@@ -9,17 +9,24 @@ use crate::git;
 
 // ── CreateReport ──────────────────────────────────────────────────────────────
 
+/// Outcome of a wiki space creation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateReport {
+    /// Absolute path of the wiki directory.
     pub path: String,
+    /// Registered name of the wiki.
     pub name: String,
+    /// True if the directory was newly created.
     pub created: bool,
+    /// True if the space was added to the global config.
     pub registered: bool,
+    /// True if an initial git commit was made.
     pub committed: bool,
 }
 
 // ── create ────────────────────────────────────────────────────────────────────
 
+/// Create a new wiki repository at `path`, register it, and optionally commit.
 pub fn create(
     path: &Path,
     name: &str,
@@ -161,6 +168,7 @@ fn generate_wiki_toml(name: &str, description: Option<&str>) -> String {
 
 // ── Space management ──────────────────────────────────────────────────────────
 
+/// Look up a registered wiki by name; error if not found.
 pub fn resolve_name(name: &str, global: &GlobalConfig) -> Result<WikiEntry> {
     global
         .wikis
@@ -170,6 +178,7 @@ pub fn resolve_name(name: &str, global: &GlobalConfig) -> Result<WikiEntry> {
         .ok_or_else(|| anyhow::anyhow!("wiki \"{name}\" is not registered"))
 }
 
+/// Add or update a wiki entry in the global config; errors if already registered and `force` is false.
 pub fn register(entry: WikiEntry, force: bool, config_path: &Path) -> Result<()> {
     let mut config = load_global(config_path)?;
 
@@ -188,6 +197,7 @@ pub fn register(entry: WikiEntry, force: bool, config_path: &Path) -> Result<()>
     save_global(&config, config_path)
 }
 
+/// Unregister a wiki from the global config; optionally delete its directory.
 pub fn remove(name: &str, delete: bool, config_path: &Path) -> Result<()> {
     let mut config = load_global(config_path)?;
 
@@ -213,10 +223,12 @@ pub fn remove(name: &str, delete: bool, config_path: &Path) -> Result<()> {
     save_global(&config, config_path)
 }
 
+/// Return all registered wiki entries from the global config.
 pub fn load_all(global: &GlobalConfig) -> Vec<WikiEntry> {
     global.wikis.clone()
 }
 
+/// Set the default wiki in the global config.
 pub fn set_default_wiki(name: &str, config_path: &Path) -> Result<()> {
     let mut config = load_global(config_path)?;
 

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -23,9 +23,13 @@ pub struct RegisteredType {
 /// A graph edge declaration from `x-graph-edges` in a type schema.
 #[derive(Debug, Clone)]
 pub struct EdgeDecl {
+    /// Frontmatter field name containing the target slugs.
     pub field: String,
+    /// Relation label for edges produced from this declaration.
     pub relation: String,
+    /// Direction of the edge: `"outgoing"` or `"incoming"`.
     pub direction: String,
+    /// Page types that are valid targets (empty = any type).
     pub target_types: Vec<String>,
 }
 
@@ -115,6 +119,7 @@ impl SpaceTypeRegistry {
         }
     }
 
+    /// Return true if `type_name` is registered in this registry.
     pub fn is_known(&self, type_name: &str) -> bool {
         self.types.contains_key(type_name)
     }
@@ -140,10 +145,12 @@ impl SpaceTypeRegistry {
         self.types.get(type_name).map(|rt| rt.schema_path.as_str())
     }
 
+    /// Return the global SHA-256 hash of all registered type schemas.
     pub fn schema_hash(&self) -> &str {
         &self.schema_hash
     }
 
+    /// Return the per-type content hash map (type name → SHA-256 hash).
     pub fn type_hashes(&self) -> &HashMap<String, String> {
         &self.type_hashes
     }

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -452,3 +452,42 @@ fn broken_cross_wiki_link_to_mounted_wiki_no_finding() {
         "mounted wiki should not produce findings: {cross_wiki_findings:?}"
     );
 }
+
+// ── LintFinding.path ──────────────────────────────────────────────────────────
+
+#[test]
+fn lint_finding_path_is_populated() {
+    let dir = tempfile::tempdir().unwrap();
+    let wiki_root = setup_repo(dir.path());
+
+    write_page(
+        &wiki_root,
+        "concepts/orphan.md",
+        "---\ntitle: \"Orphan\"\ntype: concept\nread_when: [\"x\"]\n---\n\nNo one links here.\n",
+    );
+
+    let engine = build_engine(dir.path(), &wiki_root);
+    let report = run_lint(&engine, "test", Some("orphan"), None).unwrap();
+
+    let findings = findings_for_rule(&report.findings, "orphan");
+    assert!(!findings.is_empty(), "expected at least one orphan finding");
+
+    for f in &findings {
+        assert!(
+            !f.path.is_empty(),
+            "path should be non-empty for finding: {:?}",
+            f.slug
+        );
+        assert!(
+            f.path.ends_with(".md"),
+            "path should end with .md: {}",
+            f.path
+        );
+        assert!(
+            f.path.contains(f.slug.as_str()),
+            "path should contain slug: path={} slug={}",
+            f.path,
+            f.slug
+        );
+    }
+}

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -1,9 +1,9 @@
 use llm_wiki::mcp::tools;
 
 #[test]
-fn tool_list_returns_20_tools() {
+fn tool_list_returns_22_tools() {
     let tools = tools::tool_list();
-    assert_eq!(tools.len(), 21);
+    assert_eq!(tools.len(), 22);
 }
 
 #[test]
@@ -29,6 +29,7 @@ fn tool_list_contains_expected_names() {
         "wiki_history",
         "wiki_stats",
         "wiki_lint",
+        "wiki_resolve",
         "wiki_suggest",
         "wiki_export",
     ];
@@ -124,6 +125,29 @@ fn search_has_type_param() {
         .as_object()
         .unwrap();
     assert!(props.contains_key("type"), "missing type param");
+}
+
+#[test]
+fn wiki_resolve_has_uri_required() {
+    let tools = tools::tool_list();
+    let tool = tools.iter().find(|t| t.name == "wiki_resolve").unwrap();
+    let required = tool
+        .input_schema
+        .get("required")
+        .unwrap()
+        .as_array()
+        .unwrap();
+    let req: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(req.contains(&"uri"));
+    assert!(!req.contains(&"wiki"), "wiki should be optional");
+    let props = tool
+        .input_schema
+        .get("properties")
+        .unwrap()
+        .as_object()
+        .unwrap();
+    assert!(props.contains_key("uri"));
+    assert!(props.contains_key("wiki"));
 }
 
 #[test]

--- a/tests/ops/content.rs
+++ b/tests/ops/content.rs
@@ -59,7 +59,7 @@ fn content_new_page() {
     let manager = WikiEngine::build(&config_path).unwrap();
     let engine = manager.state.read().unwrap();
 
-    let uri = ops::content_new(
+    let result = ops::content_new(
         &engine,
         "concepts/new-concept",
         None,
@@ -69,7 +69,11 @@ fn content_new_page() {
         None,
     )
     .unwrap();
-    assert!(uri.starts_with("wiki://test/concepts/new-concept"));
+    assert!(result.uri.starts_with("wiki://test/concepts/new-concept"));
+    assert_eq!(result.slug, "concepts/new-concept");
+    assert!(!result.bundle);
+    assert!(result.path.exists());
+    assert!(result.path.to_string_lossy().ends_with(".md"));
 }
 
 #[test]
@@ -79,8 +83,23 @@ fn content_new_section() {
     let manager = WikiEngine::build(&config_path).unwrap();
     let engine = manager.state.read().unwrap();
 
-    let uri = ops::content_new(&engine, "topics", None, true, false, None, None).unwrap();
-    assert!(uri.contains("topics"));
+    let result = ops::content_new(&engine, "topics", None, true, false, None, None).unwrap();
+    assert!(result.uri.contains("topics"));
+}
+
+#[test]
+fn content_new_bundle_result_has_path_and_wiki_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+
+    let result =
+        ops::content_new(&engine, "concepts/bundled", None, false, true, None, None).unwrap();
+    assert!(result.bundle);
+    assert!(result.path.ends_with("index.md"));
+    assert!(result.path.exists());
+    assert!(result.wiki_root.is_dir());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **`wiki_resolve` new MCP tool** — resolves a slug or `wiki://` URI to its local filesystem path (`slug`, `wiki`, `wiki_root`, `path`, `exists`, `bundle`); enables the direct write pattern (write file → `wiki_ingest`) without sending content through MCP
- **`wiki_content_new` JSON response** — changed from bare URI string to `{ uri, slug, path, wiki_root, bundle }`; LLM gets the local path immediately after page creation
- **`LintFinding.path` field** — absolute filesystem path added to every finding; `wiki_root` threaded through all 5 rule functions; LLM can `Edit` files directly from findings without a follow-up `wiki_resolve`

## Test plan

- [x] `cargo test` — all suites green (tool count asserts 22, new bundle/path tests pass, lint path test passes)
- [x] `cargo clippy -- -D warnings` — clean
- [x] MCP validation: `docs/testing/scripts/mcp/04-content.sh` — 5 new `wiki_resolve` checks
- [x] MCP validation: `docs/testing/scripts/mcp/06-lint.sh` — 2 new lint path checks

## Decision record

`docs/decisions/0.2.0/local-path-content.md` — rationale for each approach chosen.