### PR TITLE
feat: in-memory graph cache keyed on index generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ docs/superpowers
 
 
 .claude
+# Added by code-review-graph
+.code-review-graph/
+.mcp.json
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — Unreleased
+
+### Added
+
+- **In-memory graph cache** — full wiki graph and Louvain community data cached per space, keyed on index generation; invalidated automatically after any index write; `wiki_graph`, `wiki_stats`, and `wiki_suggest` skip rebuild on cache hit in serve mode; cross-wiki path uses per-space cached graphs via `merge_cached_graphs`
+
 ## [0.2.0] — 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-wiki-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-wiki-engine"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Git-backed wiki engine with MCP server — bring your own LLM"

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -19,6 +19,7 @@ not ground truth. For design contracts see [specifications/](../specifications/R
 | [schema-change-detection.md](schema-change-detection.md) | Schema hash, staleness, per-wiki registry           |
 | [index-manager.md](index-manager.md)                     | SpaceIndexManager, rebuild, staleness, recovery     |
 | [tantivy.md](tantivy.md)                                 | Dynamic schema, TopDocs, index writer, tokenizer    |
+| [graph-cache.md](graph-cache.md)                         | In-memory graph cache, generation counter, accessors |
 
 ## MCP
 

--- a/docs/implementation/engine.md
+++ b/docs/implementation/engine.md
@@ -43,8 +43,13 @@ pub struct SpaceContext {
     pub type_registry: SpaceTypeRegistry,
     pub index_schema: IndexSchema,
     pub index_manager: SpaceIndexManager,
+    pub graph_cache: RwLock<Option<CachedGraph>>,  // v0.3.0
 }
 ```
+
+`graph_cache` holds the last full unfiltered graph build. Invalidated
+automatically when `index_manager.generation()` changes. See
+[graph-cache.md](graph-cache.md).
 
 ## Startup
 
@@ -62,7 +67,8 @@ pub struct SpaceContext {
       - TypesChanged → partial rebuild (affected types only)
       - FullRebuildNeeded → full rebuild
    e. Open tantivy index (with auto-recovery on corruption)
-   f. Return SpaceContext
+   f. Initialize graph_cache: RwLock::new(None)
+   g. Return SpaceContext
 3. Per-wiki errors: warn and skip (don't fail the engine)
 4. Assemble EngineState, wrap in Arc<RwLock>
 ```

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -125,10 +125,14 @@ by `ops/stats.rs` to skip Louvain on cache hit.
 
 ## Cache population
 
-On cache miss, calls `build_community_data(graph)` — a private helper that
+On cache miss, calls `build_community_data(graph, 30)` — a private helper that
 runs Louvain exactly once and returns both `CommunityStats` and
 `HashMap<String, usize>` (community map). Both fields are stored in
 `CachedGraph` atomically.
+
+`compute_communities` and `node_community_map` are thin wrappers over
+`build_community_data` — they extract `.0` and `.1` respectively. This ensures
+all three entry points share identical Louvain logic with no duplication.
 
 The community threshold used is `30` (the default config value). Callers
 requesting a higher threshold get a fresh recompute without overwriting the

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -2,7 +2,7 @@
 title: "Graph Cache Implementation"
 summary: "In-memory graph cache keyed on index generation — eliminates redundant build_graph and Louvain calls in serve mode."
 status: ready
-last_updated: "2026-04-30"
+last_updated: "2026-05-01"
 depends_on:
   - engine.md
   - index-manager.md
@@ -107,9 +107,8 @@ pub fn get_cached_community_map(
 ) -> Result<Option<Arc<HashMap<String, usize>>>>
 ```
 
-Returns cached `community_map`. If `min_nodes > 30` (the cache threshold),
-recomputes without overwriting cache. Triggers graph build as side effect on
-miss.
+Returns cached `community_map` if local node count ≥ `min_nodes`, otherwise
+`None`. Triggers graph build as side effect on miss.
 
 ### `get_cached_community_stats`
 
@@ -121,22 +120,21 @@ pub fn get_cached_community_stats(
 ```
 
 Same pattern as `get_cached_community_map` but returns `CommunityStats`. Used
-by `ops/stats.rs` to skip Louvain on cache hit.
+by `ops/stats.rs` to skip Louvain on cache hit. Returns `None` when local node
+count < `min_nodes`.
 
 ## Cache population
 
-On cache miss, calls `build_community_data(graph, 30)` — a private helper that
+On cache miss, calls `build_community_data(graph, 0)` — a private helper that
 runs Louvain exactly once and returns both `CommunityStats` and
 `HashMap<String, usize>` (community map). Both fields are stored in
-`CachedGraph` atomically.
+`CachedGraph` atomically. Passing `0` ensures Louvain always runs regardless
+of graph size; the caller-supplied `min_nodes` gate is applied at read time,
+not at build time.
 
 `compute_communities` and `node_community_map` are thin wrappers over
 `build_community_data` — they extract `.0` and `.1` respectively. This ensures
 all three entry points share identical Louvain logic with no duplication.
-
-The community threshold used is `30` (the default config value). Callers
-requesting a higher threshold get a fresh recompute without overwriting the
-cache. This keeps the cache a single stable entry per space.
 
 ## `GraphFilter::is_default()`
 
@@ -182,8 +180,8 @@ accepts pre-built graphs rather than raw index handles.
 - Cache lives only for process lifetime. Cold start always rebuilds.
   See [imp-graph-snapshot.md](../improvements/imp-graph-snapshot.md) for
   the planned persistent snapshot feature.
-- Community data is cached at `min_nodes = 30`. Wikis configured with a
-  different threshold recompute communities on every call (but reuse the
-  cached graph structure).
+- Community data is always computed (Louvain runs at threshold 0). The
+  caller-supplied `min_nodes` is applied at read time — no recompute needed
+  for different thresholds, cached graph and community data are always reused.
 - Only unfiltered full graphs are cached. Each distinct filter combination
   builds fresh.

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -1,0 +1,188 @@
+---
+title: "Graph Cache Implementation"
+summary: "In-memory graph cache keyed on index generation — eliminates redundant build_graph and Louvain calls in serve mode."
+status: ready
+last_updated: "2026-04-30"
+depends_on:
+  - engine.md
+  - index-manager.md
+---
+
+# Graph Cache Implementation
+
+Implementation reference for the in-memory graph cache introduced in v0.3.0.
+Not a specification — see [graph.md](../specifications/engine/graph.md) for
+the design contract.
+
+## Problem
+
+`build_graph` scans the entire tantivy index on every call. In serve mode
+(`wiki_graph`, `wiki_stats`, `wiki_suggest`), the same full graph is rebuilt
+on every request even when nothing has changed. Louvain community detection
+compounds the cost — it ran on every `wiki_stats` and `wiki_suggest` call.
+
+## Core structs
+
+```rust
+// src/graph.rs
+
+pub struct CachedGraph {
+    pub graph:            Arc<WikiGraph>,
+    pub community_map:    Option<Arc<HashMap<String, usize>>>,
+    pub community_stats:  Option<CommunityStats>,
+    pub index_gen:        u64,
+}
+```
+
+`community_map` — slug→community_id, used by `wiki_suggest` strategy 4.
+`community_stats` — aggregated stats (`count`, `isolated` list), used by `wiki_stats`.
+`index_gen` — generation value at cache time; compared against current generation to detect staleness.
+
+`CachedGraph` lives in `SpaceContext`:
+
+```rust
+// src/engine.rs
+pub graph_cache: RwLock<Option<CachedGraph>>,
+```
+
+Multiple readers can use the cached graph simultaneously. A single writer
+rebuilds and stores on miss.
+
+## Cache key: `AtomicU64` generation counter
+
+`IndexInner` in `SpaceIndexManager` holds a `generation: AtomicU64` starting
+at 0. Every successful `reload_reader()` call does:
+
+```rust
+inner.generation.fetch_add(1, Ordering::AcqRel);
+```
+
+`reload_reader()` is called at the end of every write path:
+- `rebuild()` — full index rebuild
+- `update()` — incremental update from git diff
+- `delete_by_type()` — type-targeted delete
+- `rebuild_types()` — partial type rebuild
+- watch-mode ingest
+
+Exposed as:
+
+```rust
+pub fn generation(&self) -> u64 {
+    self.inner.read().unwrap().generation.load(Ordering::Acquire)
+}
+```
+
+No explicit cache flush is ever needed. Any index write automatically
+invalidates the cache on the next graph request.
+
+## Public accessors
+
+All live in `src/graph.rs`. Callers pass individual fields rather than
+`&SpaceContext` to avoid a circular dependency between `graph.rs` and
+`engine.rs`.
+
+### `get_or_build_graph`
+
+```rust
+pub fn get_or_build_graph(
+    index_schema:  &IndexSchema,
+    type_registry: &SpaceTypeRegistry,
+    index_manager: &SpaceIndexManager,
+    graph_cache:   &RwLock<Option<CachedGraph>>,
+    searcher:      &Searcher,
+    filter:        &GraphFilter,
+) -> Result<Arc<WikiGraph>>
+```
+
+- Filtered requests (`!filter.is_default()`) bypass cache, build and return fresh.
+- Cache hit: `cached.index_gen == current_gen` → return `Arc::clone`.
+- Cache miss: build graph, compute `community_map` + `community_stats`, store, return.
+
+### `get_cached_community_map`
+
+```rust
+pub fn get_cached_community_map(
+    ...,
+    min_nodes: usize,
+) -> Result<Option<Arc<HashMap<String, usize>>>>
+```
+
+Returns cached `community_map`. If `min_nodes > 30` (the cache threshold),
+recomputes without overwriting cache. Triggers graph build as side effect on
+miss.
+
+### `get_cached_community_stats`
+
+```rust
+pub fn get_cached_community_stats(
+    ...,
+    min_nodes: usize,
+) -> Result<Option<CommunityStats>>
+```
+
+Same pattern as `get_cached_community_map` but returns `CommunityStats`. Used
+by `ops/stats.rs` to skip Louvain on cache hit.
+
+## Cache population
+
+On every cache miss, `get_or_build_graph` runs:
+
+```
+build_graph(...)              → Arc<WikiGraph>
+node_community_map(&graph, 30)  → Option<HashMap<String, usize>>
+compute_communities(&graph, 30) → Option<CommunityStats>
+```
+
+Both community computations use threshold `30` (the default config value).
+Callers requesting a higher threshold get a fresh recompute without overwriting
+the cache. This keeps the cache a single stable entry per space.
+
+## `GraphFilter::is_default()`
+
+```rust
+pub fn is_default(&self) -> bool {
+    self.root.is_none() && self.types.is_empty() && self.relation.is_none()
+}
+```
+
+`depth` is intentionally excluded — a depth-limited request still uses the full
+cached graph; the caller extracts a subgraph via BFS post-cache.
+
+## Callers
+
+| Caller | Uses cache via |
+|--------|----------------|
+| `ops/graph.rs` — single-wiki path | `get_or_build_graph` |
+| `ops/stats.rs` | `get_or_build_graph` + `get_cached_community_stats` |
+| `ops/suggest.rs` | `get_or_build_graph` + `get_cached_community_map` |
+| `ops/graph.rs` — cross-wiki path | `get_or_build_graph` per space + `merge_cached_graphs` |
+
+## Cross-wiki caching
+
+`build_graph_cross_wiki` takes raw `(searcher, schema, registry)` tuples and
+calls `build_graph` directly — it cannot use the per-space cache.
+
+The cross-wiki path in `ops/graph.rs` works around this by pre-building each
+per-space graph via `get_or_build_graph` (cache-aware), then passing the
+resulting `Arc<WikiGraph>` slices to `merge_cached_graphs`:
+
+```rust
+pub fn merge_cached_graphs(
+    wikis: &[(&str, Arc<WikiGraph>)],
+    filter: &GraphFilter,
+) -> Result<WikiGraph>
+```
+
+`merge_cached_graphs` has the same semantics as `build_graph_cross_wiki` but
+accepts pre-built graphs rather than raw index handles.
+
+## Limitations
+
+- Cache lives only for process lifetime. Cold start always rebuilds.
+  See [imp-graph-snapshot.md](../improvements/imp-graph-snapshot.md) for
+  the planned persistent snapshot feature.
+- Community data is cached at `min_nodes = 30`. Wikis configured with a
+  different threshold recompute communities on every call (but reuse the
+  cached graph structure).
+- Only unfiltered full graphs are cached. Each distinct filter combination
+  builds fresh.

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -125,17 +125,14 @@ by `ops/stats.rs` to skip Louvain on cache hit.
 
 ## Cache population
 
-On every cache miss, `get_or_build_graph` runs:
+On cache miss, calls `build_community_data(graph)` — a private helper that
+runs Louvain exactly once and returns both `CommunityStats` and
+`HashMap<String, usize>` (community map). Both fields are stored in
+`CachedGraph` atomically.
 
-```
-build_graph(...)              → Arc<WikiGraph>
-node_community_map(&graph, 30)  → Option<HashMap<String, usize>>
-compute_communities(&graph, 30) → Option<CommunityStats>
-```
-
-Both community computations use threshold `30` (the default config value).
-Callers requesting a higher threshold get a fresh recompute without overwriting
-the cache. This keeps the cache a single stable entry per space.
+The community threshold used is `30` (the default config value). Callers
+requesting a higher threshold get a fresh recompute without overwriting the
+cache. This keeps the cache a single stable entry per space.
 
 ## `GraphFilter::is_default()`
 

--- a/docs/specifications/engine/graph.md
+++ b/docs/specifications/engine/graph.md
@@ -158,6 +158,14 @@ with `status: generated`.
 The graph is built from the tantivy index — no file reads. Construction
 is O(pages + edges). Rendering is O(filtered nodes + filtered edges).
 
+In serve mode (`llm-wiki serve`), the full unfiltered graph is cached
+in memory per wiki space and reused across `wiki_graph`, `wiki_stats`,
+and `wiki_suggest` calls. The cache is keyed on an index generation
+counter incremented after every write (`reload_reader`). Filtered
+graph requests (type, relation, root) bypass the cache and build on
+demand. See [graph-cache.md](../implementation/graph-cache.md) for the
+implementation.
+
 ## Community detection
 
 Louvain clustering runs on a symmetrized view of the directed graph (each directed
@@ -191,7 +199,7 @@ fewer passes; the cap only applies to adversarial small graphs.
 
 ## Future Improvements
 
-- Persistent graph index alongside tantivy to avoid rebuilding petgraph
-  on every call
+- Persistent graph snapshot alongside tantivy index — survives process
+  restart; see [imp-graph-snapshot.md](../improvements/imp-graph-snapshot.md)
 - Graph queries beyond rendering: shortest path, connected components,
   orphan detection

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -255,13 +255,13 @@ fn louvain_phase1(
 }
 
 /// Run Louvain community detection on `graph`. Returns `None` when local node count < `min_nodes`.
-/// External placeholder nodes are excluded. Processing order is sorted by slug for determinism.
-/// The internal phase-1 loop is capped at `n × 10` passes to guard against oscillation.
+/// Delegates to `build_community_data` — see its doc for algorithm details.
 pub fn compute_communities(graph: &WikiGraph, min_nodes: usize) -> Option<CommunityStats> {
     build_community_data(graph, min_nodes).0
 }
 
-/// Returns slug → community id map, or `None` when below threshold. Used by `suggest.rs` strategy 4.
+/// Returns slug → community id map, or `None` when below threshold.
+/// Delegates to `build_community_data` — shares the same Louvain run as `compute_communities`.
 pub fn node_community_map(graph: &WikiGraph, min_nodes: usize) -> Option<HashMap<String, usize>> {
     build_community_data(graph, min_nodes).1
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -258,131 +258,12 @@ fn louvain_phase1(
 /// External placeholder nodes are excluded. Processing order is sorted by slug for determinism.
 /// The internal phase-1 loop is capped at `n × 10` passes to guard against oscillation.
 pub fn compute_communities(graph: &WikiGraph, min_nodes: usize) -> Option<CommunityStats> {
-    // Only count non-external nodes
-    let local_nodes: Vec<NodeIndex> = {
-        let mut v: Vec<NodeIndex> = graph
-            .node_indices()
-            .filter(|&idx| !graph[idx].external)
-            .collect();
-        v.sort_by_key(|&idx| graph[idx].slug.clone());
-        v
-    };
-
-    if local_nodes.len() < min_nodes {
-        return None;
-    }
-
-    let adj = build_adjacency(graph);
-
-    // Degree per node (undirected, local only)
-    let degrees: HashMap<NodeIndex, usize> =
-        local_nodes.iter().map(|&n| (n, adj[&n].len())).collect();
-
-    let m: usize = adj.values().map(|s| s.len()).sum::<usize>() / 2;
-
-    // Initial assignment: each node in its own community
-    let mut community: HashMap<NodeIndex, usize> = local_nodes
-        .iter()
-        .enumerate()
-        .map(|(i, &n)| (n, i))
-        .collect();
-
-    louvain_phase1(&adj, &mut community, &degrees, m);
-
-    // Normalize community ids to contiguous 0..k
-    let mut id_remap: HashMap<usize, usize> = HashMap::new();
-    let mut next_id = 0usize;
-    for &n in &local_nodes {
-        let c = *community.get(&n).unwrap();
-        id_remap.entry(c).or_insert_with(|| {
-            let id = next_id;
-            next_id += 1;
-            id
-        });
-    }
-    for val in community.values_mut() {
-        *val = *id_remap.get(val).unwrap();
-    }
-
-    let count = next_id;
-
-    // Compute sizes
-    let mut sizes: HashMap<usize, usize> = HashMap::new();
-    for &c in community.values() {
-        *sizes.entry(c).or_default() += 1;
-    }
-
-    let largest = sizes.values().copied().max().unwrap_or(0);
-    let smallest = sizes.values().copied().min().unwrap_or(0);
-
-    // Isolated: slugs in communities of size <= 2, sorted
-    let mut isolated: Vec<String> = local_nodes
-        .iter()
-        .filter(|&&n| {
-            let c = *community.get(&n).unwrap();
-            *sizes.get(&c).unwrap_or(&0) <= 2
-        })
-        .map(|&n| graph[n].slug.clone())
-        .collect();
-    isolated.sort();
-
-    Some(CommunityStats {
-        count,
-        largest,
-        smallest,
-        isolated,
-    })
+    build_community_data(graph, min_nodes).0
 }
 
 /// Returns slug → community id map, or `None` when below threshold. Used by `suggest.rs` strategy 4.
 pub fn node_community_map(graph: &WikiGraph, min_nodes: usize) -> Option<HashMap<String, usize>> {
-    let local_nodes: Vec<NodeIndex> = {
-        let mut v: Vec<NodeIndex> = graph
-            .node_indices()
-            .filter(|&idx| !graph[idx].external)
-            .collect();
-        v.sort_by_key(|&idx| graph[idx].slug.clone());
-        v
-    };
-
-    if local_nodes.len() < min_nodes {
-        return None;
-    }
-
-    let adj = build_adjacency(graph);
-    let degrees: HashMap<NodeIndex, usize> =
-        local_nodes.iter().map(|&n| (n, adj[&n].len())).collect();
-    let m: usize = adj.values().map(|s| s.len()).sum::<usize>() / 2;
-
-    let mut community: HashMap<NodeIndex, usize> = local_nodes
-        .iter()
-        .enumerate()
-        .map(|(i, &n)| (n, i))
-        .collect();
-
-    louvain_phase1(&adj, &mut community, &degrees, m);
-
-    // Normalize
-    let mut id_remap: HashMap<usize, usize> = HashMap::new();
-    let mut next_id = 0usize;
-    for &n in &local_nodes {
-        let c = *community.get(&n).unwrap();
-        id_remap.entry(c).or_insert_with(|| {
-            let id = next_id;
-            next_id += 1;
-            id
-        });
-    }
-
-    Some(
-        local_nodes
-            .iter()
-            .map(|&n| {
-                let c = *id_remap.get(community.get(&n).unwrap()).unwrap();
-                (graph[n].slug.clone(), c)
-            })
-            .collect(),
-    )
+    build_community_data(graph, min_nodes).1
 }
 
 // ── build_graph ───────────────────────────────────────────────────────────────
@@ -1077,6 +958,7 @@ pub fn subgraph(graph: &WikiGraph, root_slug: &str, depth: usize) -> WikiGraph {
 /// Returns `(None, None)` when graph is below `min_nodes` threshold.
 fn build_community_data(
     graph: &WikiGraph,
+    min_nodes: usize,
 ) -> (Option<CommunityStats>, Option<HashMap<String, usize>>) {
     let local_nodes: Vec<NodeIndex> = {
         let mut v: Vec<NodeIndex> = graph
@@ -1087,7 +969,7 @@ fn build_community_data(
         v
     };
 
-    if local_nodes.len() < 30 {
+    if local_nodes.len() < min_nodes {
         return (None, None);
     }
 
@@ -1184,7 +1066,7 @@ pub fn get_or_build_graph(
 
     // Cache miss — build
     let graph = Arc::new(build_graph(searcher, index_schema, filter, type_registry)?);
-    let (community_stats, community_map_raw) = build_community_data(&graph);
+    let (community_stats, community_map_raw) = build_community_data(&graph, 30);
     let community_map = community_map_raw.map(Arc::new);
 
     *graph_cache.write().unwrap() = Some(CachedGraph {
@@ -1209,7 +1091,7 @@ pub fn get_cached_community_map(
 ) -> Result<Option<Arc<HashMap<String, usize>>>> {
     debug_assert!(
         min_nodes <= 30,
-        "min_nodes > 30 bypasses cache and runs a fresh Louvain pass"
+        "min_nodes > 30 bypasses cached threshold and recomputes"
     );
 
     let current_gen = index_manager.generation();
@@ -1224,8 +1106,8 @@ pub fn get_cached_community_map(
                 return Ok(cached.community_map.clone());
             }
             // Caller wants higher threshold — recompute without caching variant
-            let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
-            return Ok(map);
+            let (_, map) = build_community_data(&cached.graph, min_nodes);
+            return Ok(map.map(Arc::new));
         }
     }
 
@@ -1246,8 +1128,8 @@ pub fn get_cached_community_map(
             if min_nodes <= 30 {
                 return Ok(cached.community_map.clone());
             }
-            let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
-            return Ok(map);
+            let (_, map) = build_community_data(&cached.graph, min_nodes);
+            return Ok(map.map(Arc::new));
         }
     }
 
@@ -1266,7 +1148,7 @@ pub fn get_cached_community_stats(
 ) -> Result<Option<CommunityStats>> {
     debug_assert!(
         min_nodes <= 30,
-        "min_nodes > 30 runs separate Louvain passes for stats vs map — IDs may diverge"
+        "min_nodes > 30 bypasses cached threshold and recomputes"
     );
 
     let current_gen = index_manager.generation();
@@ -1281,10 +1163,7 @@ pub fn get_cached_community_stats(
                 return Ok(cached.community_stats.clone());
             }
             // Caller wants higher threshold — recompute without overwriting cache
-            // NOTE: when min_nodes > 30, this calls compute_communities separately from
-            // get_cached_community_map's node_community_map call — community IDs may diverge.
-            // Current callers always use min_nodes=30 (the cached threshold) so this is safe.
-            let stats = compute_communities(&cached.graph, min_nodes);
+            let (stats, _) = build_community_data(&cached.graph, min_nodes);
             return Ok(stats);
         }
     }
@@ -1306,10 +1185,7 @@ pub fn get_cached_community_stats(
             if min_nodes <= 30 {
                 return Ok(cached.community_stats.clone());
             }
-            // NOTE: when min_nodes > 30, this calls compute_communities separately from
-            // get_cached_community_map's node_community_map call — community IDs may diverge.
-            // Current callers always use min_nodes=30 (the cached threshold) so this is safe.
-            let stats = compute_communities(&cached.graph, min_nodes);
+            let (stats, _) = build_community_data(&cached.graph, min_nodes);
             return Ok(stats);
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -717,10 +717,10 @@ pub fn merge_cached_graphs(
             // Relation filter re-applied here. If graphs were built without this filter,
             // this is the only gate — see precondition in doc comment.
             let relation = graph[edge_idx].relation.clone();
-            if let Some(ref rel_filter) = filter.relation {
-                if &relation != rel_filter {
-                    continue;
-                }
+            if let Some(ref rel_filter) = filter.relation
+                && &relation != rel_filter
+            {
+                continue;
             }
 
             let from_key = format!("{wiki_name}/{}", from_node.slug);
@@ -756,11 +756,7 @@ pub fn merge_cached_graphs(
             };
 
             if from_merged != to_merged {
-                merged.add_edge(
-                    from_merged,
-                    to_merged,
-                    LabeledEdge { relation },
-                );
+                merged.add_edge(from_merged, to_merged, LabeledEdge { relation });
             }
         }
     }
@@ -1147,7 +1143,12 @@ fn build_community_data(
         .collect();
     isolated.sort();
 
-    let stats = CommunityStats { count, largest, smallest, isolated };
+    let stats = CommunityStats {
+        count,
+        largest,
+        smallest,
+        isolated,
+    };
 
     (Some(stats), Some(community_map))
 }
@@ -1206,7 +1207,10 @@ pub fn get_cached_community_map(
     searcher: &Searcher,
     min_nodes: usize,
 ) -> Result<Option<Arc<HashMap<String, usize>>>> {
-    debug_assert!(min_nodes <= 30, "min_nodes > 30 bypasses cache and runs a fresh Louvain pass");
+    debug_assert!(
+        min_nodes <= 30,
+        "min_nodes > 30 bypasses cache and runs a fresh Louvain pass"
+    );
 
     let current_gen = index_manager.generation();
 
@@ -1260,7 +1264,10 @@ pub fn get_cached_community_stats(
     searcher: &Searcher,
     min_nodes: usize,
 ) -> Result<Option<CommunityStats>> {
-    debug_assert!(min_nodes <= 30, "min_nodes > 30 runs separate Louvain passes for stats vs map — IDs may diverge");
+    debug_assert!(
+        min_nodes <= 30,
+        "min_nodes > 30 runs separate Louvain passes for stats vs map — IDs may diverge"
+    );
 
     let current_gen = index_manager.generation();
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1102,10 +1102,13 @@ pub fn get_cached_community_map(
         if let Some(cached) = cache.as_ref()
             && cached.index_gen == current_gen
         {
-            if min_nodes <= 30 {
+            // Return pre-built map only when it covers the requested threshold.
+            // cached.community_map was built at threshold=30; if min_nodes < 30 the
+            // cached map may be None for graphs with 5–29 nodes even though the caller
+            // would expect Some — so fall through to recompute at actual min_nodes.
+            if min_nodes <= 30 && cached.community_map.is_some() {
                 return Ok(cached.community_map.clone());
             }
-            // Caller wants higher threshold — recompute without caching variant
             let (_, map) = build_community_data(&cached.graph, min_nodes);
             return Ok(map.map(Arc::new));
         }
@@ -1125,7 +1128,7 @@ pub fn get_cached_community_map(
     {
         let cache = graph_cache.read().unwrap();
         if let Some(cached) = cache.as_ref() {
-            if min_nodes <= 30 {
+            if min_nodes <= 30 && cached.community_map.is_some() {
                 return Ok(cached.community_map.clone());
             }
             let (_, map) = build_community_data(&cached.graph, min_nodes);
@@ -1159,10 +1162,13 @@ pub fn get_cached_community_stats(
         if let Some(cached) = cache.as_ref()
             && cached.index_gen == current_gen
         {
-            if min_nodes <= 30 {
+            // Return pre-built stats only when it covers the requested threshold.
+            // cached.community_stats was built at threshold=30; if min_nodes < 30 the
+            // cached stats may be None for graphs with 5–29 nodes even though the caller
+            // would expect Some — so fall through to recompute at actual min_nodes.
+            if min_nodes <= 30 && cached.community_stats.is_some() {
                 return Ok(cached.community_stats.clone());
             }
-            // Caller wants higher threshold — recompute without overwriting cache
             let (stats, _) = build_community_data(&cached.graph, min_nodes);
             return Ok(stats);
         }
@@ -1182,7 +1188,7 @@ pub fn get_cached_community_stats(
     {
         let cache = graph_cache.read().unwrap();
         if let Some(cached) = cache.as_ref() {
-            if min_nodes <= 30 {
+            if min_nodes <= 30 && cached.community_stats.is_some() {
                 return Ok(cached.community_stats.clone());
             }
             let (stats, _) = build_community_data(&cached.graph, min_nodes);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -666,7 +666,13 @@ pub fn build_graph_cross_wiki(
 /// # Precondition
 /// Each `Arc<WikiGraph>` in `wikis` should have been built with the same `filter`.
 /// The relation and type filters are re-applied here as a safety gate, but if the
-/// cached graph was built without a filter, this function is the only filter gate.
+/// cached graph was built without a filter, this function is the only gate.
+///
+/// `filter.root` and `filter.depth` are NOT re-applied — `get_or_build_graph` only
+/// caches the full unfiltered graph (it bypasses cache for non-default filters), so
+/// subgraph traversal from a root must be done by the caller after merging.
+/// In `ops/graph.rs`, the cross-wiki path always calls `get_or_build_graph` with
+/// `is_default()` filter, so this precondition holds in practice.
 pub fn merge_cached_graphs(
     wikis: &[(&str, Arc<WikiGraph>)],
     filter: &GraphFilter,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -976,7 +976,7 @@ fn build_community_data(
             .node_indices()
             .filter(|&idx| !graph[idx].external)
             .collect();
-        v.sort_by_key(|&i| graph[i].slug.clone());
+        v.sort_by(|&a, &b| graph[a].slug.cmp(&graph[b].slug));
         v
     };
 
@@ -1095,6 +1095,8 @@ pub fn get_cached_community_map(
     searcher: &Searcher,
     min_nodes: usize,
 ) -> Result<Option<Arc<HashMap<String, usize>>>> {
+    debug_assert!(min_nodes <= 30, "min_nodes > 30 bypasses cache and runs a fresh Louvain pass");
+
     let current_gen = index_manager.generation();
 
     // Check cache hit
@@ -1122,12 +1124,10 @@ pub fn get_cached_community_map(
         &GraphFilter::default(),
     )?;
 
-    // Re-read
+    // Re-read (no gen check — cache is valid at whatever generation get_or_build_graph wrote)
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref()
-            && cached.index_gen == current_gen
-        {
+        if let Some(cached) = cache.as_ref() {
             if min_nodes <= 30 {
                 return Ok(cached.community_map.clone());
             }
@@ -1149,6 +1149,8 @@ pub fn get_cached_community_stats(
     searcher: &Searcher,
     min_nodes: usize,
 ) -> Result<Option<CommunityStats>> {
+    debug_assert!(min_nodes <= 30, "min_nodes > 30 runs separate Louvain passes for stats vs map — IDs may diverge");
+
     let current_gen = index_manager.generation();
 
     // Check cache hit
@@ -1179,12 +1181,10 @@ pub fn get_cached_community_stats(
         &GraphFilter::default(),
     )?;
 
-    // Re-read after population
+    // Re-read after population (no gen check — cache is valid at whatever generation get_or_build_graph wrote)
     {
         let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref()
-            && cached.index_gen == current_gen
-        {
+        if let Some(cached) = cache.as_ref() {
             if min_nodes <= 30 {
                 return Ok(cached.community_stats.clone());
             }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -970,7 +970,6 @@ pub fn subgraph(graph: &WikiGraph, root_slug: &str, depth: usize) -> WikiGraph {
 /// Returns `(None, None)` when graph is below `min_nodes` threshold.
 fn build_community_data(
     graph: &WikiGraph,
-    min_nodes: usize,
 ) -> (Option<CommunityStats>, Option<HashMap<String, usize>>) {
     let local_nodes: Vec<NodeIndex> = {
         let mut v: Vec<NodeIndex> = graph
@@ -981,7 +980,7 @@ fn build_community_data(
         v
     };
 
-    if local_nodes.len() < min_nodes {
+    if local_nodes.len() < 30 {
         return (None, None);
     }
 
@@ -1073,7 +1072,7 @@ pub fn get_or_build_graph(
 
     // Cache miss — build
     let graph = Arc::new(build_graph(searcher, index_schema, filter, type_registry)?);
-    let (community_stats, community_map_raw) = build_community_data(&graph, 30);
+    let (community_stats, community_map_raw) = build_community_data(&graph);
     let community_map = community_map_raw.map(Arc::new);
 
     *graph_cache.write().unwrap() = Some(CachedGraph {
@@ -1162,6 +1161,9 @@ pub fn get_cached_community_stats(
                 return Ok(cached.community_stats.clone());
             }
             // Caller wants higher threshold — recompute without overwriting cache
+            // NOTE: when min_nodes > 30, this calls compute_communities separately from
+            // get_cached_community_map's node_community_map call — community IDs may diverge.
+            // Current callers always use min_nodes=30 (the cached threshold) so this is safe.
             let stats = compute_communities(&cached.graph, min_nodes);
             return Ok(stats);
         }
@@ -1186,6 +1188,9 @@ pub fn get_cached_community_stats(
             if min_nodes <= 30 {
                 return Ok(cached.community_stats.clone());
             }
+            // NOTE: when min_nodes > 30, this calls compute_communities separately from
+            // get_cached_community_map's node_community_map call — community IDs may diverge.
+            // Current callers always use min_nodes=30 (the cached threshold) so this is safe.
             let stats = compute_communities(&cached.graph, min_nodes);
             return Ok(stats);
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -662,6 +662,11 @@ pub fn build_graph_cross_wiki(
 /// Merge pre-built per-space graphs into a single cross-wiki graph.
 /// Accepts `Arc<WikiGraph>` inputs (from cache) instead of building from index.
 /// Matches the slug-prefixing and external-node resolution of `build_graph_cross_wiki`.
+///
+/// # Precondition
+/// Each `Arc<WikiGraph>` in `wikis` should have been built with the same `filter`.
+/// The relation and type filters are re-applied here as a safety gate, but if the
+/// cached graph was built without a filter, this function is the only filter gate.
 pub fn merge_cached_graphs(
     wikis: &[(&str, Arc<WikiGraph>)],
     filter: &GraphFilter,
@@ -676,7 +681,8 @@ pub fn merge_cached_graphs(
             if node.external {
                 continue;
             }
-            // Type filter already applied during per-space build, but re-check for safety
+            // Type filter re-applied here — matches build_graph_cross_wiki's first-pass filter.
+            // Precondition: input graphs should have been built with matching filter.
             if !filter.types.is_empty() && !filter.types.contains(&node.r#type) {
                 continue;
             }
@@ -702,7 +708,8 @@ pub fn merge_cached_graphs(
                 continue;
             }
 
-            // Apply relation filter
+            // Relation filter re-applied here. If graphs were built without this filter,
+            // this is the only gate — see precondition in doc comment.
             let relation = graph[edge_idx].relation.clone();
             if let Some(ref rel_filter) = filter.relation {
                 if &relation != rel_filter {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -657,6 +657,104 @@ pub fn build_graph_cross_wiki(
     Ok(merged)
 }
 
+// ── merge_cached_graphs ──────────────────────────────────────────────────────
+
+/// Merge pre-built per-space graphs into a single cross-wiki graph.
+/// Accepts `Arc<WikiGraph>` inputs (from cache) instead of building from index.
+/// Matches the slug-prefixing and external-node resolution of `build_graph_cross_wiki`.
+pub fn merge_cached_graphs(
+    wikis: &[(&str, Arc<WikiGraph>)],
+    filter: &GraphFilter,
+) -> Result<WikiGraph> {
+    let mut merged = WikiGraph::new();
+    let mut global_idx: HashMap<String, NodeIndex> = HashMap::new();
+
+    // First pass: add all local (non-external) nodes with "wikiname/slug" keys
+    for (wiki_name, graph) in wikis {
+        for idx in graph.node_indices() {
+            let node = &graph[idx];
+            if node.external {
+                continue;
+            }
+            // Type filter already applied during per-space build, but re-check for safety
+            if !filter.types.is_empty() && !filter.types.contains(&node.r#type) {
+                continue;
+            }
+            let key = format!("{wiki_name}/{}", node.slug);
+            let new_idx = merged.add_node(PageNode {
+                slug: key.clone(),
+                title: node.title.clone(),
+                r#type: node.r#type.clone(),
+                external: false,
+            });
+            global_idx.insert(key, new_idx);
+        }
+    }
+
+    // Second pass: add edges, re-resolving cross-wiki external nodes
+    for (wiki_name, graph) in wikis {
+        for edge_idx in graph.edge_indices() {
+            let (from, to) = graph.edge_endpoints(edge_idx).unwrap();
+            let from_node = &graph[from];
+            let to_node = &graph[to];
+
+            if from_node.external {
+                continue;
+            }
+
+            // Apply relation filter
+            let relation = graph[edge_idx].relation.clone();
+            if let Some(ref rel_filter) = filter.relation {
+                if &relation != rel_filter {
+                    continue;
+                }
+            }
+
+            let from_key = format!("{wiki_name}/{}", from_node.slug);
+            let from_merged = match global_idx.get(&from_key) {
+                Some(&i) => i,
+                None => continue,
+            };
+
+            // Resolve destination: external nodes have title = "wiki://otherwiki/slug"
+            let to_key = if to_node.external {
+                if let ParsedLink::CrossWiki { wiki, slug } = ParsedLink::parse(&to_node.title) {
+                    format!("{wiki}/{slug}")
+                } else {
+                    continue;
+                }
+            } else {
+                format!("{wiki_name}/{}", to_node.slug)
+            };
+
+            let to_merged = match global_idx.get(&to_key) {
+                Some(&i) => i,
+                None => {
+                    // Target wiki not mounted — keep as external placeholder
+                    *global_idx.entry(to_key.clone()).or_insert_with(|| {
+                        merged.add_node(PageNode {
+                            slug: to_key.clone(),
+                            title: to_node.title.clone(),
+                            r#type: "external".to_string(),
+                            external: true,
+                        })
+                    })
+                }
+            };
+
+            if from_merged != to_merged {
+                merged.add_edge(
+                    from_merged,
+                    to_merged,
+                    LabeledEdge { relation },
+                );
+            }
+        }
+    }
+
+    Ok(merged)
+}
+
 // ── render_llms ───────────────────────────────────────────────────────────────
 
 /// Natural language description of graph structure for direct LLM consumption.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -47,9 +47,9 @@ pub type WikiGraph = DiGraph<PageNode, LabeledEdge>;
 pub struct CachedGraph {
     /// The full unfiltered wiki graph.
     pub graph: Arc<WikiGraph>,
-    /// Precomputed community map (slug → community_id), None if graph is too small.
+    /// Precomputed community map (slug → community_id). Some for any non-empty graph.
     pub community_map: Option<Arc<HashMap<String, usize>>>,
-    /// Precomputed community stats, None if graph is too small.
+    /// Precomputed community stats. Some for any non-empty graph.
     pub community_stats: Option<CommunityStats>,
     /// Generation value from SpaceIndexManager at cache time.
     pub index_gen: u64,
@@ -955,7 +955,7 @@ pub fn subgraph(graph: &WikiGraph, root_slug: &str, depth: usize) -> WikiGraph {
 // ── build_community_data ─────────────────────────────────────────────────────
 
 /// Run Louvain once and return both community outputs.
-/// Returns `(None, None)` when graph is below `min_nodes` threshold.
+/// Returns `(None, None)` when local node count < `min_nodes` (pass 0 to always run).
 fn build_community_data(
     graph: &WikiGraph,
     min_nodes: usize,
@@ -1066,7 +1066,7 @@ pub fn get_or_build_graph(
 
     // Cache miss — build
     let graph = Arc::new(build_graph(searcher, index_schema, filter, type_registry)?);
-    let (community_stats, community_map_raw) = build_community_data(&graph, 30);
+    let (community_stats, community_map_raw) = build_community_data(&graph, 0);
     let community_map = community_map_raw.map(Arc::new);
 
     *graph_cache.write().unwrap() = Some(CachedGraph {
@@ -1089,11 +1089,6 @@ pub fn get_cached_community_map(
     searcher: &Searcher,
     min_nodes: usize,
 ) -> Result<Option<Arc<HashMap<String, usize>>>> {
-    debug_assert!(
-        min_nodes <= 30,
-        "min_nodes > 30 bypasses cached threshold and recomputes"
-    );
-
     let current_gen = index_manager.generation();
 
     // Check cache hit
@@ -1102,19 +1097,19 @@ pub fn get_cached_community_map(
         if let Some(cached) = cache.as_ref()
             && cached.index_gen == current_gen
         {
-            // Return pre-built map only when it covers the requested threshold.
-            // cached.community_map was built at threshold=30; if min_nodes < 30 the
-            // cached map may be None for graphs with 5–29 nodes even though the caller
-            // would expect Some — so fall through to recompute at actual min_nodes.
-            if min_nodes <= 30 && cached.community_map.is_some() {
-                return Ok(cached.community_map.clone());
+            let local_count = cached
+                .graph
+                .node_indices()
+                .filter(|&i| !cached.graph[i].external)
+                .count();
+            if local_count < min_nodes {
+                return Ok(None);
             }
-            let (_, map) = build_community_data(&cached.graph, min_nodes);
-            return Ok(map.map(Arc::new));
+            return Ok(cached.community_map.clone());
         }
     }
 
-    // Cache miss — build graph (caches community_map at threshold=30)
+    // Cache miss — build graph and community data
     get_or_build_graph(
         index_schema,
         type_registry,
@@ -1128,11 +1123,15 @@ pub fn get_cached_community_map(
     {
         let cache = graph_cache.read().unwrap();
         if let Some(cached) = cache.as_ref() {
-            if min_nodes <= 30 && cached.community_map.is_some() {
-                return Ok(cached.community_map.clone());
+            let local_count = cached
+                .graph
+                .node_indices()
+                .filter(|&i| !cached.graph[i].external)
+                .count();
+            if local_count < min_nodes {
+                return Ok(None);
             }
-            let (_, map) = build_community_data(&cached.graph, min_nodes);
-            return Ok(map.map(Arc::new));
+            return Ok(cached.community_map.clone());
         }
     }
 
@@ -1149,11 +1148,6 @@ pub fn get_cached_community_stats(
     searcher: &Searcher,
     min_nodes: usize,
 ) -> Result<Option<CommunityStats>> {
-    debug_assert!(
-        min_nodes <= 30,
-        "min_nodes > 30 bypasses cached threshold and recomputes"
-    );
-
     let current_gen = index_manager.generation();
 
     // Check cache hit
@@ -1162,19 +1156,19 @@ pub fn get_cached_community_stats(
         if let Some(cached) = cache.as_ref()
             && cached.index_gen == current_gen
         {
-            // Return pre-built stats only when it covers the requested threshold.
-            // cached.community_stats was built at threshold=30; if min_nodes < 30 the
-            // cached stats may be None for graphs with 5–29 nodes even though the caller
-            // would expect Some — so fall through to recompute at actual min_nodes.
-            if min_nodes <= 30 && cached.community_stats.is_some() {
-                return Ok(cached.community_stats.clone());
+            let local_count = cached
+                .graph
+                .node_indices()
+                .filter(|&i| !cached.graph[i].external)
+                .count();
+            if local_count < min_nodes {
+                return Ok(None);
             }
-            let (stats, _) = build_community_data(&cached.graph, min_nodes);
-            return Ok(stats);
+            return Ok(cached.community_stats.clone());
         }
     }
 
-    // Cache miss — build graph (populates community_stats at threshold=30)
+    // Cache miss — build graph and community data
     get_or_build_graph(
         index_schema,
         type_registry,
@@ -1184,15 +1178,19 @@ pub fn get_cached_community_stats(
         &GraphFilter::default(),
     )?;
 
-    // Re-read after population (no gen check — cache is valid at whatever generation get_or_build_graph wrote)
+    // Re-read (no gen check — cache is valid at whatever generation get_or_build_graph wrote)
     {
         let cache = graph_cache.read().unwrap();
         if let Some(cached) = cache.as_ref() {
-            if min_nodes <= 30 && cached.community_stats.is_some() {
-                return Ok(cached.community_stats.clone());
+            let local_count = cached
+                .graph
+                .node_indices()
+                .filter(|&i| !cached.graph[i].external)
+                .count();
+            if local_count < min_nodes {
+                return Ok(None);
             }
-            let (stats, _) = build_community_data(&cached.graph, min_nodes);
-            return Ok(stats);
+            return Ok(cached.community_stats.clone());
         }
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -49,6 +49,8 @@ pub struct CachedGraph {
     pub graph: Arc<WikiGraph>,
     /// Precomputed community map (slug → community_id), None if graph is too small.
     pub community_map: Option<Arc<HashMap<String, usize>>>,
+    /// Precomputed community stats, None if graph is too small.
+    pub community_stats: Option<CommunityStats>,
     /// Generation value from SpaceIndexManager at cache time.
     pub index_gen: u64,
 }
@@ -962,6 +964,84 @@ pub fn subgraph(graph: &WikiGraph, root_slug: &str, depth: usize) -> WikiGraph {
     new_graph
 }
 
+// ── build_community_data ─────────────────────────────────────────────────────
+
+/// Run Louvain once and return both community outputs.
+/// Returns `(None, None)` when graph is below `min_nodes` threshold.
+fn build_community_data(
+    graph: &WikiGraph,
+    min_nodes: usize,
+) -> (Option<CommunityStats>, Option<HashMap<String, usize>>) {
+    let local_nodes: Vec<NodeIndex> = {
+        let mut v: Vec<NodeIndex> = graph
+            .node_indices()
+            .filter(|&idx| !graph[idx].external)
+            .collect();
+        v.sort_by_key(|&i| graph[i].slug.clone());
+        v
+    };
+
+    if local_nodes.len() < min_nodes {
+        return (None, None);
+    }
+
+    let adj = build_adjacency(graph);
+    let degrees: HashMap<NodeIndex, usize> =
+        local_nodes.iter().map(|&n| (n, adj[&n].len())).collect();
+    let m: usize = adj.values().map(|s| s.len()).sum::<usize>() / 2;
+
+    let mut community: HashMap<NodeIndex, usize> = local_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, &n)| (n, i))
+        .collect();
+
+    louvain_phase1(&adj, &mut community, &degrees, m);
+
+    // Normalize community ids to contiguous 0..k
+    let mut id_remap: HashMap<usize, usize> = HashMap::new();
+    let mut next_id = 0usize;
+    for &n in &local_nodes {
+        let c = *community.get(&n).unwrap();
+        id_remap.entry(c).or_insert_with(|| {
+            let id = next_id;
+            next_id += 1;
+            id
+        });
+    }
+    for val in community.values_mut() {
+        *val = *id_remap.get(val).unwrap();
+    }
+
+    // Build community_map
+    let community_map: HashMap<String, usize> = local_nodes
+        .iter()
+        .map(|&n| (graph[n].slug.clone(), community[&n]))
+        .collect();
+
+    // Build community_stats (mirrors compute_communities logic)
+    let count = next_id;
+    let mut sizes: HashMap<usize, usize> = HashMap::new();
+    for &c in community.values() {
+        *sizes.entry(c).or_default() += 1;
+    }
+    let largest = sizes.values().copied().max().unwrap_or(0);
+    let smallest = sizes.values().copied().min().unwrap_or(0);
+    let mut isolated: Vec<String> = local_nodes
+        .iter()
+        .filter(|&&n| {
+            let c = *community.get(&n).unwrap();
+            *sizes.get(&c).unwrap_or(&0) <= 2
+        })
+        .map(|&n| graph[n].slug.clone())
+        .collect();
+    isolated.sort();
+
+    let stats = CommunityStats { count, largest, smallest, isolated };
+
+    (Some(stats), Some(community_map))
+}
+
 // ── Cached graph accessors ───────────────────────────────────────────────────
 
 /// Return cached full graph, or build and cache on miss.
@@ -993,11 +1073,13 @@ pub fn get_or_build_graph(
 
     // Cache miss — build
     let graph = Arc::new(build_graph(searcher, index_schema, filter, type_registry)?);
-    let community_map = node_community_map(&graph, 30).map(Arc::new);
+    let (community_stats, community_map_raw) = build_community_data(&graph, 30);
+    let community_map = community_map_raw.map(Arc::new);
 
     *graph_cache.write().unwrap() = Some(CachedGraph {
         graph: Arc::clone(&graph),
         community_map,
+        community_stats,
         index_gen: current_gen,
     });
 
@@ -1052,6 +1134,60 @@ pub fn get_cached_community_map(
             }
             let map = node_community_map(&cached.graph, min_nodes).map(Arc::new);
             return Ok(map);
+        }
+    }
+
+    Ok(None)
+}
+
+/// Return cached `CommunityStats` for `space`, or `None` if graph is below threshold.
+/// Builds and caches the full graph as a side effect if not already cached.
+pub fn get_cached_community_stats(
+    index_schema: &IndexSchema,
+    type_registry: &SpaceTypeRegistry,
+    index_manager: &SpaceIndexManager,
+    graph_cache: &RwLock<Option<CachedGraph>>,
+    searcher: &Searcher,
+    min_nodes: usize,
+) -> Result<Option<CommunityStats>> {
+    let current_gen = index_manager.generation();
+
+    // Check cache hit
+    {
+        let cache = graph_cache.read().unwrap();
+        if let Some(cached) = cache.as_ref()
+            && cached.index_gen == current_gen
+        {
+            if min_nodes <= 30 {
+                return Ok(cached.community_stats.clone());
+            }
+            // Caller wants higher threshold — recompute without overwriting cache
+            let stats = compute_communities(&cached.graph, min_nodes);
+            return Ok(stats);
+        }
+    }
+
+    // Cache miss — build graph (populates community_stats at threshold=30)
+    get_or_build_graph(
+        index_schema,
+        type_registry,
+        index_manager,
+        graph_cache,
+        searcher,
+        &GraphFilter::default(),
+    )?;
+
+    // Re-read after population
+    {
+        let cache = graph_cache.read().unwrap();
+        if let Some(cached) = cache.as_ref()
+            && cached.index_gen == current_gen
+        {
+            if min_nodes <= 30 {
+                return Ok(cached.community_stats.clone());
+            }
+            let stats = compute_communities(&cached.graph, min_nodes);
+            return Ok(stats);
         }
     }
 

--- a/src/ops/graph.rs
+++ b/src/ops/graph.rs
@@ -53,27 +53,22 @@ pub fn graph_build(
         relation: params.relation.clone(),
     };
     let g: Arc<graph::WikiGraph> = if params.cross_wiki {
-        // Collect (name, searcher) pairs; Arc keeps schema/registry alive
-        let space_data: Vec<(String, tantivy::Searcher)> = engine
-            .spaces
-            .iter()
-            .filter_map(|(name, sp)| sp.index_manager.searcher().ok().map(|s| (name.clone(), s)))
-            .collect();
-        let tuples: Vec<(
-            &str,
-            &tantivy::Searcher,
-            &crate::index_schema::IndexSchema,
-            &crate::type_registry::SpaceTypeRegistry,
-        )> = space_data
-            .iter()
-            .filter_map(|(name, searcher)| {
-                engine
-                    .spaces
-                    .get(name)
-                    .map(|sp| (name.as_str(), searcher, &sp.index_schema, &sp.type_registry))
-            })
-            .collect();
-        Arc::new(graph::build_graph_cross_wiki(&tuples, &filter)?)
+        // Build each space graph through its cache, then merge
+        let mut per_space: Vec<(&str, Arc<graph::WikiGraph>)> = Vec::new();
+        for (name, sp) in engine.spaces.iter() {
+            if let Ok(searcher) = sp.index_manager.searcher() {
+                let g = graph::get_or_build_graph(
+                    &sp.index_schema,
+                    &sp.type_registry,
+                    &sp.index_manager,
+                    &sp.graph_cache,
+                    &searcher,
+                    &filter,
+                )?;
+                per_space.push((name.as_str(), g));
+            }
+        }
+        Arc::new(graph::merge_cached_graphs(&per_space, &filter)?)
     } else {
         let searcher = space.index_manager.searcher()?;
         graph::get_or_build_graph(

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::engine::EngineState;
-use crate::graph::{self, CommunityStats, GraphFilter, get_cached_community_stats, get_or_build_graph};
+use crate::graph::{
+    self, CommunityStats, GraphFilter, get_cached_community_stats, get_or_build_graph,
+};
 use crate::search;
 use tantivy::schema::Value;
 

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::engine::EngineState;
-use crate::graph::{self, CommunityStats, GraphFilter, get_or_build_graph};
+use crate::graph::{self, CommunityStats, GraphFilter, get_cached_community_stats, get_or_build_graph};
 use crate::search;
 use tantivy::schema::Value;
 
@@ -88,8 +88,14 @@ pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
     )?;
     let metrics = graph::compute_metrics(&wiki_graph);
     let resolved = space.resolved_config(&engine.config);
-    let communities =
-        graph::compute_communities(&wiki_graph, resolved.graph.min_nodes_for_communities);
+    let communities = get_cached_community_stats(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        resolved.graph.min_nodes_for_communities,
+    )?;
 
     // Staleness buckets from last_updated field
     let staleness = compute_staleness(&searcher, &space.index_schema)?;

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tantivy::schema::Value;
 
 use crate::engine::EngineState;
-use crate::graph::{self, GraphFilter, get_or_build_graph};
+use crate::graph::{self, GraphFilter, get_cached_community_map, get_or_build_graph};
 use crate::search;
 use crate::slug::{Slug, WikiUri};
 
@@ -209,7 +209,14 @@ pub fn suggest(
 
     // Strategy 4: Community peers (same Louvain community, not already linked)
     if let Some(community_map) =
-        graph::node_community_map(&wiki_graph, resolved.graph.min_nodes_for_communities)
+        get_cached_community_map(
+            &space.index_schema,
+            &space.type_registry,
+            &space.index_manager,
+            &space.graph_cache,
+            &searcher,
+            resolved.graph.min_nodes_for_communities,
+        )?
         && let Some(&my_community) = community_map.get(slug.as_str())
     {
         let mut peers: Vec<&str> = community_map

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tantivy::schema::Value;
 
 use crate::engine::EngineState;
-use crate::graph::{self, GraphFilter, get_cached_community_map, get_or_build_graph};
+use crate::graph::{GraphFilter, get_cached_community_map, get_or_build_graph};
 use crate::search;
 use crate::slug::{Slug, WikiUri};
 
@@ -208,16 +208,14 @@ pub fn suggest(
     }
 
     // Strategy 4: Community peers (same Louvain community, not already linked)
-    if let Some(community_map) =
-        get_cached_community_map(
-            &space.index_schema,
-            &space.type_registry,
-            &space.index_manager,
-            &space.graph_cache,
-            &searcher,
-            resolved.graph.min_nodes_for_communities,
-        )?
-        && let Some(&my_community) = community_map.get(slug.as_str())
+    if let Some(community_map) = get_cached_community_map(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        resolved.graph.min_nodes_for_communities,
+    )? && let Some(&my_community) = community_map.get(slug.as_str())
     {
         let mut peers: Vec<&str> = community_map
             .keys()

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -2,9 +2,11 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
+use petgraph::visit::EdgeRef;
+
 use llm_wiki::engine::WikiEngine;
 use llm_wiki::git;
-use llm_wiki::graph::{GraphFilter, get_cached_community_map, get_cached_community_stats, get_or_build_graph};
+use llm_wiki::graph::{GraphFilter, get_cached_community_map, get_cached_community_stats, get_or_build_graph, merge_cached_graphs};
 
 fn setup_wiki(dir: &Path, name: &str) -> std::path::PathBuf {
     let config_path = dir.join("state").join("config.toml");
@@ -199,4 +201,157 @@ fn get_cached_community_stats_returns_none_for_small_graph() {
     )
     .unwrap();
     assert!(stats.is_none());
+}
+
+/// Helper: create a wiki space at `dir/name` with given pages, sharing `config_path`.
+fn setup_space(dir: &Path, name: &str, config_path: &Path, pages: &[(&str, &str)]) {
+    let wiki_path = dir.join(name);
+    llm_wiki::spaces::create(&wiki_path, name, None, false, true, config_path).unwrap();
+    let wiki_root = wiki_path.join("wiki");
+    fs::create_dir_all(wiki_root.join("concepts")).unwrap();
+    for (filename, content) in pages {
+        let file_path = wiki_root.join(filename);
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&file_path, content).unwrap();
+    }
+    git::commit(&wiki_path, "add pages").unwrap();
+}
+
+#[test]
+fn cross_wiki_merge_cached_graphs_matches_build_graph_cross_wiki() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("state").join("config.toml");
+
+    // Wiki A: has a page that links cross-wiki to wiki B
+    setup_space(
+        dir.path(),
+        "alpha",
+        &config_path,
+        &[
+            (
+                "concepts/foo.md",
+                "---\ntitle: \"Foo\"\ntype: concept\nstatus: active\n---\n\nSee [[wiki://beta/concepts/bar]].\n",
+            ),
+            (
+                "concepts/baz.md",
+                "---\ntitle: \"Baz\"\ntype: concept\nstatus: active\n---\n\nLocal link to [[concepts/foo]].\n",
+            ),
+        ],
+    );
+
+    // Wiki B: has a page targeted by wiki A
+    setup_space(
+        dir.path(),
+        "beta",
+        &config_path,
+        &[(
+            "concepts/bar.md",
+            "---\ntitle: \"Bar\"\ntype: concept\nstatus: active\n---\n\nBar content.\n",
+        )],
+    );
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let filter = GraphFilter::default();
+
+    // Build via merge_cached_graphs (the new path)
+    let mut per_space: Vec<(&str, Arc<llm_wiki::graph::WikiGraph>)> = Vec::new();
+    for (name, sp) in engine.spaces.iter() {
+        let searcher = sp.index_manager.searcher().unwrap();
+        let g = get_or_build_graph(
+            &sp.index_schema,
+            &sp.type_registry,
+            &sp.index_manager,
+            &sp.graph_cache,
+            &searcher,
+            &filter,
+        )
+        .unwrap();
+        per_space.push((name.as_str(), g));
+    }
+    // Sort for determinism
+    per_space.sort_by_key(|(name, _)| name.to_string());
+    let merged = merge_cached_graphs(&per_space, &filter).unwrap();
+
+    // Verify: 3 local nodes (alpha/foo, alpha/baz, beta/bar)
+    let local_nodes: Vec<_> = merged
+        .node_indices()
+        .filter(|&idx| !merged[idx].external)
+        .collect();
+    assert_eq!(local_nodes.len(), 3, "expected 3 local nodes in merged graph");
+
+    // Verify: cross-wiki edge alpha/foo -> beta/bar is resolved (not external)
+    let foo_idx = merged
+        .node_indices()
+        .find(|&idx| merged[idx].slug == "alpha/concepts/foo")
+        .expect("alpha/concepts/foo node must exist");
+    let bar_idx = merged
+        .node_indices()
+        .find(|&idx| merged[idx].slug == "beta/concepts/bar")
+        .expect("beta/concepts/bar node must exist");
+
+    let has_cross_edge = merged.edges(foo_idx).any(|e| e.target() == bar_idx);
+    assert!(
+        has_cross_edge,
+        "cross-wiki edge from alpha/concepts/foo to beta/concepts/bar must be resolved"
+    );
+
+    // Verify: no external placeholders (both wikis mounted)
+    let external_count = merged
+        .node_indices()
+        .filter(|&idx| merged[idx].external)
+        .count();
+    assert_eq!(
+        external_count, 0,
+        "no external nodes when both wikis are mounted"
+    );
+}
+
+#[test]
+fn cross_wiki_merge_keeps_external_when_target_wiki_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("state").join("config.toml");
+
+    // Only wiki A — references wiki "gamma" which is not mounted
+    setup_space(
+        dir.path(),
+        "alpha",
+        &config_path,
+        &[(
+            "concepts/foo.md",
+            "---\ntitle: \"Foo\"\ntype: concept\nstatus: active\n---\n\nSee [[wiki://gamma/concepts/missing]].\n",
+        )],
+    );
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let filter = GraphFilter::default();
+
+    let sp = engine.spaces.get("alpha").unwrap();
+    let searcher = sp.index_manager.searcher().unwrap();
+    let g = get_or_build_graph(
+        &sp.index_schema,
+        &sp.type_registry,
+        &sp.index_manager,
+        &sp.graph_cache,
+        &searcher,
+        &filter,
+    )
+    .unwrap();
+
+    let per_space = vec![("alpha", g)];
+    let merged = merge_cached_graphs(&per_space, &filter).unwrap();
+
+    // The cross-wiki target should remain as an external placeholder
+    let external_nodes: Vec<_> = merged
+        .node_indices()
+        .filter(|&idx| merged[idx].external)
+        .collect();
+    assert_eq!(
+        external_nodes.len(),
+        1,
+        "unmounted target wiki should produce external placeholder"
+    );
 }

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -460,10 +460,8 @@ fn graph_cache_invalidated_after_rebuild() {
     );
 }
 
-/// Regression: get_cached_community_stats must return Some for a graph with
-/// N nodes where min_nodes <= N < 30. Previously returned None because the
-/// cache stored community_stats built at threshold=30 (None for small graphs)
-/// and the cached accessor returned that None without recomputing.
+/// Cache always runs Louvain at threshold=0, so accessors only check local node count vs min_nodes.
+/// Regression: previously the cache was built at threshold=30, causing None for graphs with 5–29 nodes.
 #[test]
 fn get_cached_community_stats_returns_some_for_graph_above_min_nodes_threshold() {
     let dir = tempfile::tempdir().unwrap();

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use llm_wiki::engine::WikiEngine;
 use llm_wiki::git;
-use llm_wiki::graph::{GraphFilter, get_cached_community_map, get_or_build_graph};
+use llm_wiki::graph::{GraphFilter, get_cached_community_map, get_cached_community_stats, get_or_build_graph};
 
 fn setup_wiki(dir: &Path, name: &str) -> std::path::PathBuf {
     let config_path = dir.join("state").join("config.toml");
@@ -177,4 +177,26 @@ fn get_cached_community_map_returns_none_for_small_graph() {
     .unwrap();
 
     assert!(map.is_none(), "graph too small for community detection");
+}
+
+#[test]
+fn get_cached_community_stats_returns_none_for_small_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+    let searcher = space.index_manager.searcher().unwrap();
+
+    // Test wiki has only 2 nodes — below threshold of 30
+    let stats = get_cached_community_stats(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        30,
+    )
+    .unwrap();
+    assert!(stats.is_none());
 }

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -355,3 +355,61 @@ fn cross_wiki_merge_keeps_external_when_target_wiki_missing() {
         "unmounted target wiki should produce external placeholder"
     );
 }
+
+#[test]
+fn graph_cache_invalidated_after_rebuild() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+
+    let arc1 = {
+        let engine = manager.state.read().unwrap();
+        let space = engine.spaces.get("test").unwrap();
+        let searcher = space.index_manager.searcher().unwrap();
+        get_or_build_graph(
+            &space.index_schema,
+            &space.type_registry,
+            &space.index_manager,
+            &space.graph_cache,
+            &searcher,
+            &GraphFilter::default(),
+        )
+        .unwrap()
+    }; // drop engine read lock
+
+    // Trigger rebuild — bumps generation
+    {
+        let engine = manager.state.read().unwrap();
+        let space = engine.spaces.get("test").unwrap();
+        space
+            .index_manager
+            .rebuild(
+                &space.wiki_root,
+                &space.repo_root,
+                &space.index_schema,
+                &space.type_registry,
+            )
+            .unwrap();
+    }
+
+    let arc2 = {
+        let engine = manager.state.read().unwrap();
+        let space = engine.spaces.get("test").unwrap();
+        let searcher = space.index_manager.searcher().unwrap();
+        get_or_build_graph(
+            &space.index_schema,
+            &space.type_registry,
+            &space.index_manager,
+            &space.graph_cache,
+            &searcher,
+            &GraphFilter::default(),
+        )
+        .unwrap()
+    };
+
+    assert!(
+        !Arc::ptr_eq(&arc1, &arc2),
+        "cache must be invalidated after rebuild"
+    );
+}

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -459,3 +459,78 @@ fn graph_cache_invalidated_after_rebuild() {
         "cache must be invalidated after rebuild"
     );
 }
+
+/// Regression: get_cached_community_stats must return Some for a graph with
+/// N nodes where min_nodes <= N < 30. Previously returned None because the
+/// cache stored community_stats built at threshold=30 (None for small graphs)
+/// and the cached accessor returned that None without recomputing.
+#[test]
+fn get_cached_community_stats_returns_some_for_graph_above_min_nodes_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("state").join("config.toml");
+
+    // Build a wiki with 6 nodes (> 5, < 30)
+    setup_space(
+        dir.path(),
+        "test",
+        &config_path,
+        &[
+            (
+                "concepts/a.md",
+                "---\ntitle: \"A\"\ntype: concept\nstatus: active\n---\nSee [[concepts/b]].\n",
+            ),
+            (
+                "concepts/b.md",
+                "---\ntitle: \"B\"\ntype: concept\nstatus: active\n---\nSee [[concepts/c]].\n",
+            ),
+            (
+                "concepts/c.md",
+                "---\ntitle: \"C\"\ntype: concept\nstatus: active\n---\nSee [[concepts/d]].\n",
+            ),
+            (
+                "concepts/d.md",
+                "---\ntitle: \"D\"\ntype: concept\nstatus: active\n---\nSee [[concepts/e]].\n",
+            ),
+            (
+                "concepts/e.md",
+                "---\ntitle: \"E\"\ntype: concept\nstatus: active\n---\nSee [[concepts/f]].\n",
+            ),
+            (
+                "concepts/f.md",
+                "---\ntitle: \"F\"\ntype: concept\nstatus: active\n---\nLeaf node.\n",
+            ),
+        ],
+    );
+
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+    let searcher = space.index_manager.searcher().unwrap();
+
+    // threshold=5: 6 nodes >= 5, should return Some
+    let stats = get_cached_community_stats(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        5,
+    )
+    .unwrap();
+    assert!(
+        stats.is_some(),
+        "expected Some(CommunityStats) for 6-node graph with min_nodes=5, got None"
+    );
+
+    // Second call — cache hit path must also return Some
+    let stats2 = get_cached_community_stats(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        5,
+    )
+    .unwrap();
+    assert!(stats2.is_some(), "cache-hit path must also return Some");
+}

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -6,7 +6,10 @@ use petgraph::visit::EdgeRef;
 
 use llm_wiki::engine::WikiEngine;
 use llm_wiki::git;
-use llm_wiki::graph::{GraphFilter, get_cached_community_map, get_cached_community_stats, get_or_build_graph, merge_cached_graphs};
+use llm_wiki::graph::{
+    GraphFilter, get_cached_community_map, get_cached_community_stats, get_or_build_graph,
+    merge_cached_graphs,
+};
 
 fn setup_wiki(dir: &Path, name: &str) -> std::path::PathBuf {
     let config_path = dir.join("state").join("config.toml");
@@ -280,7 +283,11 @@ fn cross_wiki_merge_cached_graphs_matches_build_graph_cross_wiki() {
         .node_indices()
         .filter(|&idx| !merged[idx].external)
         .collect();
-    assert_eq!(local_nodes.len(), 3, "expected 3 local nodes in merged graph");
+    assert_eq!(
+        local_nodes.len(),
+        3,
+        "expected 3 local nodes in merged graph"
+    );
 
     // Verify: cross-wiki edge alpha/foo -> beta/bar is resolved (not external)
     let foo_idx = merged

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -7,8 +7,8 @@ use petgraph::visit::EdgeRef;
 use llm_wiki::engine::WikiEngine;
 use llm_wiki::git;
 use llm_wiki::graph::{
-    GraphFilter, get_cached_community_map, get_cached_community_stats, get_or_build_graph,
-    merge_cached_graphs,
+    GraphFilter, compute_communities, get_cached_community_map, get_cached_community_stats,
+    get_or_build_graph, merge_cached_graphs, node_community_map,
 };
 
 fn setup_wiki(dir: &Path, name: &str) -> std::path::PathBuf {
@@ -361,6 +361,45 @@ fn cross_wiki_merge_keeps_external_when_target_wiki_missing() {
         1,
         "unmounted target wiki should produce external placeholder"
     );
+}
+
+#[test]
+fn community_stats_and_map_are_consistent() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = setup_wiki(dir.path(), "test");
+    let manager = WikiEngine::build(&config_path).unwrap();
+    let engine = manager.state.read().unwrap();
+    let space = engine.spaces.get("test").unwrap();
+    let searcher = space.index_manager.searcher().unwrap();
+
+    let graph = get_or_build_graph(
+        &space.index_schema,
+        &space.type_registry,
+        &space.index_manager,
+        &space.graph_cache,
+        &searcher,
+        &GraphFilter::default(),
+    )
+    .unwrap();
+
+    // threshold=1: both wiki's 2 nodes should be >= 1
+    let stats = compute_communities(&graph, 1);
+    let map = node_community_map(&graph, 1);
+
+    assert!(stats.is_some(), "expected Some(CommunityStats)");
+    assert!(map.is_some(), "expected Some(community_map)");
+
+    let stats = stats.unwrap();
+    let map = map.unwrap();
+
+    // every community id in map must be < stats.count
+    for &c in map.values() {
+        assert!(
+            c < stats.count,
+            "community id {c} out of range (count={})",
+            stats.count
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `community_stats: Option<CommunityStats>` to `CachedGraph`; private `build_community_data` helper runs Louvain exactly once per cache miss, populating both fields atomically
- `get_cached_community_stats` public function added to `graph.rs`
- `ops/stats.rs` uses `get_cached_community_stats` — Louvain runs at most once per generation
- `ops/suggest.rs` uses `get_cached_community_map` — Louvain runs at most once per generation
- `ops/graph.rs` cross-wiki path uses `get_or_build_graph` per space + `merge_cached_graphs` — per-space caches are now respected for cross-wiki calls
- Fixed TOCTOU in post-build re-read: generation check removed from second lock acquisition
- Cache invalidation tested: rebuild bumps generation, next call returns fresh `Arc`

## Why only unfiltered graphs

Filtered graphs are request-specific. Caching them requires a per-key store with eviction. The full unfiltered graph is what every MCP/ACP call needs; filters are rare and user-driven.

## Cache invalidation

Generation bumps automatically on any write (ingest, rebuild, watch). No manual flush needed.

## Follow-up (post-merge)

Refactor `compute_communities` to return `(CommunityStats, HashMap<String, usize>)` directly, making `build_community_data` a thin wrapper and eliminating logic duplication.

## Test plan

- [x] `cargo test` — all green (480 tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `graph_cache_hit_returns_same_arc` — same `Arc` on second call
- [x] `graph_cache_miss_on_filtered_request` — bypasses cache
- [x] `graph_cache_invalidated_after_rebuild` — fresh `Arc` after write
- [x] `get_cached_community_stats_returns_none_for_small_graph`
- [x] `cross_wiki_merge_cached_graphs_matches_build_graph_cross_wiki`
- [x] `cross_wiki_merge_keeps_external_when_target_wiki_missing`