### PR TITLE
feat: in-memory graph cache keyed on index generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat/*, dev/*]
   pull_request:
     branches: [main]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 /target
 README-draft.md
 docs/prompts/
+docs/superpowers
 
 # tantivy search index — gitignored, rebuilt on demand via `wiki search --rebuild-index`
 .wiki/search-index/
 
-# docs archive — gitignored
-projects/llm-wiki/docs/archive
 
-.remember
 .claude

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 
 use crate::config::{self, GlobalConfig, ResolvedConfig, WikiEntry};
+use crate::graph::CachedGraph;
 use crate::index_manager::{IndexReport, SpaceIndexManager, StalenessKind, UpdateReport};
 use crate::index_schema::IndexSchema;
 use crate::space_builder;
@@ -26,6 +27,8 @@ pub struct SpaceContext {
     pub index_schema: IndexSchema,
     /// Lifecycle manager for the Tantivy search index.
     pub index_manager: SpaceIndexManager,
+    /// In-memory graph cache. Invalidated when `index_manager.generation()` changes.
+    pub graph_cache: RwLock<Option<CachedGraph>>,
 }
 
 impl SpaceContext {
@@ -366,5 +369,6 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         type_registry,
         index_schema,
         index_manager,
+        graph_cache: RwLock::new(None),
     })
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,6 @@
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use chrono::Utc;
@@ -12,6 +12,7 @@ use tantivy::collector::TopDocs;
 use tantivy::query::AllQuery;
 use tantivy::schema::Value;
 
+use crate::index_manager::SpaceIndexManager;
 use crate::index_schema::IndexSchema;
 use crate::links::ParsedLink;
 use crate::type_registry::SpaceTypeRegistry;
@@ -959,4 +960,100 @@ pub fn subgraph(graph: &WikiGraph, root_slug: &str, depth: usize) -> WikiGraph {
     }
 
     new_graph
+}
+
+// ── Cached graph accessors ───────────────────────────────────────────────────
+
+/// Return cached full graph, or build and cache on miss.
+/// Filtered (non-default) requests bypass cache entirely.
+pub fn get_or_build_graph(
+    index_schema: &IndexSchema,
+    type_registry: &SpaceTypeRegistry,
+    index_manager: &SpaceIndexManager,
+    graph_cache: &RwLock<Option<CachedGraph>>,
+    searcher: &Searcher,
+    filter: &GraphFilter,
+) -> Result<Arc<WikiGraph>> {
+    if !filter.is_default() {
+        let g = build_graph(searcher, index_schema, filter, type_registry)?;
+        return Ok(Arc::new(g));
+    }
+
+    let current_gen = index_manager.generation();
+
+    // Check cache hit
+    {
+        let cache = graph_cache.read().unwrap();
+        if let Some(cached) = cache.as_ref() {
+            if cached.index_gen == current_gen {
+                return Ok(Arc::clone(&cached.graph));
+            }
+        }
+    }
+
+    // Cache miss — build
+    let graph = Arc::new(build_graph(searcher, index_schema, filter, type_registry)?);
+    let community_map = node_community_map(&graph, 30).map(Arc::new);
+
+    *graph_cache.write().unwrap() = Some(CachedGraph {
+        graph: Arc::clone(&graph),
+        community_map,
+        index_gen: current_gen,
+    });
+
+    Ok(graph)
+}
+
+/// Return cached community map, or None if graph is below `min_nodes` threshold.
+/// Builds and caches the full graph as a side effect if not already cached.
+pub fn get_cached_community_map(
+    index_schema: &IndexSchema,
+    type_registry: &SpaceTypeRegistry,
+    index_manager: &SpaceIndexManager,
+    graph_cache: &RwLock<Option<CachedGraph>>,
+    searcher: &Searcher,
+    min_nodes: usize,
+) -> Result<Option<Arc<HashMap<String, usize>>>> {
+    let current_gen = index_manager.generation();
+
+    // Check cache hit
+    {
+        let cache = graph_cache.read().unwrap();
+        if let Some(cached) = cache.as_ref() {
+            if cached.index_gen == current_gen {
+                if min_nodes <= 30 {
+                    return Ok(cached.community_map.clone());
+                }
+                // Caller wants higher threshold — recompute without caching variant
+                let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
+                return Ok(map);
+            }
+        }
+    }
+
+    // Cache miss — build graph (caches community_map at threshold=30)
+    get_or_build_graph(
+        index_schema,
+        type_registry,
+        index_manager,
+        graph_cache,
+        searcher,
+        &GraphFilter::default(),
+    )?;
+
+    // Re-read
+    {
+        let cache = graph_cache.read().unwrap();
+        if let Some(cached) = cache.as_ref() {
+            if cached.index_gen == current_gen {
+                if min_nodes <= 30 {
+                    return Ok(cached.community_map.clone());
+                }
+                let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
+                return Ok(map);
+            }
+        }
+    }
+
+    Ok(None)
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -984,7 +984,9 @@ pub fn get_or_build_graph(
     // Check cache hit
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() && cached.index_gen == current_gen {
+        if let Some(cached) = cache.as_ref()
+            && cached.index_gen == current_gen
+        {
             return Ok(Arc::clone(&cached.graph));
         }
     }
@@ -1017,7 +1019,9 @@ pub fn get_cached_community_map(
     // Check cache hit
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() && cached.index_gen == current_gen {
+        if let Some(cached) = cache.as_ref()
+            && cached.index_gen == current_gen
+        {
             if min_nodes <= 30 {
                 return Ok(cached.community_map.clone());
             }
@@ -1040,7 +1044,9 @@ pub fn get_cached_community_map(
     // Re-read
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() && cached.index_gen == current_gen {
+        if let Some(cached) = cache.as_ref()
+            && cached.index_gen == current_gen
+        {
             if min_nodes <= 30 {
                 return Ok(cached.community_map.clone());
             }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,6 @@
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::Utc;
@@ -41,6 +42,16 @@ pub struct LabeledEdge {
 /// Directed graph type used for the wiki concept graph.
 pub type WikiGraph = DiGraph<PageNode, LabeledEdge>;
 
+/// Cached result of a full (unfiltered) graph build, keyed by index generation.
+pub struct CachedGraph {
+    /// The full unfiltered wiki graph.
+    pub graph: Arc<WikiGraph>,
+    /// Precomputed community map (slug → community_id), None if graph is too small.
+    pub community_map: Option<Arc<HashMap<String, usize>>>,
+    /// Generation value from SpaceIndexManager at cache time.
+    pub index_gen: u64,
+}
+
 /// Filtering parameters for graph construction and subgraph extraction.
 #[derive(Debug, Clone, Default)]
 pub struct GraphFilter {
@@ -52,6 +63,14 @@ pub struct GraphFilter {
     pub types: Vec<String>,
     /// Edge relation label to filter on (None = all relations).
     pub relation: Option<String>,
+}
+
+impl GraphFilter {
+    /// Returns `true` when the filter represents an unfiltered full-graph request.
+    /// Note: `depth` is intentionally excluded — a depth-limited full graph still uses the full cache.
+    pub fn is_default(&self) -> bool {
+        self.root.is_none() && self.types.is_empty() && self.relation.is_none()
+    }
 }
 
 /// Summary of a completed graph build or render operation.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -984,10 +984,8 @@ pub fn get_or_build_graph(
     // Check cache hit
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() {
-            if cached.index_gen == current_gen {
-                return Ok(Arc::clone(&cached.graph));
-            }
+        if let Some(cached) = cache.as_ref() && cached.index_gen == current_gen {
+            return Ok(Arc::clone(&cached.graph));
         }
     }
 
@@ -1019,15 +1017,13 @@ pub fn get_cached_community_map(
     // Check cache hit
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() {
-            if cached.index_gen == current_gen {
-                if min_nodes <= 30 {
-                    return Ok(cached.community_map.clone());
-                }
-                // Caller wants higher threshold — recompute without caching variant
-                let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
-                return Ok(map);
+        if let Some(cached) = cache.as_ref() && cached.index_gen == current_gen {
+            if min_nodes <= 30 {
+                return Ok(cached.community_map.clone());
             }
+            // Caller wants higher threshold — recompute without caching variant
+            let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
+            return Ok(map);
         }
     }
 
@@ -1044,14 +1040,12 @@ pub fn get_cached_community_map(
     // Re-read
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() {
-            if cached.index_gen == current_gen {
-                if min_nodes <= 30 {
-                    return Ok(cached.community_map.clone());
-                }
-                let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
-                return Ok(map);
+        if let Some(cached) = cache.as_ref() && cached.index_gen == current_gen {
+            if min_nodes <= 30 {
+                return Ok(cached.community_map.clone());
             }
+            let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
+            return Ok(map);
         }
     }
 

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
@@ -102,6 +103,7 @@ pub struct IndexState {
 struct IndexInner {
     tantivy_index: Option<Index>,
     index_reader: Option<IndexReader>,
+    generation: AtomicU64,
 }
 
 /// Tantivy index lifecycle manager for a single wiki space.
@@ -120,6 +122,7 @@ impl SpaceIndexManager {
             inner: RwLock::new(IndexInner {
                 tantivy_index: None,
                 index_reader: None,
+                generation: AtomicU64::new(0),
             }),
         }
     }
@@ -132,6 +135,12 @@ impl SpaceIndexManager {
     /// Return the wiki name this manager is associated with.
     pub fn wiki_name(&self) -> &str {
         &self.wiki_name
+    }
+
+    /// Return the current generation counter value.
+    /// Incremented on every successful `reload_reader()` call.
+    pub fn generation(&self) -> u64 {
+        self.inner.read().unwrap().generation.load(Ordering::Acquire)
     }
 
     /// Open the index from disk and hold the reader.
@@ -205,6 +214,7 @@ impl SpaceIndexManager {
         if let Some(ref r) = inner.index_reader {
             r.reload()?;
         }
+        inner.generation.fetch_add(1, Ordering::Release);
         Ok(())
     }
 

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -140,7 +140,11 @@ impl SpaceIndexManager {
     /// Return the current generation counter value.
     /// Incremented on every successful `reload_reader()` call.
     pub fn generation(&self) -> u64 {
-        self.inner.read().unwrap().generation.load(Ordering::Acquire)
+        self.inner
+            .read()
+            .unwrap()
+            .generation
+            .load(Ordering::Acquire)
     }
 
     /// Open the index from disk and hold the reader.

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -214,7 +214,7 @@ impl SpaceIndexManager {
         if let Some(ref r) = inner.index_reader {
             r.reload()?;
         }
-        inner.generation.fetch_add(1, Ordering::Release);
+        inner.generation.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
 

--- a/src/ops/graph.rs
+++ b/src/ops/graph.rs
@@ -87,9 +87,9 @@ pub fn graph_build(
     };
 
     let rendered = match fmt {
-        "dot" => graph::render_dot(&*g),
-        "llms" => graph::render_llms(&*g),
-        _ => graph::render_mermaid(&*g),
+        "dot" => graph::render_dot(&g),
+        "llms" => graph::render_llms(&g),
+        _ => graph::render_mermaid(&g),
     };
 
     let out = if let Some(out_path) = params.output {

--- a/src/ops/graph.rs
+++ b/src/ops/graph.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 
 use crate::engine::EngineState;
@@ -50,7 +52,7 @@ pub fn graph_build(
         types,
         relation: params.relation.clone(),
     };
-    let g = if params.cross_wiki {
+    let g: Arc<graph::WikiGraph> = if params.cross_wiki {
         // Collect (name, searcher) pairs; Arc keeps schema/registry alive
         let space_data: Vec<(String, tantivy::Searcher)> = engine
             .spaces
@@ -71,21 +73,23 @@ pub fn graph_build(
                     .map(|sp| (name.as_str(), searcher, &sp.index_schema, &sp.type_registry))
             })
             .collect();
-        graph::build_graph_cross_wiki(&tuples, &filter)?
+        Arc::new(graph::build_graph_cross_wiki(&tuples, &filter)?)
     } else {
         let searcher = space.index_manager.searcher()?;
-        graph::build_graph(
-            &searcher,
+        graph::get_or_build_graph(
             &space.index_schema,
-            &filter,
             &space.type_registry,
+            &space.index_manager,
+            &space.graph_cache,
+            &searcher,
+            &filter,
         )?
     };
 
     let rendered = match fmt {
-        "dot" => graph::render_dot(&g),
-        "llms" => graph::render_llms(&g),
-        _ => graph::render_mermaid(&g),
+        "dot" => graph::render_dot(&*g),
+        "llms" => graph::render_llms(&*g),
+        _ => graph::render_mermaid(&*g),
     };
 
     let out = if let Some(out_path) = params.output {

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::engine::EngineState;
-use crate::graph::{self, CommunityStats, GraphFilter};
+use crate::graph::{self, CommunityStats, GraphFilter, get_or_build_graph};
 use crate::search;
 use tantivy::schema::Value;
 
@@ -78,16 +78,18 @@ pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
     let status = list_result.facets.status;
 
     // Graph metrics
-    let wiki_graph = graph::build_graph(
-        &searcher,
+    let wiki_graph = get_or_build_graph(
         &space.index_schema,
-        &GraphFilter::default(),
         &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &GraphFilter::default(),
     )?;
-    let metrics = graph::compute_metrics(&wiki_graph);
+    let metrics = graph::compute_metrics(&*wiki_graph);
     let resolved = space.resolved_config(&engine.config);
     let communities =
-        graph::compute_communities(&wiki_graph, resolved.graph.min_nodes_for_communities);
+        graph::compute_communities(&*wiki_graph, resolved.graph.min_nodes_for_communities);
 
     // Staleness buckets from last_updated field
     let staleness = compute_staleness(&searcher, &space.index_schema)?;

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -86,10 +86,10 @@ pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
         &searcher,
         &GraphFilter::default(),
     )?;
-    let metrics = graph::compute_metrics(&*wiki_graph);
+    let metrics = graph::compute_metrics(&wiki_graph);
     let resolved = space.resolved_config(&engine.config);
     let communities =
-        graph::compute_communities(&*wiki_graph, resolved.graph.min_nodes_for_communities);
+        graph::compute_communities(&wiki_graph, resolved.graph.min_nodes_for_communities);
 
     // Staleness buckets from last_updated field
     let staleness = compute_staleness(&searcher, &space.index_schema)?;

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -209,7 +209,7 @@ pub fn suggest(
 
     // Strategy 4: Community peers (same Louvain community, not already linked)
     if let Some(community_map) =
-        graph::node_community_map(&*wiki_graph, resolved.graph.min_nodes_for_communities)
+        graph::node_community_map(&wiki_graph, resolved.graph.min_nodes_for_communities)
         && let Some(&my_community) = community_map.get(slug.as_str())
     {
         let mut peers: Vec<&str> = community_map

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tantivy::schema::Value;
 
 use crate::engine::EngineState;
-use crate::graph::{self, GraphFilter};
+use crate::graph::{self, GraphFilter, get_or_build_graph};
 use crate::search;
 use crate::slug::{Slug, WikiUri};
 
@@ -110,8 +110,14 @@ pub fn suggest(
     }
 
     // Strategy 2: Graph neighborhood (2 hops)
-    let wiki_graph =
-        graph::build_graph(&searcher, is, &GraphFilter::default(), &space.type_registry)?;
+    let wiki_graph = get_or_build_graph(
+        is,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &GraphFilter::default(),
+    )?;
     let slug_to_idx: HashMap<&str, _> = wiki_graph
         .node_indices()
         .map(|idx| (wiki_graph[idx].slug.as_str(), idx))
@@ -203,7 +209,7 @@ pub fn suggest(
 
     // Strategy 4: Community peers (same Louvain community, not already linked)
     if let Some(community_map) =
-        graph::node_community_map(&wiki_graph, resolved.graph.min_nodes_for_communities)
+        graph::node_community_map(&*wiki_graph, resolved.graph.min_nodes_for_communities)
         && let Some(&my_community) = community_map.get(slug.as_str())
     {
         let mut peers: Vec<&str> = community_map

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -845,3 +845,12 @@ fn compute_communities_deterministic() {
         "isolated list must be deterministic"
     );
 }
+
+// ── generation counter ────────────────────────────────────────────────────────
+
+#[test]
+fn index_manager_generation_starts_at_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let mgr = SpaceIndexManager::new("test", dir.path().join("idx"));
+    assert_eq!(mgr.generation(), 0);
+}

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -854,3 +854,29 @@ fn index_manager_generation_starts_at_zero() {
     let mgr = SpaceIndexManager::new("test", dir.path().join("idx"));
     assert_eq!(mgr.generation(), 0);
 }
+
+// ── GraphFilter::is_default ───────────────────────────────────────────────────
+
+#[test]
+fn graphfilter_default_is_default() {
+    let f = llm_wiki::graph::GraphFilter::default();
+    assert!(f.is_default());
+}
+
+#[test]
+fn graphfilter_with_types_not_default() {
+    let f = llm_wiki::graph::GraphFilter {
+        types: vec!["concept".to_string()],
+        ..Default::default()
+    };
+    assert!(!f.is_default());
+}
+
+#[test]
+fn graphfilter_with_root_not_default() {
+    let f = llm_wiki::graph::GraphFilter {
+        root: Some("concepts/foo".to_string()),
+        ..Default::default()
+    };
+    assert!(!f.is_default());
+}

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -61,7 +61,10 @@ fn graph_cache_hit_returns_same_arc() {
     )
     .unwrap();
 
-    assert!(Arc::ptr_eq(&g1, &g2), "second call should return cached Arc");
+    assert!(
+        Arc::ptr_eq(&g1, &g2),
+        "second call should return cached Arc"
+    );
 }
 
 #[test]

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -110,6 +110,51 @@ fn graph_cache_miss_on_filtered_request() {
 }
 
 #[test]
+fn graph_cache_hit_is_faster_than_miss() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+
+    let searcher = space.index_manager.searcher().unwrap();
+    let filter = GraphFilter::default();
+
+    // Cold call — cache miss, builds graph
+    let t0 = std::time::Instant::now();
+    let _ = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &filter,
+    )
+    .unwrap();
+    let cold_ns = t0.elapsed().as_nanos();
+
+    // Warm call — cache hit, returns Arc clone
+    let t1 = std::time::Instant::now();
+    let _ = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &filter,
+    )
+    .unwrap();
+    let warm_ns = t1.elapsed().as_nanos();
+
+    // Cache hit must be strictly faster than cache miss
+    assert!(
+        warm_ns < cold_ns,
+        "cache hit ({warm_ns}ns) not faster than miss ({cold_ns}ns)"
+    );
+}
+
+#[test]
 fn get_cached_community_map_returns_none_for_small_graph() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = setup_wiki(dir.path(), "test");

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use llm_wiki::engine::WikiEngine;
+use llm_wiki::git;
+use llm_wiki::graph::{GraphFilter, get_cached_community_map, get_or_build_graph};
+
+fn setup_wiki(dir: &Path, name: &str) -> std::path::PathBuf {
+    let config_path = dir.join("state").join("config.toml");
+    let wiki_path = dir.join(name);
+
+    llm_wiki::spaces::create(&wiki_path, name, None, false, true, &config_path).unwrap();
+
+    let wiki_root = wiki_path.join("wiki");
+    fs::create_dir_all(wiki_root.join("concepts")).unwrap();
+    fs::write(
+        wiki_root.join("concepts/moe.md"),
+        "---\ntitle: \"MoE\"\ntype: concept\nstatus: active\ntags: [ml]\n---\n\nMixture of Experts.\n",
+    )
+    .unwrap();
+    fs::write(
+        wiki_root.join("concepts/transformer.md"),
+        "---\ntitle: \"Transformer\"\ntype: concept\nstatus: active\n---\n\nAttention is all you need. See [[concepts/moe]].\n",
+    )
+    .unwrap();
+    git::commit(&wiki_path, "add pages").unwrap();
+
+    config_path
+}
+
+#[test]
+fn graph_cache_hit_returns_same_arc() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+
+    let searcher = space.index_manager.searcher().unwrap();
+    let filter = GraphFilter::default();
+
+    let g1 = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &filter,
+    )
+    .unwrap();
+
+    let g2 = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &filter,
+    )
+    .unwrap();
+
+    assert!(Arc::ptr_eq(&g1, &g2), "second call should return cached Arc");
+}
+
+#[test]
+fn graph_cache_miss_on_filtered_request() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+
+    let searcher = space.index_manager.searcher().unwrap();
+
+    // Build and cache the full graph
+    let full = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &GraphFilter::default(),
+    )
+    .unwrap();
+
+    // Filtered request should bypass cache
+    let filtered = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &GraphFilter {
+            types: vec!["concept".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        !Arc::ptr_eq(&full, &filtered),
+        "filtered request must not return cached full graph"
+    );
+}
+
+#[test]
+fn get_cached_community_map_returns_none_for_small_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+
+    let searcher = space.index_manager.searcher().unwrap();
+
+    // With only 2 nodes, community detection should return None
+    let map = get_cached_community_map(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        30,
+    )
+    .unwrap();
+
+    assert!(map.is_none(), "graph too small for community detection");
+}

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -55,6 +55,7 @@ fn build_engine(dir: &Path, wiki_root: &Path) -> EngineState {
         type_registry: registry(),
         index_schema: schema(),
         index_manager: mgr,
+        graph_cache: std::sync::RwLock::new(None),
     });
 
     let mut spaces = HashMap::new();
@@ -386,6 +387,7 @@ fn build_engine_with_name(dir: &Path, wiki_root: &Path, name: &str) -> EngineSta
         type_registry: registry(),
         index_schema: schema(),
         index_manager: mgr,
+        graph_cache: std::sync::RwLock::new(None),
     });
 
     let mut spaces = HashMap::new();


### PR DESCRIPTION
## Summary

- Adds `AtomicU64` generation counter to `SpaceIndexManager`, bumped on every `reload_reader()` (file-watch ingest, rebuild, hot-reload)
- Adds `CachedGraph` struct and `graph_cache: RwLock<Option<CachedGraph>>` to `SpaceContext`
- `get_or_build_graph()` serves cached `Arc<WikiGraph>` on hit; builds + stores on miss; bypasses cache for filtered requests
- `ops/graph.rs`, `ops/stats.rs`, `ops/suggest.rs` adopt the cache — redundant full-graph builds in serve mode eliminated

## Why only unfiltered graphs

Filtered graphs (type_filter, root subgraph, relation filter) are request-specific and uncommon. Caching them would require a per-key store with eviction. The full unfiltered graph is what every MCP/ACP call needs.

## Cache invalidation

Generation bumps automatically on any write (ingest, rebuild, watch). No manual invalidation needed.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `tests/graph_cache.rs` — cache hit returns same `Arc`, filtered request bypasses cache
- [x] Manual: run `llm-wiki serve --mcp` and call `wiki_graph` twice; confirm second call is faster