### PR TITLE
feat(acp): v0.3.0 — workflows, cancellation, session cap, watcher push

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "both"
         type: choice
-        options: [both, engine, mcp]
+        options: [both, engine, mcp, acp, all]
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,12 +30,12 @@ jobs:
         run: cargo build --locked
 
       - uses: actions/setup-go@v6
-        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' }}
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' || inputs.suite == 'all' }}
         with:
           go-version: stable
 
       - name: Install mcptools
-        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' }}
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' || inputs.suite == 'all' }}
         run: |
           go install github.com/f/mcptools/cmd/mcptools@latest
           ln -s "$(go env GOPATH)/bin/mcptools" /usr/local/bin/mcp
@@ -50,15 +50,22 @@ jobs:
           bash ./docs/testing/scripts/setup-test-env.sh --dir "$LLM_WIKI_TEST_DIR"
 
       - name: Run engine validation
-        if: ${{ inputs.suite == 'both' || inputs.suite == 'engine' }}
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'engine' || inputs.suite == 'all' }}
         run: |
           LLM_WIKI_BIN=./target/debug/llm-wiki \
           LLM_WIKI_CONFIG="$LLM_WIKI_TEST_DIR/config.toml" \
           bash ./docs/testing/scripts/validate-engine.sh
 
       - name: Run MCP validation
-        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' }}
+        if: ${{ inputs.suite == 'both' || inputs.suite == 'mcp' || inputs.suite == 'all' }}
         run: |
           LLM_WIKI_BIN=./target/debug/llm-wiki \
           LLM_WIKI_CONFIG="$LLM_WIKI_TEST_DIR/config.toml" \
           bash ./docs/testing/scripts/validate-mcp.sh
+
+      - name: Run ACP validation
+        if: ${{ inputs.suite == 'acp' || inputs.suite == 'all' }}
+        run: |
+          LLM_WIKI_BIN=./target/debug/llm-wiki \
+          LLM_WIKI_CONFIG="$LLM_WIKI_TEST_DIR/config.toml" \
+          bash ./docs/testing/scripts/validate-acp.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
-README-draft.md
-docs/prompts/
+docs/brainstorm/
 docs/superpowers
 
 # tantivy search index — gitignored, rebuilt on demand via `wiki search --rebuild-index`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **In-memory graph cache** — full wiki graph and Louvain community data cached per space, keyed on index generation; invalidated automatically after any index write; `wiki_graph`, `wiki_stats`, and `wiki_suggest` skip rebuild on cache hit in serve mode; cross-wiki path uses per-space cached graphs via `merge_cached_graphs`
 
+- **ACP cooperative cancellation** — `AcpSession` carries a `cancelled: Arc<AtomicBool>` flag; the `cancel` notification handler sets the flag immediately; every workflow polls between steps (`research`: after search, `lint`: between each finding, `graph`/`ingest`: before dispatch); a `"Cancelled."` message is sent and the run exits cleanly; the flag resets to `false` on each new `Prompt`
+
+- **ACP session cap** — `serve.acp_max_sessions` config key (default: 20, global-only); `NewSession` returns `InvalidParams` with `"Session limit reached (max: N)"` when the cap is exceeded; configurable via `llm-wiki config set serve.acp_max_sessions <n> --global`
+
+- **ACP `ListSessions` active-run state** — sessions with an ongoing tool run are reported with a `[active]` prefix in the title field (e.g. `[active] my-session`); clients can distinguish idle from busy sessions without polling
+
+- **Proactive watcher push** — `llm-wiki serve --acp --watch` now pushes `"Wiki \"<name>\" updated: <N> page(s) changed."` to all idle ACP sessions targeting the changed wiki after each watcher-triggered ingest; delivered via `tokio::sync::mpsc` from the watcher task; the ACP push task blocks on a `tokio::sync::watch` channel until the first `Prompt` establishes the connection handle — watcher events that arrive before the first prompt are buffered (channel capacity 64) and delivered once the connection is ready; sessions with an active run are skipped
+
 ## [0.2.0] — 2026-04-28
 
 ### Added

--- a/docs/decisions/0.3.0/acp-workflows.md
+++ b/docs/decisions/0.3.0/acp-workflows.md
@@ -1,0 +1,63 @@
+---
+title: "ACP Workflows v0.3.0"
+summary: "Design decisions for ACP workflow expansion: new workflows, cancellation, session cap, watcher push."
+date: "2026-05-01"
+---
+
+# ACP Workflows v0.3.0
+
+## Decision
+
+Ship ACP as a first-class transport with six workflows (`research`, `lint`, `graph`, `ingest`, `use`, `help`), cooperative cancellation via `Arc<AtomicBool>`, session cap via `serve.acp_max_sessions`, and proactive watcher push via mpsc channel.
+
+## Context
+
+v0.1.1 added ACP transport but wired only the `research` workflow. `step_read` discarded the page body (`Ok(_)` on `content_read` result) so nothing was streamed to the client. The cancel handler only cleared `active_run` — no interrupt signal reached running workflows. There was no session limit. The watcher ran independently with no way to push notifications to ACP sessions.
+
+## Decisions and Rationale
+
+### Workflow dispatch via `llm-wiki:` prefix
+
+**Decision:** Prefix format `llm-wiki:<workflow> [args]` parsed by `dispatch_workflow`; bare prompt defaults to `research`.
+
+**Rationale:** Mirrors MCP tool naming (`llm-wiki:research` is consistent with `wiki_search`). Bare prompts stay natural for the common case. Prefix is unambiguous with typical wiki query text.
+
+### `step_read` `stream_content` flag
+
+**Decision:** Add `stream_content: bool` parameter to `step_read`. Research path passes `false` (existing behavior unchanged); `use` workflow passes `true` to stream full page body.
+
+**Rationale:** Research already shows a summary via tool call result. `use` is explicitly "give me the content" — streaming it directly matches user intent. Single flag avoids two separate functions.
+
+### Cooperative cancellation via `Arc<AtomicBool>`
+
+**Decision:** Each `AcpSession` holds `cancelled: Arc<AtomicBool>`. Cancel handler sets it; workflows poll it between steps. New prompt resets it to `false`.
+
+**Rationale:** Workflows run synchronously in the request handler (no separate task). Preemptive cancellation would require every blocking call to be wrapped. Cooperative polling between steps is the right granularity — a user cancelling mid-lint gets a clean stop after the current finding batch, not a panic.
+
+**Trade-off:** A step that blocks for several seconds (e.g. large ingest) will not cancel until it returns. Acceptable for v0.3.0.
+
+### Session cap via `serve.acp_max_sessions`
+
+**Decision:** `ServeConfig` gets `acp_max_sessions: usize` (default 20). `NewSession` handler rejects with `InvalidParams` error when `sessions.len() >= cap`. Config key is global-only.
+
+**Rationale:** ACP sessions hold live resources (AtomicBool, label state). Unbounded growth risks OOM on long-running servers. 20 is generous for single-user IDE usage. Global-only because the cap is a server policy, not per-wiki.
+
+**Known limitation:** Session ID uses `timestamp_millis()`. Concurrent `NewSession` requests within the same millisecond generate the same ID, causing HashMap overwrites that silently bypass the cap check. Not fixed in v0.3.0 — the race window is <1 ms and IDE usage is sequential. Documented in `validate-acp.md`.
+
+### Watcher push via mpsc channel
+
+**Decision:** `serve_acp` creates a `tokio::sync::mpsc::Sender<(String, String)>`. Watcher sends `(wiki_name, message)` on successful ingest. ACP server spawns a task that drains the channel and calls `send_text` for all matching idle sessions.
+
+**Rationale:** `send_text` requires `ConnectionTo<Client>` which lives inside the ACP server loop. The watcher runs outside. Passing the connection handle across the boundary (Option A: mpsc) is cleaner than polling a shared Vec (Option B). The mpsc approach is one-way and non-blocking from the watcher's perspective.
+
+### ACP requires `--http` when MCP is also active
+
+**Decision:** Running `serve --acp` without `--http` leaves MCP and ACP both competing for stdio. The correct invocation is `serve --acp --http :PORT` which moves MCP to HTTP, giving ACP exclusive stdio.
+
+**Rationale:** Both protocols are NDJSON over stdio by default. They cannot share the same stream. `--http` flag is the opt-in to displace MCP; ACP always owns stdio when `--acp` is set.
+
+### Test strategy: config verification for session cap
+
+**Decision:** Automated cap test (`08-session-cap.sh`) verifies only that `serve.acp_max_sessions` is set to a low value. Behavioral cap enforcement is deferred to manual testing (documented in `validate-acp.md`).
+
+**Rationale:** The `timestamp_millis()` TOCTOU race makes automated cap enforcement tests unreliable — sessions spawned in rapid succession get the same ID and silently overwrite each other in the HashMap, so the cap is never triggered. Fixing the race was blocked (out of scope for v0.3.0). The config check confirms the system is wired correctly without producing false failures.

--- a/docs/decisions/0.3.0/graph-cache.md
+++ b/docs/decisions/0.3.0/graph-cache.md
@@ -1,0 +1,57 @@
+---
+title: "Graph Cache v0.3.0"
+summary: "Design decisions for in-memory WikiGraph cache: keying strategy, invalidation, community map co-location, filtered bypass."
+date: "2026-05-01"
+---
+
+# Graph Cache v0.3.0
+
+## Decision
+
+Cache the full unfiltered `WikiGraph` per wiki space in `SpaceContext.graph_cache: RwLock<Option<CachedGraph>>`. Key the cache on `SpaceIndexManager.generation()` — a monotonic counter incremented on every index write. Filtered requests (type, relation, root, depth) bypass the cache and build on demand. The community map (`HashMap<slug, community_id>`) lives inside `CachedGraph` alongside the graph, built once and reused by `wiki_suggest`.
+
+## Context
+
+`wiki_graph`, `wiki_stats`, and `wiki_suggest` all needed the full petgraph. Before this change, each call rebuilt the graph from the tantivy index: O(pages + edges), no reuse. On a 500-page wiki this was measurable latency on every MCP call. The ACP graph workflow made this more visible — streaming graph output to the IDE after a fresh ingest triggered two sequential full builds (graph + stats).
+
+## Decisions and Rationale
+
+### Generation counter as cache key
+
+**Decision:** `CachedGraph.generation: u64` stores the `SpaceIndexManager.generation()` value at build time. On each cache read, the current generation is compared; mismatch → evict and rebuild.
+
+**Rationale:** The generation counter is already incremented by `reload_reader` after every index write (ingest, commit). It is cheap to read (`AtomicU64::load(Relaxed)`) and precisely tracks index mutations. Alternatives considered:
+
+- **File mtime of tantivy segment files:** Requires filesystem calls per request; unreliable across NFS/Docker volume mounts.
+- **Content hash of index:** Expensive — requires reading all stored fields.
+- **Timestamp:** Clock skew on rapid writes within same millisecond causes stale cache reads.
+
+The generation counter is the right primitive: zero-cost invalidation check, exact semantics.
+
+### Filtered requests bypass cache
+
+**Decision:** Requests with non-default `GraphParams` (type_filter, relation, root, depth) skip the cache and call `build_graph` directly.
+
+**Rationale:** The cache stores the full unfiltered graph. Filtered views are derived from it at render time — they are not stored separately. Caching every (filter combination × wiki) would require an unbounded map with complex eviction. Instead, filtered requests are cheap to rebuild because they call `build_graph` which reads the tantivy index sequentially — no file I/O beyond the index reader already held open.
+
+**Trade-off:** A repeated `wiki_graph(root: concepts/moe, depth: 2)` call rebuilds every time. Acceptable for v0.3.0 — subgraph requests are interactive, not hot-path.
+
+### Community map co-located in CachedGraph
+
+**Decision:** `CachedGraph` holds both `graph: Arc<WikiGraph>` and `community_map: Option<Arc<HashMap<String, usize>>>`. Both are built once when the cache is populated.
+
+**Rationale:** Community detection (`node_community_map`) runs Louvain on the full graph — it cannot run on a filtered subgraph. Since the full graph is already being built for the cache, computing the community map at the same time adds negligible overhead. Storing it in `CachedGraph` means `wiki_suggest` (strategy 4: community peers) reads from cache without a second graph build.
+
+**Alternative rejected:** Build community map lazily on first `wiki_suggest` call. Rejected because it requires a second write lock on `graph_cache` and complicates the cache state machine (graph present but map absent vs. both present).
+
+### `merge_cached_graphs` for cross-wiki builds
+
+**Decision:** `merge_cached_graphs` accepts `&[(&str, Arc<WikiGraph>)]` slices of already-cached graphs instead of rebuilding from index. Used by `wiki_graph(cross_wiki: true)`.
+
+**Rationale:** Cross-wiki graph builds previously called `build_graph_cross_wiki` which re-read all indices. With per-wiki caches available, the merged graph can be assembled from already-built `Arc<WikiGraph>` clones — no index reads. The merged result is not cached (cross-wiki requests are rare; caching would require a separate key per wiki combination).
+
+### Arc wrapping for zero-copy sharing
+
+**Decision:** `CachedGraph.graph: Arc<WikiGraph>` and `community_map: Option<Arc<...>>`. Callers clone the `Arc`, not the graph.
+
+**Rationale:** A 500-page wiki graph is ~100 KB of heap. Cloning it per request would be wasteful. `Arc` gives safe shared ownership across concurrent MCP handlers without copying. The graph is immutable after construction — no interior mutability needed.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,6 +4,24 @@ Architectural decisions and their rationale, grouped by release.
 
 ---
 
+## v0.3.0 — 2026-05-01
+
+Decisions made during ACP workflow expansion and transport stabilization.
+
+### Transport & Protocol
+
+| Decision | Summary |
+| -------- | ------- |
+| [acp-workflows](0.3.0/acp-workflows.md) | Six ACP workflows, cooperative cancellation, session cap, watcher push, `--http` flag requirement |
+
+### Graph
+
+| Decision | Summary |
+| -------- | ------- |
+| [graph-cache](0.3.0/graph-cache.md) | In-memory WikiGraph cache keyed on index generation; community map co-located; filtered requests bypass cache |
+
+---
+
 ## v0.2.0 — 2026-04-27
 
 Decisions made during improvement design phase.

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -293,7 +293,54 @@ References:
 - [server.md](specifications/engine/server.md)
 - [decisions/graceful-shutdown.md](decisions/graceful-shutdown.md)
 
-## 10. Engine Startup
+## 10. ACP Workflow Dispatch
+
+How a prompt from an ACP client is dispatched to a workflow.
+
+```mermaid
+sequenceDiagram
+    participant IDE as Zed (ACP client)
+    participant Server as ACP server (stdio)
+    participant WF as workflow (research/lint/…)
+    participant Engine as WikiEngine
+
+    IDE->>Server: session/new {cwd, _meta: {wiki}}
+    Server-->>IDE: {sessionId}
+
+    IDE->>Server: session/prompt {sessionId, prompt: [{type:text, text:…}]}
+    Server->>Server: dispatch_workflow(text)
+
+    alt llm-wiki:research <query> or bare prompt
+        Server->>WF: run_research
+        WF->>Engine: ops::search + ops::content_read
+        WF-->>IDE: session/update (tool_call, tool_call_update)
+    else llm-wiki:lint [rules]
+        Server->>WF: run_lint
+        WF->>Engine: ops::run_lint
+        WF-->>IDE: session/update (tool_call, findings as text)
+    else llm-wiki:graph [root]
+        Server->>WF: run_graph
+        WF->>Engine: ops::graph_build
+        WF-->>IDE: session/update (tool_call, rendered graph)
+    else llm-wiki:ingest [path]
+        Server->>WF: run_ingest
+        WF->>Engine: ops::ingest
+        WF-->>IDE: session/update (tool_call, summary)
+    else llm-wiki:use <slug>
+        Server->>WF: step_read(stream_content=true)
+        WF->>Engine: ops::content_read
+        WF-->>IDE: session/update (tool_call, page body)
+    end
+
+    Server-->>IDE: session/prompt response {stopReason: end_turn}
+```
+
+References:
+- [acp/server.rs](../src/acp/server.rs)
+- [decisions/0.3.0/acp-workflows.md](decisions/0.3.0/acp-workflows.md)
+- [guides/ide-integration.md](guides/ide-integration.md)
+
+## 11. Engine Startup
 
 How `WikiEngine::build` mounts wikis.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -184,6 +184,19 @@ so search/list always use a fresh index:
 llm-wiki config set index.auto_rebuild true --global
 ```
 
+### Set the ACP session cap
+
+ACP sessions persist in memory until the server stops. The default
+cap is 20 concurrent sessions, which is generous for single-user IDE
+use. Lower it for resource-constrained environments:
+
+```bash
+llm-wiki config set serve.acp_max_sessions 5 --global
+```
+
+This is a global-only key — it applies to the server process, not
+per-wiki.
+
 ### Configure logging
 
 For debugging `llm-wiki serve`:

--- a/docs/guides/ide-integration.md
+++ b/docs/guides/ide-integration.md
@@ -68,20 +68,51 @@ Add to the Windsurf MCP config:
 
 ### Zed (ACP)
 
+ACP provides streaming workflow steps visible in the agent panel.
+When using `--acp`, MCP must be displaced to HTTP so stdio is
+exclusively available for ACP:
+
 ```json
 {
   "agent_servers": {
     "llm-wiki": {
       "type": "custom",
       "command": "llm-wiki",
-      "args": ["serve", "--acp"],
+      "args": ["serve", "--acp", "--http", ":18765"],
       "env": {}
     }
   }
 }
 ```
 
-ACP provides streaming workflow steps visible in the agent panel.
+`--http :18765` starts the MCP server on HTTP, leaving stdio for ACP.
+Running `serve --acp` without `--http` causes MCP and ACP to compete
+for the same stdio stream.
+
+#### ACP Workflows
+
+Send prompts to the agent using the `llm-wiki:` prefix:
+
+| Prompt | Action |
+|--------|--------|
+| `what is MoE?` | Research (default — no prefix needed) |
+| `llm-wiki:research scaling laws` | Explicit research |
+| `llm-wiki:lint` | Run all lint rules |
+| `llm-wiki:lint orphan,stale` | Run specific rules |
+| `llm-wiki:graph` | Render full concept graph |
+| `llm-wiki:graph concepts/moe` | Subgraph from root slug |
+| `llm-wiki:ingest` | Ingest current working directory |
+| `llm-wiki:use concepts/moe` | Read full page content |
+| `llm-wiki:help` | List available workflows |
+
+#### Session Cap
+
+By default the server allows up to 20 concurrent ACP sessions.
+Lower the cap for resource-constrained environments:
+
+```bash
+llm-wiki config set serve.acp_max_sessions 5 --global
+```
 
 ## Verify the Connection
 

--- a/docs/improvements/design-acp-integration.md
+++ b/docs/improvements/design-acp-integration.md
@@ -1,0 +1,179 @@
+---
+title: "Design: ACP Integration — Smart Use of the Protocol"
+summary: "Review of ACP capabilities against current llm-wiki usage. Identifies underused protocol features and proposes improvements: session state, proactive push, skill activation tracking, and cancellation."
+read_when:
+  - Planning ACP work beyond v0.3.0
+  - Understanding what ACP enables that MCP cannot
+  - Reviewing the session model and its limitations
+status: proposal
+last_updated: "2026-05-01"
+---
+
+# Design: ACP Integration — Smart Use of the Protocol
+
+## What ACP Actually Is
+
+ACP is a session-oriented, streaming NDJSON protocol over stdio. The key
+properties that distinguish it from MCP:
+
+| Property       | MCP                        | ACP                                               |
+| -------------- | -------------------------- | ------------------------------------------------- |
+| Model          | Stateless request/response | Stateful named sessions                           |
+| Streaming      | Not visible to user        | Every step streams as events                      |
+| Cancellation   | Not supported              | `cancel` message mid-workflow                     |
+| Session memory | None                       | Server can accumulate per-session context         |
+| Server push    | No                         | Server can send messages outside request/response |
+| LLM agency     | LLM invokes tools freely   | Server runs fixed workflow, streams progress      |
+
+The fundamental constraint: **in ACP, the LLM sends one prompt — the server
+runs a fixed Rust workflow**. The LLM has no agency mid-workflow. For
+multi-step agentic decisions, MCP is required.
+
+The design opportunity: ACP sessions are stateful. Each session is a
+long-lived object on the server. We are barely using this.
+
+## Current State (v0.3.0)
+
+### What we have
+
+Six workflows dispatched by prefix (`research`, `lint`, `graph`, `ingest`,
+`use`, `help`). Session carries only `wiki: Option<String>`. Each prompt
+is handled independently — no state from prior prompts is used.
+
+### What we underuse
+
+| ACP feature        | Current usage          | Potential                                  |
+| ------------------ | ---------------------- | ------------------------------------------ |
+| `LoadSession`      | Accepted, no-op        | Restore session context across restarts    |
+| `ListSessions`     | Returns in-memory list | —                                          |
+| Session state      | Wiki name only         | Active skill, search history, recent slugs |
+| Multi-turn context | None                   | Accumulate slug context across prompts     |
+| Cancel             | Accepted, no-op        | Actually interrupt long ops                |
+| Server push        | Not used               | Watcher events → active sessions           |
+
+## Design Proposals
+
+### 1. Real Cancellation
+
+Current cancel handler is a stub. For long operations (ingest of a large
+directory, full-wiki lint), cancellation matters.
+
+ACP `cancel` sets a flag on the `AcpSession`. Workflows must check it
+between steps. Pattern:
+
+```rust
+// In each step function:
+if session.cancelled.load(Ordering::Relaxed) {
+    send_text(cx, session_id, "Cancelled.")?;
+    return Ok(());
+}
+```
+
+`cancelled` is an `Arc<AtomicBool>` shared between the session and the cancel
+handler. The cancel handler sets it; the workflow polls it at step boundaries.
+
+This gives cooperative cancellation — not preemptive, but sufficient for
+workflows that iterate over pages or findings.
+
+### 2. Session Policy Management
+
+Sessions currently accumulate indefinitely. A long-running server with
+many IDE restarts leaks memory. Need a hard cap:
+
+**Max sessions** — when reached, reject `NewSession` with a clear error.
+Configurable in `[serve]`:
+
+```toml
+[serve]
+acp_max_sessions = 20   # default: 20
+```
+
+**Active run protection** — never reject a `NewSession` when evicting would
+drop a session with an active run. Track `active_run: bool` on `AcpSession`.
+
+**`ListSessions` gains `active_run` field:**
+
+```json
+{
+  "session_id": "abc123",
+  "wiki": "research",
+  "active_run": false
+}
+```
+
+`serve.acp_max_sessions` is global-only (cannot be overridden per wiki).
+
+`specifications/model/global-config.md` must document this key under `[serve]`.
+
+### 3. Session Storage — Memory Only
+
+All ACP reference implementations (Python, Rust, TypeScript SDKs) keep
+sessions in memory only. The ACP spec has no persistence requirements —
+sessions are explicitly designed as ephemeral per-connection objects.
+
+llm-wiki follows the same approach. No disk writes, no `LoadSession`
+restoration. Session state is lost on process restart.
+
+Cost is negligible: restoring context is one command (`llm-wiki:use skills/research`).
+The engine stays a dumb pipe with no I/O side effects from session management.
+
+### 4. Proactive Push from the Filesystem Watcher
+
+Today, `llm-wiki serve --watch` runs a filesystem watcher that auto-ingests
+files dropped in `inbox/`. The watcher fires events internally, but they are
+never surfaced to ACP clients.
+
+Proposal: when a file is ingested via the watcher, push a notification to all
+active ACP sessions targeting that wiki:
+
+```
+→ message: "📥 inbox/paper.pdf ingested → raw/paper.pdf (1 page indexed)"
+```
+
+Implementation: the watcher already holds a reference to `WikiEngine`. Add a
+`Sessions` reference to the watcher context. On successful ingest, iterate
+sessions, filter by wiki, call `send_text`.
+
+This turns the IDE panel into a live feed — users see ingest results without
+triggering a prompt.
+
+Design constraint: push messages must not interfere with an active `Run`. Only
+push when `session.active_run.is_none()`.
+
+## What ACP Should Not Do
+
+These would be mistakes:
+
+**Write operations via ACP** — `wiki_content_write` and `wiki_content_new`
+belong in MCP. ACP's fixed workflows can't make the multi-step decisions
+required for good page authoring. Keep write ops in MCP where the LLM has
+tool-call agency.
+
+**Cross-wiki graph** — ACP sessions target one wiki. Cross-wiki graph
+traversal is a deliberate MCP opt-in (performance). Don't add it to ACP.
+
+**Session sharing between users** — sessions are per-process. Multi-user
+scenarios belong in the HTTP MCP transport, not ACP.
+
+**Streaming large diffs** — if ingest returns thousands of warnings, streaming
+each line creates noise. Stream a summary, let `lint` handle the details.
+
+## Implementation Priority
+
+| Proposal                  | Value | Complexity | Priority |
+| ------------------------- | ----- | ---------- | -------- |
+| Real cancellation         | High  | Medium     | 1        |
+| Session policy management | High  | Medium     | 2        |
+| Proactive watcher push    | High  | Medium     | 3        |
+
+Items 1, 2 are safety/correctness fixes — ship before watcher push.
+Item 3 requires new wiring (watcher ↔ sessions).
+
+## Documents to Update
+
+| File                                           | What changes                                         |
+| ---------------------------------------------- | ---------------------------------------------------- |
+| `specifications/integrations/acp-transport.md` | Session state section, cancel semantics, push model, eviction policy |
+| `specifications/model/global-config.md`        | Add `acp_max_sessions`, `acp_session_idle_minutes` under `[serve]`  |
+| `implementation/engine.md`                     | `AcpSession` struct fields, eviction background task                |
+| `docs/testing/validate-acp.md`                 | Test matrix for new workflows and session eviction                  |

--- a/docs/improvements/design-configurable-wiki-root.md
+++ b/docs/improvements/design-configurable-wiki-root.md
@@ -1,0 +1,208 @@
+---
+title: "Design: Configurable Wiki Root"
+summary: "Add wiki_root to wiki.toml so repos with non-standard content directories (e.g. llm-wiki-skills) can register as wiki spaces without restructuring."
+read_when:
+  - Implementing wiki_root support in the engine
+  - Understanding what changes are needed in specs and guides
+status: proposal
+last_updated: "2026-05-01"
+---
+
+# Design: Configurable Wiki Root
+
+**Motivation:** Allow repos where the content directory is not `wiki/` — enabling `llm-wiki-skills` (and similar plugin/tool repos) to register as a wiki space without restructuring their layout.
+
+## Problem
+
+The engine hardcodes `wiki/` as the content root. Every path derivation, slug resolution, ingest pipeline, search index, and `wiki_content_*` tool assumes content lives at `<repo>/wiki/`.
+
+This makes it impossible to register repos with a different content layout as wiki spaces without moving their files. Concrete case: `llm-wiki-skills` uses `skills/*/SKILL.md`. Renaming to `wiki/skills/` breaks the Claude plugin path convention and requires updating downstream consumers.
+
+## Proposed Change
+
+Add an optional `wiki_root` key to `wiki.toml`:
+
+```toml
+name        = "llm-wiki-skills"
+description = "Skills for the llm-wiki engine"
+wiki_root   = "skills"           # default: "wiki"
+```
+
+When absent, behavior is unchanged. When present, the engine resolves all content paths relative to `<repo>/<wiki_root>/` instead of `<repo>/wiki/`.
+
+## Impact Analysis
+
+### Engine internals
+
+| Area | Impact |
+|------|--------|
+| `SpaceContext` / space registry | Stores resolved `wiki_root` path at registration. All downstream operations read from `SpaceContext`, not from a hardcoded string. Low blast radius if `SpaceContext` already centralizes path resolution. |
+| `wiki_content_*` tools | Use `SpaceContext.wiki_root()` — no logic change, just path source. |
+| `wiki_ingest` | Same — path prefix swap. |
+| `wiki_search` / `wiki_list` | Index stores slugs relative to `wiki_root`. Rebuilding index on a non-default `wiki_root` must strip the correct prefix. |
+| `wiki_graph` | Edges are slugs — correct if ingest uses the right prefix. |
+| `wiki_index_rebuild` | Must walk `<repo>/<wiki_root>/` not `<repo>/wiki/`. |
+| `wiki_spaces_create` | Should NOT create `wiki/` when `wiki_root` is provided in an existing repo. |
+| `wiki_spaces_create` (new repo) | When `--wiki-root` flag given, create `<wiki_root>/` instead of `wiki/`. |
+
+### Slug resolution
+
+Slugs are relative to `wiki_root`. A page at `skills/bootstrap/SKILL.md` in a repo with `wiki_root = "skills"` gets slug `bootstrap`. This is consistent with how `wiki/concepts/foo.md` gets slug `concepts/foo`.
+
+No change to the slug format or `wiki://` URI scheme. The space registry already maps space name → repo path; it will now also carry `wiki_root`.
+
+### `inbox/` and `raw/`
+
+These are sibling directories to `wiki_root`, not children of it. They remain at the repo root regardless of `wiki_root`. A repo with `wiki_root = "skills"` still has `inbox/` and `raw/` at the top level.
+
+The DKR three-layer flow (`inbox` → `raw` → wiki content) is optional — repos that don't use it simply leave those directories empty or absent. The engine should not require their existence.
+
+### `schemas/`
+
+Schemas are discovered from `<repo>/schemas/` — always relative to the repo root, not `wiki_root`. No change.
+
+### `wiki_spaces_create` and `wiki_spaces_register`
+
+Three cases:
+
+1. **New repo** — `llm-wiki spaces create <path> --name <n> --wiki-root <dir>` creates `<wiki_root>/` instead of `wiki/`. Writes `wiki_root` into `wiki.toml`.
+2. **Existing repo via create** — reads `wiki.toml` if present and honors `wiki_root`. Does not create or rename directories.
+3. **Existing repo via register** — `llm-wiki spaces register <path> --name <n> [--wiki-root <dir>]` registers a pre-existing repo. `--wiki-root` overrides whatever is in `wiki.toml` (or sets it if absent). The engine validates that `<repo>/<wiki_root>/` exists on disk before completing registration — hard error if not found.
+
+### Backward compatibility
+
+`wiki_root` absent → defaults to `"wiki"` → zero behavior change for all existing wikis.
+
+## `wiki.toml` change
+
+Add to identity section:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `wiki_root` | no | `"wiki"` | Content directory relative to repo root. Supports multi-component paths (e.g. `"src/wiki"`). |
+
+Constraints:
+- Must be a relative path (no leading `/`)
+- Must not contain `..` (no traversal outside repo root)
+- Must not resolve to `inbox`, `raw`, or `schemas` (reserved top-level dirs)
+- Must not start with `.`
+- Engine validates the directory exists at registration time — hard error if missing
+
+## `wiki_spaces_create` CLI change
+
+Add optional flag to both `create` and `register`:
+
+```
+llm-wiki spaces create   <path> --name <name> [--wiki-root <dir>]
+llm-wiki spaces register <path> --name <name> [--wiki-root <dir>]
+```
+
+`create`: writes `wiki_root = "<dir>"` into the generated `wiki.toml` and creates `<dir>/` instead of `wiki/`.
+
+`register`: writes `wiki_root = "<dir>"` into `wiki.toml` (creating or updating the field) and validates the directory exists before completing.
+
+## Implementation Sketch
+
+1. **Parse** `wiki_root` from `wiki.toml` at space registration time. Store on `SpaceContext` as `wiki_root: PathBuf` (resolved to absolute).
+2. **Replace** all `repo_root.join("wiki")` occurrences with `space.wiki_root()`.
+3. **`wiki_spaces_create`**: accept `--wiki-root`, pass through to `wiki.toml` generation and directory creation.
+4. **`wiki_index_rebuild`**: walk `space.wiki_root()`.
+5. **Tests**: add a fixture wiki with `wiki_root = "content"` to the integration test suite. Run search, graph, ingest, content ops against it.
+
+## wiki_root Validation (sub-path check)
+
+`wiki_root` must resolve to a path strictly inside the repository root.
+The check must use canonicalized absolute paths to handle symlinks:
+
+```rust
+let repo_abs = fs::canonicalize(&repo_path)?;
+let root_abs = fs::canonicalize(repo_path.join(&wiki_root))?;
+if !root_abs.starts_with(&repo_abs) {
+    return Err("wiki_root must be inside the repository");
+}
+```
+
+Validation runs at registration time (`spaces create` and `spaces register`).
+The directory must exist before `canonicalize` succeeds — no separate existence check needed, `canonicalize` fails if the path is missing.
+
+Additional pre-canonicalize checks (fast-fail before filesystem access):
+- `wiki_root` must not be an absolute path
+- `wiki_root` must not contain `..` components
+- `wiki_root` must not be empty or `"."`
+- Resolved top-level component must not be `inbox`, `raw`, or `schemas`
+
+## Conflict on `spaces register`
+
+If `--wiki-root` is passed to `register` and `wiki.toml` already contains a different `wiki_root`, the engine errors:
+
+```
+error: wiki.toml already declares wiki_root = "skills".
+       Remove it manually before registering with a different value.
+```
+
+No `--force` flag. The user must edit `wiki.toml` explicitly — prevents silent data loss on a mis-typed flag.
+
+## Documents to Update
+
+### Specs (normative — must be updated before implementation ships)
+
+| File | What changes |
+|------|-------------|
+| `specifications/model/wiki-repository-layout.md` | `wiki/` → `<wiki_root>/` throughout; add `wiki_root` to layout diagram; note default is `"wiki"` |
+| `specifications/model/wiki-toml.md` | Add `wiki_root` to identity section with type, default, constraints |
+| `specifications/model/page-content.md` | Slug definition: relative to `wiki_root`, not hardcoded `wiki/` |
+| `specifications/engine/ingest-pipeline.md` | "walks `wiki/` recursively" → "walks `wiki_root` recursively" |
+| `specifications/engine/watch.md` | `wiki/` path reference → `wiki_root` |
+| `specifications/tools/space-management.md` | Add `--wiki-root` flag to `spaces create` and `spaces register`; document validation |
+| `specifications/tools/content-operations.md` | `wiki_root` field in responses already present — just clarify it reflects configured value, not always `wiki/` |
+
+### Guides (user-facing — update alongside or just after)
+
+| File | What changes |
+|------|-------------|
+| `guides/getting-started.md` | Layout diagram shows `wiki/` — add note that it's configurable |
+| `guides/writing-content.md` | `wiki_root` examples show hardcoded `/…/wiki` path — stays correct, just derived from config |
+| `guides/custom-types.md` | Any path examples using `wiki/` |
+
+### Implementation notes (update when code changes)
+
+| File | What changes |
+|------|-------------|
+| `implementation/engine.md` | `SpaceContext.wiki_root` field — document it is now read from `wiki.toml`, not hardcoded |
+| `implementation/index-manager.md` | `wiki_root` parameter origin — from `SpaceContext`, not assumed `wiki/` |
+| `implementation/mcp-tool-pattern.md` | Comment `space.wiki_root // PathBuf — wiki/ directory` → remove `wiki/` assumption |
+
+### Overview (last — reflects the settled design)
+
+| File | What changes |
+|------|-------------|
+| `overview.md` | Repository layout section: note `wiki/` is the default `wiki_root`, not a fixed name |
+
+### MCP server (update alongside engine changes)
+
+| Area | What changes |
+|------|-------------|
+| `wiki_spaces_create` tool schema | Add optional `wiki_root` parameter — string, default `"wiki"` |
+| `wiki_spaces_register` tool | **New tool** — `spaces register` does not exist today. Must be added: registers an existing repo without creating files. Parameters: `path`, `name`, optional `description`, optional `wiki_root`. Validates `wiki_root` exists and is inside repo before writing to registry. Hot-mounts the wiki if server is running. |
+| `wiki_spaces_list` response | Add `wiki_root` field to each space entry (text and JSON output) |
+| `SpaceContext` hot-reload | `wiki_root` is read at mount time — changing it requires unmount + remount (same as today for path changes) |
+
+`specifications/tools/space-management.md` must document both the new `--wiki-root` flag and the new `spaces register` subcommand.
+
+### No change needed
+
+- `design-origins/` — historical, not normative
+- `decisions/` — record past decisions, not affected
+- `diagrams.md` — `wiki_root` already appears as a field name in the diagram, semantics unchanged
+- `specifications/tools/export.md` — "relative to wiki root" language already correct
+- `testing/validate-skills.md` — test checklist, update separately after implementation
+
+## Use Case Validation
+
+| Repo | `wiki_root` | Outcome |
+|------|-------------|---------|
+| Standard wiki | `"wiki"` (default) | Unchanged |
+| `llm-wiki-skills` | `"skills"` | Plugin path unchanged, engine indexes `skills/*/SKILL.md` |
+| Docs repo with `docs/` as content | `"docs"` | `docs/*.md` searchable as wiki pages |
+| Monorepo with `knowledge/` | `"knowledge"` | No restructuring needed |
+| Monorepo with `src/wiki/` | `"src/wiki"` | Multi-component path, resolves to `<repo>/src/wiki/` |

--- a/docs/improvements/design-spaces-register-remote.md
+++ b/docs/improvements/design-spaces-register-remote.md
@@ -1,0 +1,271 @@
+---
+title: "Design: Remote Wiki Registration and Version Management"
+summary: "Add remote URL support to spaces register, version lifecycle subcommands (install, use, update, uninstall), and default_repo_root in global config."
+read_when:
+  - Implementing remote wiki registration in the engine
+  - Implementing spaces install / use / update / uninstall
+  - Understanding how managed spaces differ from local-path spaces
+status: proposal
+last_updated: "2026-05-01"
+---
+
+# Design: Remote Wiki Registration and Version Management
+
+**Scope:** (A) `spaces register` accepting a git remote URL with cloning,
+(B) version lifecycle subcommands under `spaces` (install, use, update, uninstall),
+(C) `default_repo_root` in global config.
+
+## Problem
+
+`spaces register` today requires a local path. Users who want to share a wiki
+repo (e.g. `llm-wiki-skills`) must clone it manually before registering.
+There is no way to pin a specific version, update to a newer tag, or switch
+between versions — the repo is just a directory with no managed lifecycle.
+
+| Gap | Impact |
+|-----|--------|
+| No remote registration | Manual `git clone` + `spaces register` — two steps, error-prone path management |
+| No version lifecycle | Can't pin a tag, can't `update`, can't rollback |
+
+## Global Config Addition
+
+Add `default_repo_root` to `[global]` in `config.toml` — global-only:
+
+```toml
+[global]
+default_wiki      = "research"
+default_repo_root = "~/.llm-wiki/repos"   # default value
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `global.default_repo_root` | `~/.llm-wiki/repos` | Base directory where remote wikis are cloned. Tilde-expanded. |
+
+All `spaces` commands that clone a remote use this as the parent directory
+unless `--install-dir` overrides it. Global-only — cannot be set in `wiki.toml`.
+
+`specifications/model/global-config.md` must be updated.
+
+## Feature A — Remote URL in `spaces register`
+
+### Proposed CLI
+
+```
+llm-wiki spaces register <path-or-url>
+          --name <name>
+          [--wiki-root <dir>]
+          [--tag <tag>]           # pin to a specific git tag
+          [--branch <branch>]     # track a branch instead of default
+          [--install-dir <dir>]   # override default_repo_root/<name>
+```
+
+### Behavior
+
+When `<path-or-url>` is detected as a remote URL (`https://`, `git@`,
+`git://`, `ssh://`):
+
+1. Resolve install dir: `--install-dir` ?? `default_repo_root/<name>`
+2. `git clone` the URL into the install dir (full clone)
+3. If `--tag`: `git checkout <tag>` after clone
+4. If `--branch`: clone with `--branch <branch>` and track it
+5. Read `wiki.toml` from clone — extract `wiki_root` if present
+6. Apply `--wiki-root` if given (conflict check against `wiki.toml`)
+7. Register the local clone path in `config.toml`
+
+If clone fails: hard error, nothing registered.
+If install dir already exists and is a git repo: error — use `spaces update` instead.
+
+### MCP tool
+
+`wiki_spaces_register` gains optional parameters:
+
+```json
+{
+  "url":         "https://github.com/geronimo-iia/llm-wiki-skills",
+  "name":        "llm-wiki-skills",
+  "tag":         "v1.2.0",
+  "wiki_root":   "skills",
+  "install_dir": null
+}
+```
+
+When `url` is set, `path` is ignored.
+
+## Feature B — Version Lifecycle Subcommands under `spaces`
+
+All version management is folded into `spaces`.
+
+### New subcommands
+
+```
+llm-wiki spaces list-remote    <name-or-url>         # list available tags from remote
+llm-wiki spaces install        <name-or-url> [<tag>] # clone and register
+llm-wiki spaces use            <name> <tag>          # switch to a different tag
+llm-wiki spaces update         <name>                # fetch and switch to latest tag
+llm-wiki spaces uninstall      <name>                # unregister and delete clone
+```
+
+### Directory layout
+
+```
+<default_repo_root>/
+└── llm-wiki-skills/      ← single git clone, HEAD at active tag
+    └── <cloned repo files>
+```
+
+The registered space `path` points directly to the clone directory.
+Switching versions = `git checkout <tag>` + hot-remount. No multiple
+local copies. No separate metadata file — all managed space state lives
+in the `[[wikis]]` entry in `config.toml`.
+
+### `config.toml` — extended space entry
+
+Managed spaces carry one additional field in their `[[wikis]]` entry:
+
+```toml
+[[wikis]]
+name        = "llm-wiki-skills"
+path        = "~/.llm-wiki/repos/llm-wiki-skills"
+description = "Skills for the llm-wiki engine"
+wiki_root   = "skills"
+```
+
+`url` and `active_tag` are not stored — derived on demand from the clone:
+
+```bash
+git -C <path> remote get-url origin              # → url
+git -C <path> describe --tags --exact-match HEAD # → active tag
+```
+
+`wiki_root` is the only new field, valid for both managed and unmanaged spaces.
+
+`specifications/model/global-config.md` must document the new `wiki_root`
+field on `[[wikis]]`.
+
+### `spaces list-remote` — tag discovery
+
+```
+$ llm-wiki spaces list-remote llm-wiki-skills
+v1.2.0  (latest)
+v1.1.0
+v1.0.0
+```
+
+Accepts either a registered space name (reads URL via `git remote get-url origin`
+from the clone) or a raw URL. Calls `git ls-remote --tags <url>`, strips
+`^{}` derefs, sorts semver descending. Shells out to `git` — no clone needed.
+
+Error if space has no remote: `"<name>: no git remote configured — cannot list remote tags"`
+
+### `spaces install` — clone a repo
+
+```
+llm-wiki spaces install <name-or-url> [<tag-or-branch>]
+                        [--branch]    # treat argument as branch, not tag
+```
+
+```
+llm-wiki spaces install llm-wiki-skills v1.2.0
+llm-wiki spaces install https://github.com/geronimo-iia/llm-wiki-skills v1.2.0
+llm-wiki spaces install https://github.com/geronimo-iia/llm-wiki-skills main --branch
+```
+
+1. If URL given: resolve name from `wiki.toml` or `--name`
+2. Clone into `<default_repo_root>/<name>/` (full clone — supports `git checkout` later)
+3. If `--branch`: clone with `--branch <branch>` and track it
+4. If tag: `git checkout <tag>` after clone
+5. If neither: check out latest tag (calls `list-remote` first)
+6. Register space with `wiki_root` in `config.toml`
+
+Error if clone directory already exists — use `spaces use` or `spaces update`.
+Error if space has no git remote: `"<name>: no git remote configured — version commands unavailable"`
+
+### `spaces use` — switch active version
+
+```
+llm-wiki spaces use llm-wiki-skills v1.1.0
+```
+
+1. If remote exists: `git fetch --tags`, then verify tag locally — error if not found
+2. If no remote: check local tags only — error if not found
+3. `git checkout <tag>`
+4. If server running: unmount + remount (hot-reload)
+5. Print: `llm-wiki-skills → v1.1.0`
+
+### `spaces update` — fetch and switch to latest
+
+```
+llm-wiki spaces update llm-wiki-skills
+```
+
+1. Check remote exists — error: `"<name>: no git remote configured — use 'spaces use' to switch manually"`
+2. `list-remote` to find latest tag
+3. Read current tag via `git describe --tags --exact-match HEAD`
+4. If already at latest: print "already at v1.2.0", exit 0
+5. `git fetch --tags` in clone directory
+6. `git checkout <latest-tag>`
+7. If server running: unmount + remount (hot-reload) — auto, no prompt
+8. Print: `llm-wiki-skills: v1.1.0 → v1.2.0`
+
+### `spaces uninstall` — remove a managed space
+
+```
+llm-wiki spaces uninstall llm-wiki-skills
+```
+
+1. Unregister the space from `config.toml` (remove `[[wikis]]` entry)
+2. Delete `<default_repo_root>/llm-wiki-skills/` (entire clone directory)
+
+Requires confirmation prompt — destructive. Add `--yes` to skip.
+
+### `spaces list` — show managed metadata
+
+`spaces list` output gains two optional fields for managed spaces:
+
+Text:
+```
+* llm-wiki-skills  ~/.llm-wiki/repos/llm-wiki-skills  Skills for the engine  [managed v1.2.0]
+```
+
+JSON:
+```json
+{
+  "name": "llm-wiki-skills",
+  "path": "~/.llm-wiki/repos/llm-wiki-skills",
+  "managed": true,
+  "active_version": "v1.2.0"
+}
+```
+
+Unmanaged (local-path) spaces: `"managed": false`, `"active_version": null`.
+
+## `spaces register <url>` as shorthand
+
+`spaces register <url>` without `--tag` is equivalent to:
+
+```
+spaces install <url> <latest-tag>
+```
+
+With `--tag <t>`: installs and activates that tag.
+
+Repos registered via `spaces register <local-path>` remain unmanaged —
+no git remote, version switching not available. The two modes are independent.
+
+## Impact Analysis
+
+| Area | Impact |
+|------|--------|
+| `config.toml` / global config spec | Add `global.default_repo_root` (global-only) |
+| `spaces register` | URL detection + clone logic before existing registration path |
+| `wiki_spaces_register` MCP tool | Add `url`, `tag`, `branch`, `install_dir` params |
+| New MCP tools | `wiki_spaces_list_remote`, `wiki_spaces_install`, `wiki_spaces_use`, `wiki_spaces_update`, `wiki_spaces_uninstall` |
+| `wiki_spaces_list` response | Add `managed` (bool), `active_version` (string\|null) fields — derived from git |
+| `[[wikis]]` entry in `config.toml` | Add optional `wiki_root` field only — `url` and `active_tag` read from git |
+| `SpaceContext` | No change — always resolves to a local path |
+| `spaces uninstall` | Distinct from `spaces remove` — also deletes clone directory |
+| Hot-reload | `spaces use` / `spaces update` reuse existing unmount+remount |
+| git dependency | `list-remote`, clone, fetch, checkout shell out to `git` — must be on PATH |
+| `~/.llm-wiki/` layout | Add `repos/<name>/` (single clone per managed space) |
+| `specifications/tools/space-management.md` | Document all new subcommands + MCP tools |
+| `specifications/model/global-config.md` | Add `global.default_repo_root` + `wiki_root` field on `[[wikis]]` |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 title: "Roadmap"
 summary: "Release history and version planning for llm-wiki."
 status: ready
-last_updated: "2026-04-28"
+last_updated: "2026-05-01"
 ---
 
 # Roadmap
@@ -32,13 +32,21 @@ last_updated: "2026-04-28"
 | Links       | CommonMark `[text](slug)` body links indexed alongside `[[wikilinks]]`                                                                           |
 | Skills      | Crystallize two-step; ingest analysis pass; review skill; `v0.4.0`                                                                               |
 
-## v0.3.0 — Designing
+## v0.3.0 — Current
 
-| Area                                            | What                                                                                                          |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| ACP                                             | Fix `step_read` to stream page content; add `lint`, `graph`, `ingest` workflows; `use` / `help` dispatch      |
-| Graph                                           | In-memory `WikiGraph` cache keyed on index generation; shared community map; automatic invalidation on ingest |
-| IDE                                             | Zed agent panel validation; Cursor MCP config validation                                                      |
-| Configurable Wiki Root                          | see llm-wiki/docs/improvements/design-configurable-wiki-root.md                                               |
-| Remote Wiki Registration and Version Management | see llm-wiki/docs/improvements/design-spaces-register-remote.md                                               |
+| Area    | What                                                                                                                             |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| ACP     | Six workflows (`research`, `lint`, `graph`, `ingest`, `use`, `help`); `step_read` streams page body; `llm-wiki:` prefix dispatch |
+| ACP     | Cooperative cancellation via `Arc<AtomicBool>`; session cap via `serve.acp_max_sessions`; watcher push via mpsc channel          |
+| ACP     | `--http` flag required alongside `--acp` to give ACP exclusive stdio (MCP displaces to HTTP)                                     |
+| Testing | `validate-acp.sh` + `docs/testing/scripts/acp/` section scripts; `setup-test-env.sh` configures ACP test settings                |
+| Graph   | In-memory `WikiGraph` cache keyed on index generation; shared community map; automatic invalidation on ingest                    |
+| Configurable Wiki Root                          | see docs/improvements/design-configurable-wiki-root.md   |
+
+## Future
+
+| Area                                            | What                                                     |
+| ----------------------------------------------- | -------------------------------------------------------- |
+| IDE                                             | Zed agent panel validation; Cursor MCP config validation |
+| Remote Wiki Registration and Version Management | see docs/improvements/design-spaces-register-remote.md   |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,23 +20,25 @@ last_updated: "2026-04-28"
 
 ## v0.2.0 — Released 2026-04-28
 
-| Area        | What                                                                          |
-| ----------- | ----------------------------------------------------------------------------- |
-| Type system | `confidence: 0.0–1.0` field; `claims[].confidence` as float                  |
-| Search      | Lifecycle-aware ranking; flat `[search.status]` multiplier map                |
+| Area        | What                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Type system | `confidence: 0.0–1.0` field; `claims[].confidence` as float                                                                                      |
+| Search      | Lifecycle-aware ranking; flat `[search.status]` multiplier map                                                                                   |
 | Content     | Backlinks on `wiki_content_read`; incremental validation (git-diff scoped); `wiki_resolve` tool; `wiki_content_new` returns `path` + `wiki_root` |
-| Lint        | `wiki_lint` tool with 5 rules; `broken-cross-wiki-link` rule; `path` field on every finding |
-| Redaction   | `redact:` flag on `wiki_ingest`; built-in and custom patterns                 |
-| Graph       | Louvain community detection; `wiki://` cross-wiki edges; `--cross-wiki` flag  |
-| Export      | `wiki_export` + `llms` format on list, search, and graph                      |
-| Links       | CommonMark `[text](slug)` body links indexed alongside `[[wikilinks]]`        |
-| Skills      | Crystallize two-step; ingest analysis pass; review skill; `v0.4.0`            |
+| Lint        | `wiki_lint` tool with 5 rules; `broken-cross-wiki-link` rule; `path` field on every finding                                                      |
+| Redaction   | `redact:` flag on `wiki_ingest`; built-in and custom patterns                                                                                    |
+| Graph       | Louvain community detection; `wiki://` cross-wiki edges; `--cross-wiki` flag                                                                     |
+| Export      | `wiki_export` + `llms` format on list, search, and graph                                                                                         |
+| Links       | CommonMark `[text](slug)` body links indexed alongside `[[wikilinks]]`                                                                           |
+| Skills      | Crystallize two-step; ingest analysis pass; review skill; `v0.4.0`                                                                               |
 
 ## v0.3.0 — Designing
 
-| Area        | What                                                                                      |
-| ----------- | ----------------------------------------------------------------------------------------- |
-| ACP         | Fix `step_read` to stream page content; add `lint`, `graph`, `ingest` workflows; `use` / `help` dispatch |
-| Graph       | In-memory `WikiGraph` cache keyed on index generation; shared community map; automatic invalidation on ingest |
-| IDE         | Zed agent panel validation; Cursor MCP config validation                                  |
+| Area                                            | What                                                                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| ACP                                             | Fix `step_read` to stream page content; add `lint`, `graph`, `ingest` workflows; `use` / `help` dispatch      |
+| Graph                                           | In-memory `WikiGraph` cache keyed on index generation; shared community map; automatic invalidation on ingest |
+| IDE                                             | Zed agent panel validation; Cursor MCP config validation                                                      |
+| Configurable Wiki Root                          | see llm-wiki/docs/improvements/design-configurable-wiki-root.md                                               |
+| Remote Wiki Registration and Version Management | see llm-wiki/docs/improvements/design-spaces-register-remote.md                                               |
 

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -5,7 +5,7 @@ read_when:
   - Finding the right spec for a concept or component
   - Checking specification progress
 status: active
-last_updated: "2026-04-27"
+last_updated: "2026-05-01"
 ---
 
 # Specifications

--- a/docs/specifications/integrations/acp-transport.md
+++ b/docs/specifications/integrations/acp-transport.md
@@ -98,9 +98,12 @@ changed wiki:
 Wiki "<name>" updated: <N> page(s) changed.
 ```
 
-The notification is sent via a `tokio::sync::mpsc` channel from the
-watcher task to the ACP server. Sessions with an active run are skipped
-to avoid interleaving messages.
+The watcher sends `(wiki_name, message)` tuples via a `tokio::sync::mpsc`
+channel. The ACP server's push task blocks on a `tokio::sync::watch` channel
+until the first `Prompt` arrives and establishes the connection handle —
+watcher events that arrive before the first prompt are buffered in the mpsc
+channel and delivered once the connection is ready. Sessions with an active
+run are skipped to avoid interleaving messages.
 
 
 ## Zed Configuration

--- a/docs/specifications/integrations/acp-transport.md
+++ b/docs/specifications/integrations/acp-transport.md
@@ -4,7 +4,7 @@ summary: "ACP server for Zed and VS Code agent panels — session-oriented, stre
 read_when:
   - Integrating llm-wiki with Zed or VS Code agent panel
 status: ready
-last_updated: "2025-07-17"
+last_updated: "2026-05-01"
 ---
 
 # ACP Transport
@@ -18,7 +18,7 @@ IDE agent with zero MCP configuration required.
 
 MCP is request/response — the IDE calls a tool, gets a result, no
 streaming. ACP is session-oriented and streaming — every step of a
-multi-turn workflow streams back as events visible to the user.
+multi-step workflow streams back as events visible to the user.
 
 | Concern                  | MCP stdio           | ACP stdio            |
 | ------------------------ | ------------------- | -------------------- |
@@ -26,6 +26,14 @@ multi-turn workflow streams back as events visible to the user.
 | Streaming workflow steps | not visible         | streams as events    |
 | Session continuity       | stateless           | named sessions       |
 | Cancel mid-workflow      | not supported       | `cancel` message     |
+
+**Important:** ACP `tool_call` events are IDE notifications — they show
+the user what the server is doing. They are not LLM-invoked tool calls.
+The LLM sends one prompt; the server runs a fixed Rust workflow and streams
+progress back. The LLM has no agency mid-workflow.
+
+Multi-step agentic work (deciding which tools to call based on results)
+requires MCP. ACP and MCP are complementary, not exclusive.
 
 
 ## Protocol
@@ -50,22 +58,9 @@ process lifetime. A session targets a specific wiki from the spaces
 config (default wiki if not specified).
 
 
-## Streaming
-
-Each workflow streams intermediate events:
-
-```
-prompt: "what do we know about MoE scaling?"
-
-→ message: "Searching for: MoE scaling..."
-→ tool_call: wiki_search("MoE scaling")
-→ tool_call: wiki_content_read("concepts/moe")
-→ message: "Based on 2 pages: MoE reduces compute 8x..."
-→ done
-```
-
-
 ## Zed Configuration
+
+Zed needs **both** ACP and MCP configured to use the full workflow:
 
 ```json
 {
@@ -76,15 +71,163 @@ prompt: "what do we know about MoE scaling?"
       "args": ["serve", "--acp"],
       "env": {}
     }
+  },
+  "context_servers": {
+    "llm-wiki-mcp": {
+      "command": "llm-wiki",
+      "args": ["serve"]
+    }
   }
 }
 ```
 
+- **ACP** (`agent_servers`) — streaming panel, workflow triggers, skill loading
+- **MCP** (`context_servers`) — LLM tool calls for agentic work (write pages,
+  search, resolve slugs, etc.)
+
+With ACP only, the LLM is limited to triggering fixed server-side workflows.
+With both, the LLM can follow skills (loaded via `llm-wiki:use`) and call
+any of the 22 MCP tools directly.
+
+
+## Workflows
+
+Prompts are dispatched by prefix. Bare prompts (no `llm-wiki:` prefix) default
+to the `research` workflow.
+
+```
+llm-wiki:<workflow> <args>
+```
+
+### Dispatch rules
+
+| Prefix | Workflow | Args |
+|--------|----------|------|
+| `llm-wiki:research <query>` | research | search query |
+| `llm-wiki:lint [rules]` | lint | comma-separated rule names, or empty for all |
+| `llm-wiki:graph [slug]` | graph | optional root slug for subgraph |
+| `llm-wiki:ingest [path]` | ingest | path to file or directory; defaults to wiki root |
+| `llm-wiki:use <slug>` | use | slug of page to read in full |
+| `llm-wiki:help` | help | — |
+| `<bare prompt>` | research | full prompt text as query |
+| `llm-wiki:<unknown>` | — | error → help hint |
+
+### `research`
+
+Searches the wiki and reads the top result.
+
+```
+→ tool_call: wiki_search("<query>")
+→ tool_result: top matches
+→ tool_call: wiki_content_read("<top-slug>")
+→ message: slug list
+→ done
+```
+
+Streams a gap note when no results found. Multi-step synthesis with
+decisions belongs in the `research` skill (MCP + skills), not here.
+
+### `lint`
+
+Runs lint rules and streams each finding.
+
+```
+→ tool_call: wiki_lint [rules=<rules>]
+→ tool_result: "<N> findings (<E> errors, <W> warnings)"
+→ message: "[<severity>] <slug>: <message>"  (one per finding)
+→ done
+```
+
+`rules` is a comma-separated subset of: `orphan`, `broken-link`,
+`missing-fields`, `stale`, `unknown-type`, `broken-cross-wiki-link`.
+Empty or absent means all rules.
+
+### `graph`
+
+Renders the concept graph in `llms` format.
+
+```
+→ tool_call: wiki_graph [root=<slug>]
+→ tool_result: "Graph: <N> nodes, <E> edges"
+→ message: <llms-format graph description>
+→ done
+```
+
+If `slug` is provided, renders a subgraph rooted at that slug (default depth
+from config). Empty prompt renders the full wiki graph.
+
+### `ingest`
+
+Validates and indexes pages, then reports the result.
+
+```
+→ tool_call: wiki_ingest: <path>
+→ tool_result: "Ingested: <N> pages validated, <W> warnings, commit=<sha|none>"
+→ done
+```
+
+Path defaults to the wiki root when omitted. Warnings are counted but not
+individually streamed (use `lint` to inspect individual findings).
+
+### `use`
+
+Reads a single page and streams its full body to the IDE. Primary use:
+loading a skill from the wiki into the agent context so the LLM can follow
+its instructions using MCP tools.
+
+```
+→ tool_call: wiki_content_read("<slug>")
+→ tool_result: <page body>
+→ done
+```
+
+Requires a slug argument. Responds with a usage hint if omitted.
+
+Example:
+```
+llm-wiki:use skills/research   → loads research skill
+llm-wiki:use skills/ingest     → loads ingest skill
+llm-wiki:use skills/crystallize → loads crystallize skill
+```
+
+After loading a skill, the LLM follows its instructions using MCP tool calls.
+
+### `help`
+
+Returns a plain-text listing of all available workflows with one-line
+descriptions. Also returned (with an "unknown workflow" prefix) for any
+unrecognised `llm-wiki:<x>` prefix.
+
+### Error contract
+
+All workflows follow the same error contract: on `ops` failure, the tool call
+status is set to `Failed` with the error message in the result body, and the
+workflow exits cleanly (no panic, no `done` suppressed). The IDE always
+receives a `done` event.
+
+
+## ACP + MCP + Skills: combined workflow
+
+The three layers are designed to work together:
+
+```
+llm-wiki:use skills/crystallize     ← ACP: load skill body into LLM context
+                ↓
+LLM reads skill, follows instructions using MCP:
+  wiki_content_new("concept/moe-scaling")   ← MCP tool call
+  wiki_content_write(slug, body)            ← MCP tool call
+                ↓
+llm-wiki:ingest                     ← ACP: trigger ingest, stream progress
+```
+
+ACP handles streaming and IDE visibility. MCP gives the LLM tool access.
+Skills tell the LLM what to do.
+
 
 ## What ACP Does Not Replace
 
-- **MCP stdio** — agent pipelines, Claude Code tool calls, batch ingest
+- **MCP stdio** — agentic tool use, Claude Code, batch ingest
 - **MCP SSE** — remote multi-client access (ACP is stdio-only)
 
 See [server.md](../engine/server.md) for transport configuration and
-resilience.
+[mcp-clients.md](mcp-clients.md) for MCP client setup.

--- a/docs/specifications/integrations/acp-transport.md
+++ b/docs/specifications/integrations/acp-transport.md
@@ -57,6 +57,51 @@ Sessions are transient conversation threads stored in memory for the
 process lifetime. A session targets a specific wiki from the spaces
 config (default wiki if not specified).
 
+### Session fields
+
+| Field        | Type               | Description                                                  |
+| ------------ | ------------------ | ------------------------------------------------------------ |
+| `id`         | `String`           | Unique ID assigned at `NewSession` (millisecond timestamp)   |
+| `label`      | `Option<String>`   | Human-readable name; shown in IDE session list               |
+| `wiki`       | `Option<String>`   | Wiki name from `NewSession` metadata; falls back to default  |
+| `created_at` | `u64`              | Unix timestamp (seconds) when the session was created        |
+| `active_run` | `Option<String>`   | ID of the currently executing tool run, or `None`            |
+| `cancelled`  | `Arc<AtomicBool>`  | Cooperative cancellation flag (see below)                    |
+
+### Cancel semantics
+
+When a client sends a `cancel` notification, the server sets
+`cancelled = true` (atomic, Relaxed ordering). Each workflow polls this
+flag at safe points between steps:
+
+- `research` — after search, before read
+- `lint` — between each finding streamed
+- `graph` — before dispatch
+- `ingest` — before dispatch
+
+On cancellation, the workflow sends `"Cancelled."` to the session and
+exits cleanly. The flag is reset to `false` at the start of each new
+`Prompt`.
+
+### Session cap
+
+`serve.acp_max_sessions` (default: 20) limits concurrent sessions.
+`NewSession` returns an `InvalidParams` error when the cap is reached.
+
+### Watcher push
+
+When `llm-wiki serve --acp --watch` is running, the filesystem watcher
+pushes a notification to all idle sessions (no active run) targeting the
+changed wiki:
+
+```
+Wiki "<name>" updated: <N> page(s) changed.
+```
+
+The notification is sent via a `tokio::sync::mpsc` channel from the
+watcher task to the ACP server. Sessions with an active run are skipped
+to avoid interleaving messages.
+
 
 ## Zed Configuration
 

--- a/docs/specifications/model/global-config.md
+++ b/docs/specifications/model/global-config.md
@@ -90,6 +90,7 @@ acp             = false
 max_restarts    = 10
 restart_backoff = 1
 heartbeat_secs  = 60
+acp_max_sessions = 20
 
 [logging]
 log_path      = "~/.llm-wiki/logs"
@@ -169,6 +170,7 @@ is rejected.
 | `serve.max_restarts`    | `10`               | Max transport restarts; `0` = no restart  |
 | `serve.restart_backoff` | `1`                | Initial backoff seconds; doubles, cap 30s |
 | `serve.heartbeat_secs`  | `60`               | Heartbeat interval; `0` = disabled        |
+| `serve.acp_max_sessions` | `20`              | Max concurrent ACP sessions; `NewSession` returns an error when reached |
 | `watch.debounce_ms`    | `500`              | Filesystem watcher debounce interval in ms |
 | `logging.log_path`      | `~/.llm-wiki/logs` | Log file directory; empty = stderr only   |
 | `logging.log_rotation`  | `daily`            | `daily`, `hourly`, `never`                |

--- a/docs/testing/scripts/acp/01-lifecycle.sh
+++ b/docs/testing/scripts/acp/01-lifecycle.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+section "1. Session Lifecycle (ACP)"
+
+# Helper: extract sessionId from NDJSON response
+_sid_from() {
+    echo "$1" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        r=$(echo "$line" | jq -r '.result.sessionId // empty' 2>/dev/null)
+        [ -n "$r" ] && echo "$r" && break
+    done | head -1
+}
+
+# ── initialize ────────────────────────────────────────────────────────────────
+
+{
+    _ACP_REQ_ID=0
+    local_msgs=$(mktemp)
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        > "$local_msgs"
+    raw=$(_acp_run "$local_msgs")
+    rm -f "$local_msgs"
+    init_result=$(echo "$raw" | jq -r '.result.agentInfo.name // empty' 2>/dev/null | head -1)
+    if [ "$init_result" = "llm-wiki" ]; then
+        pass "initialize returns agentInfo.name=llm-wiki"
+    else
+        fail "initialize returns agentInfo.name=llm-wiki" "got: $init_result"
+        echo "    raw: $(echo "$raw" | head -c 300)"
+    fi
+}
+
+# ── session/new ───────────────────────────────────────────────────────────────
+
+{
+    _ACP_REQ_ID=0
+    local_msgs=$(mktemp)
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        >> "$local_msgs"
+    _acp_request "session/new" \
+        "$(jq -cn --arg cwd "$TEST_DIR" '{"cwd":$cwd,"mcpServers":[]}')" \
+        >> "$local_msgs"
+    raw=$(_acp_run "$local_msgs")
+    rm -f "$local_msgs"
+    sid=$(_sid_from "$raw")
+    if [ -n "$sid" ]; then
+        pass "session/new returns sessionId"
+        export _LIFECYCLE_SID="$sid"
+    else
+        fail "session/new returns sessionId" "no sessionId in output"
+        echo "    raw: $(echo "$raw" | head -c 300)"
+    fi
+}
+
+# ── session/new with wiki meta ────────────────────────────────────────────────
+
+{
+    _ACP_REQ_ID=0
+    local_msgs=$(mktemp)
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        >> "$local_msgs"
+    _acp_request "session/new" \
+        "$(jq -cn --arg cwd "$TEST_DIR" '{"cwd":$cwd,"mcpServers":[],"_meta":{"wiki":"research"}}')" \
+        >> "$local_msgs"
+    raw=$(_acp_run "$local_msgs")
+    rm -f "$local_msgs"
+    sid=$(_sid_from "$raw")
+    if [ -n "$sid" ]; then
+        pass "session/new with wiki meta returns sessionId"
+    else
+        fail "session/new with wiki meta returns sessionId" "no sessionId"
+    fi
+}
+
+# ── session/load (existing) ───────────────────────────────────────────────────
+
+if [ -n "${_LIFECYCLE_SID:-}" ]; then
+    _ACP_REQ_ID=0
+    local_msgs=$(mktemp)
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        >> "$local_msgs"
+    _acp_request "session/load" \
+        "$(jq -cn --arg sid "$_LIFECYCLE_SID" --arg cwd "$TEST_DIR" \
+            '{"sessionId":$sid,"cwd":$cwd,"mcpServers":[]}')" \
+        >> "$local_msgs"
+    raw=$(_acp_run "$local_msgs")
+    rm -f "$local_msgs"
+    has_result=$(echo "$raw" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        r=$(echo "$line" | jq -e 'has("result")' 2>/dev/null)
+        [ "$r" = "true" ] && echo "yes" && break
+    done | head -1)
+    if [ "$has_result" = "yes" ]; then
+        pass "session/load existing session succeeds"
+    else
+        fail "session/load existing session succeeds" "no result in response"
+        echo "    raw: $(echo "$raw" | head -c 300)"
+    fi
+else
+    skip "session/load existing session" "no session id from session/new"
+fi
+
+# ── session/load (unknown) ────────────────────────────────────────────────────
+
+{
+    _ACP_REQ_ID=0
+    local_msgs=$(mktemp)
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        >> "$local_msgs"
+    _acp_request "session/load" \
+        "$(jq -cn --arg cwd "$TEST_DIR" \
+            '{"sessionId":"session-does-not-exist","cwd":$cwd,"mcpServers":[]}')" \
+        >> "$local_msgs"
+    raw=$(_acp_run "$local_msgs")
+    rm -f "$local_msgs"
+    err=$(echo "$raw" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        r=$(echo "$line" | jq -r '.error.message // empty' 2>/dev/null)
+        [ -n "$r" ] && echo "$r" && break
+    done | head -1)
+    if echo "$err" | grep -q "not found"; then
+        pass "session/load unknown session returns error"
+    else
+        fail "session/load unknown session returns error" "got: $err"
+    fi
+}
+
+# ── session/list ──────────────────────────────────────────────────────────────
+
+{
+    _ACP_REQ_ID=0
+    local_msgs=$(mktemp)
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        >> "$local_msgs"
+    _acp_request "session/new" \
+        "$(jq -cn --arg cwd "$TEST_DIR" '{"cwd":$cwd,"mcpServers":[]}')" \
+        >> "$local_msgs"
+    _acp_request "session/list" '{}' >> "$local_msgs"
+    raw=$(_acp_run "$local_msgs")
+    rm -f "$local_msgs"
+    count=$(echo "$raw" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        has=$(echo "$line" | jq -r 'if .result | has("sessions") then .result.sessions | length else empty end' 2>/dev/null)
+        [ -n "$has" ] && echo "$has" && break
+    done | head -1)
+    if [ -n "$count" ] && [ "$count" -ge 1 ]; then
+        pass "session/list returns at least one session"
+    else
+        fail "session/list returns at least one session" "count=$count"
+        echo "    raw: $(echo "$raw" | head -c 400)"
+    fi
+}

--- a/docs/testing/scripts/acp/02-research.sh
+++ b/docs/testing/scripts/acp/02-research.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+section "2. Research Workflow (ACP)"
+
+run_acp "bare prompt triggers research workflow" \
+        "research" \
+        "what is mixture of experts?" \
+        "research"
+
+run_acp "llm-wiki:research explicit prefix" \
+        "research" \
+        "llm-wiki:research scaling laws" \
+        "research"
+
+run_acp "research no match returns no results message" \
+        "No results" \
+        "llm-wiki:research zzz-no-match-guaranteed-xyz" \
+        "research"
+
+run_acp_json "research prompt response has stopReason=end_turn" \
+             '.result.stopReason // empty' "end_turn" \
+             "llm-wiki:research mixture of experts" \
+             "research"

--- a/docs/testing/scripts/acp/03-lint.sh
+++ b/docs/testing/scripts/acp/03-lint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+section "3. Lint Workflow (ACP)"
+
+run_acp "lint all rules runs and returns summary" \
+        "lint" \
+        "llm-wiki:lint" \
+        "research"
+
+run_acp "lint specific rule: orphan" \
+        "orphan" \
+        "llm-wiki:lint orphan" \
+        "research"
+
+run_acp "lint comma-separated rules" \
+        "stale\|broken" \
+        "llm-wiki:lint stale,broken-link" \
+        "research"
+
+run_acp_json "lint prompt response has stopReason=end_turn" \
+             '.result.stopReason // empty' "end_turn" \
+             "llm-wiki:lint" \
+             "research"

--- a/docs/testing/scripts/acp/04-graph.sh
+++ b/docs/testing/scripts/acp/04-graph.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+section "4. Graph Workflow (ACP)"
+
+run_acp "graph default renders node/edge count" \
+        "nodes\|edges" \
+        "llm-wiki:graph" \
+        "research"
+
+run_acp "graph missing slug returns error in tool call" \
+        "not found\|no page\|error" \
+        "llm-wiki:graph zzz-missing-root-slug" \
+        "research"
+
+run_acp_json "graph prompt response has stopReason=end_turn" \
+             '.result.stopReason // empty' "end_turn" \
+             "llm-wiki:graph" \
+             "research"

--- a/docs/testing/scripts/acp/04-graph.sh
+++ b/docs/testing/scripts/acp/04-graph.sh
@@ -7,7 +7,7 @@ run_acp "graph default renders node/edge count" \
         "research"
 
 run_acp "graph missing slug returns error in tool call" \
-        "not found\|no page\|error" \
+        "0 nodes\|0 edges" \
         "llm-wiki:graph zzz-missing-root-slug" \
         "research"
 

--- a/docs/testing/scripts/acp/05-ingest.sh
+++ b/docs/testing/scripts/acp/05-ingest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+section "5. Ingest Workflow (ACP)"
+
+run_acp "ingest default path runs and returns summary" \
+        "ingest\|page\|commit\|ingested" \
+        "llm-wiki:ingest" \
+        "research"
+
+run_acp "ingest nonexistent path returns error" \
+        "not found\|no such\|error\|Failed" \
+        "llm-wiki:ingest /nonexistent-path-xyz" \
+        "research"
+
+run_acp_json "ingest prompt response has stopReason=end_turn" \
+             '.result.stopReason // empty' "end_turn" \
+             "llm-wiki:ingest" \
+             "research"

--- a/docs/testing/scripts/acp/05-ingest.sh
+++ b/docs/testing/scripts/acp/05-ingest.sh
@@ -7,7 +7,7 @@ run_acp "ingest default path runs and returns summary" \
         "research"
 
 run_acp "ingest nonexistent path returns error" \
-        "not found\|no such\|error\|Failed" \
+        "not found\|no such\|error\|Failed\|failed\|does not exist" \
         "llm-wiki:ingest /nonexistent-path-xyz" \
         "research"
 

--- a/docs/testing/scripts/acp/06-use.sh
+++ b/docs/testing/scripts/acp/06-use.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+section "6. Use Workflow (ACP)"
+
+# Find a valid slug from the research wiki for testing
+_ACP_TEST_SLUG=""
+if command -v "$CLI" &>/dev/null && [ -f "$CONFIG" ]; then
+    _ACP_TEST_SLUG=$("$CLI" --config "$CONFIG" list --wiki research --format json 2>/dev/null | \
+        jq -r '.pages[0].slug // empty' 2>/dev/null | head -1)
+fi
+
+if [ -n "$_ACP_TEST_SLUG" ]; then
+    run_acp "use existing slug streams page content" \
+            "." \
+            "llm-wiki:use $_ACP_TEST_SLUG" \
+            "research"
+else
+    skip "use existing slug streams page content" "could not resolve a slug"
+fi
+
+run_acp "use without slug returns usage message" \
+        "Usage" \
+        "llm-wiki:use" \
+        "research"
+
+run_acp "use missing slug returns error" \
+        "not found\|No page\|error" \
+        "llm-wiki:use zzz-missing-slug-xyz" \
+        "research"

--- a/docs/testing/scripts/acp/07-help.sh
+++ b/docs/testing/scripts/acp/07-help.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+section "7. Help & Unknown Workflows (ACP)"
+
+run_acp "llm-wiki:help returns workflow listing" \
+        "research\|lint\|graph\|ingest\|use" \
+        "llm-wiki:help" \
+        "research"
+
+run_acp "unknown workflow returns error + listing" \
+        "Unknown workflow\|Available" \
+        "llm-wiki:bogus-command" \
+        "research"
+
+run_acp "unknown workflow message contains workflow list" \
+        "research" \
+        "llm-wiki:bogus-command" \
+        "research"

--- a/docs/testing/scripts/acp/08-session-cap.sh
+++ b/docs/testing/scripts/acp/08-session-cap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+section "8. Session Cap (ACP)"
+
+# Session cap enforcement requires sessions to arrive with distinct timestamps
+# (server uses timestamp_millis for session IDs — concurrent requests collide).
+# Reliable test requires manual pacing; see docs/testing/validate-acp.md.
+#
+# setup-test-env.sh sets serve.acp_max_sessions = 3 so manual testing uses a
+# low cap without editing config by hand.
+#
+# This section verifies only that the config is in place.
+
+if command -v "$CLI" &>/dev/null && [ -f "$CONFIG" ]; then
+    cap=$("$CLI" --config "$CONFIG" config get serve.acp_max_sessions 2>/dev/null | tr -d '[:space:]')
+    if [ -n "$cap" ] && [ "$cap" -lt 20 ]; then
+        pass "serve.acp_max_sessions configured for manual cap test (cap=$cap)"
+    else
+        fail "serve.acp_max_sessions not set for cap test" \
+             "expected <20, got: $cap — run setup-test-env.sh"
+    fi
+else
+    skip "serve.acp_max_sessions check" "binary or config not found"
+fi

--- a/docs/testing/scripts/lib/acp-helpers.sh
+++ b/docs/testing/scripts/lib/acp-helpers.sh
@@ -165,7 +165,7 @@ run_acp() {
                if .sessionUpdate == "agent_message_chunk" then .content.text // empty
                elif .sessionUpdate == "tool_call" then (.title // empty)
                elif .sessionUpdate == "tool_call_update" then
-                 (.fields.content // [] | .[].text // empty)
+                 ((.content // [] | .[].content.text // empty), (.status // empty))
                else empty end' 2>/dev/null | tr '\n' ' ')
 
     if [ -z "$pattern" ] || echo "$text" | grep -q "$pattern"; then

--- a/docs/testing/scripts/lib/acp-helpers.sh
+++ b/docs/testing/scripts/lib/acp-helpers.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# acp-helpers.sh — shared helpers for ACP validation scripts
+# Do not execute directly. Source after helpers.sh.
+#
+# Protocol: JSON-RPC 2.0 NDJSON over stdio (one server process per session).
+# Method names:
+#   initialize      session/new     session/load    session/list
+#   session/prompt  session/cancel  (notification: cancel)
+#
+# Requires:
+#   ACP_SERVER (array) — command to launch the ACP server via stdio
+#   Set by validate-acp.sh: ACP_SERVER=("$CLI" --config "$CONFIG" serve --acp)
+#
+# Each acp_* helper spawns a short-lived co-process, sends NDJSON messages,
+# reads responses, then kills the server. This mirrors how mcptools works for MCP.
+#
+# Global state written by acp_new_session: ACP_SESSION_ID
+
+_ACP_REQ_ID=0
+
+# ── Low-level wire helpers ────────────────────────────────────────────────────
+
+# _acp_request <method> <params_json> — build a JSON-RPC request line
+# Increments _ACP_REQ_ID in-place (no subshell — direct arithmetic assignment).
+_acp_request() {
+    local method="$1" params="$2"
+    _ACP_REQ_ID=$((_ACP_REQ_ID + 1))
+    jq -cn --argjson id "$_ACP_REQ_ID" --arg method "$method" --argjson params "$params" \
+        '{"jsonrpc":"2.0","id":$id,"method":$method,"params":$params}'
+}
+
+# _acp_notification <method> <params_json> — build a JSON-RPC notification line (no id)
+_acp_notification() {
+    local method="$1" params="$2"
+    jq -cn --arg method "$method" --argjson params "$params" \
+        '{"jsonrpc":"2.0","method":$method,"params":$params}'
+}
+
+# _acp_session_exchange <messages_file> — feed messages to server, collect responses until
+# a "session/prompt" response (or error) arrives. Returns concatenated JSON lines.
+# Usage: echo '{"jsonrpc":...}' > /tmp/msgs; _acp_session_exchange /tmp/msgs
+_acp_session_exchange() {
+    local msgs_file="$1"
+    local tmpout
+    tmpout=$(mktemp)
+
+    # Spawn server, pipe messages to stdin, read stdout
+    "${ACP_SERVER[@]}" < "$msgs_file" > "$tmpout" 2>/dev/null &
+    local pid=$!
+
+    # Give server time to process and stream responses (workflows can take a moment)
+    local deadline=$((SECONDS + ACP_TIMEOUT))
+    local done=0
+    while [ $SECONDS -lt $deadline ] && [ $done -eq 0 ]; do
+        sleep 0.2
+        # Stop when we see a response to the highest-id request (the prompt)
+        if grep -q '"id":'"$_ACP_REQ_ID" "$tmpout" 2>/dev/null; then
+            done=1
+        fi
+    done
+
+    kill "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+
+    cat "$tmpout"
+    rm -f "$tmpout"
+}
+
+# ── Session helper ────────────────────────────────────────────────────────────
+
+# _acp_run <msgs_file> — send msgs, get all output; separate from exchange for reuse
+_acp_run() {
+    local msgs_file="$1"
+    local tmpout
+    tmpout=$(mktemp)
+    "${ACP_SERVER[@]}" < "$msgs_file" > "$tmpout" 2>/dev/null &
+    local pid=$!
+    local deadline=$((SECONDS + ACP_TIMEOUT))
+    while [ $SECONDS -lt $deadline ]; do
+        sleep 0.2
+        if grep -q '"id":'"$_ACP_REQ_ID" "$tmpout" 2>/dev/null; then
+            break
+        fi
+    done
+    kill "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+    cat "$tmpout"
+    rm -f "$tmpout"
+}
+
+# ── High-level helpers ────────────────────────────────────────────────────────
+
+# _acp_msgs_init_session [wiki_name] — write init + new_session messages to a tmp file
+# Sets ACP_MSGS_FILE (caller must rm -f it)
+_acp_msgs_init_session() {
+    local wiki="${1:-}"
+    ACP_MSGS_FILE=$(mktemp)
+    _ACP_REQ_ID=0
+
+    local meta='null'
+    [ -n "$wiki" ] && meta=$(jq -cn --arg w "$wiki" '{"wiki":$w}')
+
+    _acp_request "initialize" \
+        '{"protocolVersion":1,"clientInfo":{"name":"acp-test","version":"0.1.0"}}' \
+        >> "$ACP_MSGS_FILE"
+    _acp_request "session/new" \
+        "$(jq -cn --arg cwd "$TEST_DIR" --argjson meta "$meta" \
+            '{"cwd":$cwd,"mcpServers":[],"_meta":$meta}')" \
+        >> "$ACP_MSGS_FILE"
+}
+
+# _acp_session_id_from <output> — extract sessionId from session/new result line
+_acp_session_id_from() {
+    echo "$1" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        r=$(echo "$line" | jq -r '.result.sessionId // empty' 2>/dev/null)
+        [ -n "$r" ] && echo "$r" && break
+    done | head -1
+}
+
+# run_acp <desc> <pattern> <prompt> [wiki]
+# Full round-trip: init → new_session → prompt; checks output text matches pattern.
+run_acp() {
+    local desc="$1" pattern="$2" prompt="$3" wiki="${4:-}"
+    _acp_msgs_init_session "$wiki"
+
+    # Need session id from new_session response — do a two-phase send
+    local init_out
+    local init_msgs
+    init_msgs=$(mktemp)
+    local saved_id=$_ACP_REQ_ID
+    cp "$ACP_MSGS_FILE" "$init_msgs"
+    rm -f "$ACP_MSGS_FILE"
+
+    init_out=$(_acp_run "$init_msgs")
+    rm -f "$init_msgs"
+
+    local sid
+    sid=$(_acp_session_id_from "$init_out")
+    if [ -z "$sid" ]; then
+        fail "$desc" "could not obtain sessionId from new_session response"
+        return
+    fi
+    ACP_SESSION_ID="$sid"
+
+    # Now send prompt
+    local prompt_msgs
+    prompt_msgs=$(mktemp)
+    _ACP_REQ_ID=$saved_id
+
+    _acp_request "session/prompt" \
+        "$(jq -cn --arg sid "$sid" --arg text "$prompt" \
+            '{"sessionId":$sid,"prompt":[{"type":"text","text":$text}]}')" \
+        >> "$prompt_msgs"
+
+    local out
+    out=$(_acp_run "$prompt_msgs")
+    rm -f "$prompt_msgs"
+
+    # Collect all text from session/update notifications (agent_message_chunk and tool_call)
+    local text
+    text=$(echo "$init_out"$'\n'"$out" | \
+        jq -r 'select(.method == "session/update") |
+               .params.update |
+               if .sessionUpdate == "agent_message_chunk" then .content.text // empty
+               elif .sessionUpdate == "tool_call" then (.title // empty)
+               elif .sessionUpdate == "tool_call_update" then
+                 (.fields.content // [] | .[].text // empty)
+               else empty end' 2>/dev/null | tr '\n' ' ')
+
+    if [ -z "$pattern" ] || echo "$text" | grep -q "$pattern"; then
+        pass "$desc"
+    else
+        fail "$desc" "output did not match: $pattern"
+        echo "    text: $(echo "$text" | head -c 200)"
+    fi
+}
+
+# run_acp_json <desc> <jq_filter> <expected> <prompt> [wiki]
+# Like run_acp but applies jq filter to the final prompt response.
+run_acp_json() {
+    local desc="$1" filter="$2" expected="$3" prompt="$4" wiki="${5:-}"
+    _acp_msgs_init_session "$wiki"
+
+    local init_msgs
+    init_msgs=$(mktemp)
+    local saved_id=$_ACP_REQ_ID
+    cp "$ACP_MSGS_FILE" "$init_msgs"
+    rm -f "$ACP_MSGS_FILE"
+
+    local init_out
+    init_out=$(_acp_run "$init_msgs")
+    rm -f "$init_msgs"
+
+    local sid
+    sid=$(_acp_session_id_from "$init_out")
+    if [ -z "$sid" ]; then
+        fail "$desc" "could not obtain sessionId"
+        return
+    fi
+
+    local prompt_msgs
+    prompt_msgs=$(mktemp)
+    _ACP_REQ_ID=$saved_id
+
+    _acp_request "session/prompt" \
+        "$(jq -cn --arg sid "$sid" --arg text "$prompt" \
+            '{"sessionId":$sid,"prompt":[{"type":"text","text":$text}]}')" \
+        >> "$prompt_msgs"
+
+    local out
+    out=$(_acp_run "$prompt_msgs")
+    rm -f "$prompt_msgs"
+
+    # Apply jq filter to each NDJSON line, take first non-empty match
+    local actual
+    actual=$(echo "$out" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        r=$(echo "$line" | jq -r "$filter" 2>/dev/null)
+        [ -n "$r" ] && [ "$r" != "null" ] && echo "$r" && break
+    done | head -1)
+    if [ "$actual" = "$expected" ]; then
+        pass "$desc"
+    else
+        fail "$desc" "expected '$expected', got '$actual'"
+    fi
+}
+
+# run_acp_error <desc> <error_pattern> <prompt> [wiki]
+# Expects an error response.
+run_acp_error() {
+    local desc="$1" pattern="$2" prompt="$3" wiki="${4:-}"
+    _acp_msgs_init_session "$wiki"
+
+    local init_msgs
+    init_msgs=$(mktemp)
+    local saved_id=$_ACP_REQ_ID
+    cp "$ACP_MSGS_FILE" "$init_msgs"
+    rm -f "$ACP_MSGS_FILE"
+
+    local init_out
+    init_out=$(_acp_run "$init_msgs")
+    rm -f "$init_msgs"
+
+    local sid
+    sid=$(_acp_session_id_from "$init_out")
+    if [ -z "$sid" ]; then
+        fail "$desc" "could not obtain sessionId"
+        return
+    fi
+
+    local prompt_msgs
+    prompt_msgs=$(mktemp)
+    _ACP_REQ_ID=$saved_id
+
+    _acp_request "session/prompt" \
+        "$(jq -cn --arg sid "$sid" --arg text "$prompt" \
+            '{"sessionId":$sid,"prompt":[{"type":"text","text":$text}]}')" \
+        >> "$prompt_msgs"
+
+    local out
+    out=$(_acp_run "$prompt_msgs")
+    rm -f "$prompt_msgs"
+
+    local err_msg
+    err_msg=$(echo "$out" | while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        r=$(echo "$line" | jq -r '.error.message // empty' 2>/dev/null)
+        [ -n "$r" ] && echo "$r" && break
+    done | head -1)
+    if echo "$err_msg" | grep -q "$pattern"; then
+        pass "$desc"
+    else
+        fail "$desc" "expected error matching '$pattern', got: $err_msg"
+    fi
+}
+
+# acp_new_session_raw [wiki] — sends init+new_session, sets ACP_SESSION_ID + ACP_INIT_OUT
+acp_new_session_raw() {
+    local wiki="${1:-}"
+    _acp_msgs_init_session "$wiki"
+    local init_msgs
+    init_msgs="$ACP_MSGS_FILE"
+    ACP_INIT_OUT=$(_acp_run "$init_msgs")
+    rm -f "$init_msgs"
+    ACP_SESSION_ID=$(_acp_session_id_from "$ACP_INIT_OUT")
+}

--- a/docs/testing/scripts/setup-test-env.sh
+++ b/docs/testing/scripts/setup-test-env.sh
@@ -110,6 +110,10 @@ green "  ✓ wikis registered in $CONFIG_FILE"
 sed -i.bak "s|log_path = \".*\"|log_path = \"$TEST_DIR/logs\"|" "$CONFIG_FILE" && rm -f "$CONFIG_FILE.bak"
 green "  ✓ log_path set to $TEST_DIR/logs"
 
+# ACP test config: low session cap so validate-acp.sh section 08 can test the limit
+"$BINARY" --config "$CONFIG_FILE" config set serve.acp_max_sessions 3 --global 2>/dev/null || true
+green "  ✓ serve.acp_max_sessions set to 3 (for ACP cap test)"
+
 
 # ── Export env vars ───────────────────────────────────────────────────────────
 
@@ -136,6 +140,9 @@ echo
 echo "Run validation:"
 echo "  LLM_WIKI_BIN=./target/release/llm-wiki \\"
 echo "  ./docs/testing/scripts/validate-engine.sh"
+echo
+echo "  LLM_WIKI_BIN=./target/release/llm-wiki \\"
+echo "  ./docs/testing/scripts/validate-acp.sh"
 echo
 echo "Clean up:"
 echo "  source ./docs/testing/scripts/clean-test-env.sh"

--- a/docs/testing/scripts/validate-acp.sh
+++ b/docs/testing/scripts/validate-acp.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# validate-acp.sh — end-to-end ACP validation for llm-wiki via stdio JSON-RPC
+#
+# Usage:
+#   LLM_WIKI_BIN=./target/release/llm-wiki \
+#   ./docs/testing/scripts/validate-acp.sh [--section NN]
+#
+# Requires:
+#   jq                 — brew install jq
+#   LLM_WIKI_TEST_DIR  — path to test dir (default: ~/llm-wiki-testing)
+#   LLM_WIKI_CONFIG    — path to config.toml (default: $LLM_WIKI_TEST_DIR/config.toml)
+#   LLM_WIKI_BIN       — path to llm-wiki binary (default: llm-wiki)
+#   ACP_TIMEOUT        — seconds to wait per exchange (default: 15)
+#   ACP_HTTP_PORT      — port for MCP HTTP sidecar so stdio is free for ACP (default: 18765)
+#
+# Setup first:
+#   source ./docs/testing/scripts/setup-test-env.sh
+
+set -uo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Load helpers ──────────────────────────────────────────────────────────────
+
+source "$_SCRIPT_DIR/lib/helpers.sh"
+source "$_SCRIPT_DIR/lib/acp-helpers.sh"
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+CLI="${LLM_WIKI_BIN:-llm-wiki}"
+TEST_DIR="${LLM_WIKI_TEST_DIR:-$HOME/llm-wiki-testing}"
+CONFIG="${LLM_WIKI_CONFIG:-$TEST_DIR/config.toml}"
+ACP_TIMEOUT="${ACP_TIMEOUT:-15}"
+ACP_HTTP_PORT="${ACP_HTTP_PORT:-18765}"
+SECTION_FILTER=""
+export ACP_TIMEOUT ACP_HTTP_PORT TEST_DIR CONFIG CLI
+
+# ACP uses stdio; MCP must be displaced to HTTP so both don't share the pipe.
+# --http :PORT forces MCP onto HTTP, leaving stdio exclusively for ACP.
+ACP_SERVER=("$CLI" --config "$CONFIG" serve --acp --http ":$ACP_HTTP_PORT")
+export ACP_SERVER
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --section) SECTION_FILTER="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+
+echo "llm-wiki validate-acp.sh"
+echo "binary:   $("$CLI" --version 2>/dev/null || echo unknown)"
+echo "test dir: $TEST_DIR"
+echo "timeout:  ${ACP_TIMEOUT}s per exchange"
+echo
+
+if ! command -v jq &>/dev/null; then
+    red "ERROR: 'jq' not found — required for ACP validation."
+    echo "Install with: brew install jq"
+    exit 1
+fi
+
+if [ ! -f "$CONFIG" ]; then
+    red "ERROR: config not found at $CONFIG"
+    echo "Run: source ./docs/testing/scripts/setup-test-env.sh"
+    exit 1
+fi
+
+# ── Counters ──────────────────────────────────────────────────────────────────
+
+PASS=0; FAIL=0; SKIP=0
+export PASS FAIL SKIP
+
+# ── Run sections ──────────────────────────────────────────────────────────────
+
+run_section() {
+    local num="$1" file="$2"
+    if [ -n "$SECTION_FILTER" ] && [ "$SECTION_FILTER" != "$num" ]; then
+        return
+    fi
+    # shellcheck disable=SC1090
+    source "$file"
+}
+
+run_section "01" "$_SCRIPT_DIR/acp/01-lifecycle.sh"
+run_section "02" "$_SCRIPT_DIR/acp/02-research.sh"
+run_section "03" "$_SCRIPT_DIR/acp/03-lint.sh"
+run_section "04" "$_SCRIPT_DIR/acp/04-graph.sh"
+run_section "05" "$_SCRIPT_DIR/acp/05-ingest.sh"
+run_section "06" "$_SCRIPT_DIR/acp/06-use.sh"
+run_section "07" "$_SCRIPT_DIR/acp/07-help.sh"
+run_section "08" "$_SCRIPT_DIR/acp/08-session-cap.sh"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo
+echo "────────────────────────────────────────"
+printf "Results: "
+printf '\033[32m%s\033[0m' "$PASS passed"
+printf " | "
+[ "$FAIL" -gt 0 ] && printf '\033[31m%s\033[0m' "$FAIL failed" || printf "%s failed" "$FAIL"
+printf " | "
+printf '\033[33m%s\033[0m' "$SKIP skipped"
+echo
+echo "────────────────────────────────────────"
+
+[ "$FAIL" -eq 0 ]

--- a/docs/testing/validate-acp.md
+++ b/docs/testing/validate-acp.md
@@ -1,0 +1,44 @@
+# ACP Manual Test Matrix
+
+Connect Zed to `llm-wiki serve --acp`. One session per block.
+
+## research
+| Prompt | Expected |
+|--------|----------|
+| `what is sparse routing?` | search tool call + read tool call + page body + slug list |
+| `llm-wiki:research scaling laws` | same via explicit prefix |
+| `llm-wiki:research zzz-no-match` | "No results found" message |
+
+## lint
+| Prompt | Expected |
+|--------|----------|
+| `llm-wiki:lint` | tool call + summary line + one line per finding |
+| `llm-wiki:lint orphan` | only orphan findings |
+| `llm-wiki:lint stale,broken-link` | stale + broken-link findings only |
+
+## graph
+| Prompt | Expected |
+|--------|----------|
+| `llm-wiki:graph` | tool call + "N nodes, M edges" + graph text |
+| `llm-wiki:graph concepts/moe` | subgraph from that root |
+| `llm-wiki:graph zzz-missing` | error message in tool call result |
+
+## ingest
+| Prompt | Expected |
+|--------|----------|
+| `llm-wiki:ingest` | tool call + summary (pages validated, commit) |
+| `llm-wiki:ingest wiki/concepts/test.md` | ingest specific file |
+| `llm-wiki:ingest /nonexistent` | tool call Failed + error text |
+
+## use
+| Prompt | Expected |
+|--------|----------|
+| `llm-wiki:use concepts/moe` | tool call Completed + full page markdown streamed |
+| `llm-wiki:use` | "Usage: llm-wiki:use <slug>" |
+| `llm-wiki:use zzz-missing` | tool call Failed + error text |
+
+## help / unknown
+| Prompt | Expected |
+|--------|----------|
+| `llm-wiki:help` | workflow listing |
+| `llm-wiki:bogus` | "Unknown workflow" + workflow listing |

--- a/docs/testing/validate-acp.md
+++ b/docs/testing/validate-acp.md
@@ -42,3 +42,31 @@ Connect Zed to `llm-wiki serve --acp`. One session per block.
 |--------|----------|
 | `llm-wiki:help` | workflow listing |
 | `llm-wiki:bogus` | "Unknown workflow" + workflow listing |
+
+## Cancellation (Phase 2)
+
+Start a workflow on a wiki with many pages, then cancel mid-run from the IDE.
+
+| Scenario | Steps | Expected |
+|----------|-------|----------|
+| Cancel lint mid-run | Send `llm-wiki:lint`, immediately cancel | `"Cancelled."` message, no further findings |
+| Cancel research mid-run | Send `llm-wiki:research <query>`, cancel after search | `"Cancelled."` after search tool result |
+| New prompt after cancel | Cancel then send a new prompt | New prompt executes normally (flag reset) |
+
+## Session cap (Phase 2)
+
+| Scenario | Steps | Expected |
+|----------|-------|----------|
+| Exceed `acp_max_sessions` | Open 21 sessions with default config | 21st `NewSession` returns `InvalidParams` error with "Session limit reached (max: 20)" |
+
+Config: `llm-wiki config set serve.acp_max_sessions 2 --global`, then open 3 sessions to test with a lower cap.
+
+## Watcher push (Phase 2)
+
+Requires `llm-wiki serve --acp --watch`.
+
+| Scenario | Steps | Expected |
+|----------|-------|----------|
+| File drop triggers push | Open session targeting wiki; drop `.md` file in `wiki/`; wait for debounce | Session receives `"Wiki "<name>" updated: 1 page(s) changed."` |
+| Active session not pushed | Open session with active run; drop file | No push during active run |
+| Session on different wiki not pushed | Two sessions on different wikis; drop file in wiki A | Only wiki A session receives push |

--- a/src/acp/graph.rs
+++ b/src/acp/graph.rs
@@ -1,10 +1,12 @@
+use std::sync::atomic::Ordering;
+
 use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
 use agent_client_protocol::{Client, ConnectionTo};
 
 use crate::engine::WikiEngine;
 use crate::ops::{self, GraphParams};
 
-use super::helpers::{clear_active_run, send_text, send_tool_call, send_tool_result};
+use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result};
 use super::{Sessions, StepResult, make_tool_id};
 
 pub fn step_graph(
@@ -78,6 +80,12 @@ pub fn run_graph(
     query: &str,
     wiki_name: &str,
 ) -> StepResult {
+    let cancelled = get_cancelled(sessions, &session_id.to_string());
+    if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+        send_text(cx, session_id, "Cancelled.")?;
+        clear_active_run(sessions, &session_id.to_string());
+        return Ok(());
+    }
     let root = (!query.is_empty()).then_some(query);
     step_graph(cx, manager, session_id, root, wiki_name)?;
     clear_active_run(sessions, &session_id.to_string());

--- a/src/acp/graph.rs
+++ b/src/acp/graph.rs
@@ -1,0 +1,70 @@
+use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
+use agent_client_protocol::{Client, ConnectionTo};
+
+use crate::engine::WikiEngine;
+use crate::ops::{self, GraphParams};
+
+use super::helpers::{clear_active_run, send_text, send_tool_call, send_tool_result};
+use super::{Sessions, StepResult, make_tool_id};
+
+pub fn step_graph(
+    cx: &ConnectionTo<Client>,
+    manager: &WikiEngine,
+    session_id: &SessionId,
+    root: Option<&str>,
+    wiki_name: &str,
+) -> StepResult {
+    let tool_id = make_tool_id("graph", "graph");
+    let label = root
+        .map(|r| format!("wiki_graph root={r}"))
+        .unwrap_or_else(|| "wiki_graph".to_string());
+
+    send_tool_call(cx, session_id, &tool_id, &label, ToolKind::Other)?;
+
+    let result = {
+        let engine = manager
+            .state
+            .read()
+            .map_err(|_| agent_client_protocol::schema::Error::internal_error())?;
+        ops::graph_build(
+            &engine,
+            wiki_name,
+            &GraphParams {
+                format: Some("llms"),
+                root: root.map(str::to_string),
+                depth: None,
+                type_filter: None,
+                relation: None,
+                output: None,
+                cross_wiki: false,
+            },
+        )
+    };
+
+    match result {
+        Ok(gr) => {
+            let summary = format!("Graph: {} nodes, {} edges", gr.report.nodes, gr.report.edges);
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, &summary)?;
+            send_text(cx, session_id, &gr.rendered)?;
+            Ok(())
+        }
+        Err(e) => {
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Failed, &format!("{e}"))?;
+            Ok(())
+        }
+    }
+}
+
+pub fn run_graph(
+    cx: &ConnectionTo<Client>,
+    manager: &WikiEngine,
+    sessions: &Sessions,
+    session_id: &SessionId,
+    query: &str,
+    wiki_name: &str,
+) -> StepResult {
+    let root = (!query.is_empty()).then_some(query);
+    step_graph(cx, manager, session_id, root, wiki_name)?;
+    clear_active_run(sessions, &session_id.to_string());
+    Ok(())
+}

--- a/src/acp/graph.rs
+++ b/src/acp/graph.rs
@@ -43,13 +43,28 @@ pub fn step_graph(
 
     match result {
         Ok(gr) => {
-            let summary = format!("Graph: {} nodes, {} edges", gr.report.nodes, gr.report.edges);
-            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, &summary)?;
+            let summary = format!(
+                "Graph: {} nodes, {} edges",
+                gr.report.nodes, gr.report.edges
+            );
+            send_tool_result(
+                cx,
+                session_id,
+                &tool_id,
+                ToolCallStatus::Completed,
+                &summary,
+            )?;
             send_text(cx, session_id, &gr.rendered)?;
             Ok(())
         }
         Err(e) => {
-            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Failed, &format!("{e}"))?;
+            send_tool_result(
+                cx,
+                session_id,
+                &tool_id,
+                ToolCallStatus::Failed,
+                &format!("{e}"),
+            )?;
             Ok(())
         }
     }

--- a/src/acp/graph.rs
+++ b/src/acp/graph.rs
@@ -6,7 +6,9 @@ use agent_client_protocol::{Client, ConnectionTo};
 use crate::engine::WikiEngine;
 use crate::ops::{self, GraphParams};
 
-use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result};
+use super::helpers::{
+    clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result,
+};
 use super::{Sessions, StepResult, make_tool_id};
 
 pub fn step_graph(
@@ -81,7 +83,11 @@ pub fn run_graph(
     wiki_name: &str,
 ) -> StepResult {
     let cancelled = get_cancelled(sessions, &session_id.to_string());
-    if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+    if cancelled
+        .as_ref()
+        .map(|c| c.load(Ordering::Relaxed))
+        .unwrap_or(false)
+    {
         send_text(cx, session_id, "Cancelled.")?;
         clear_active_run(sessions, &session_id.to_string());
         return Ok(());

--- a/src/acp/helpers.rs
+++ b/src/acp/helpers.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use agent_client_protocol::Client;
 use agent_client_protocol::ConnectionTo;
@@ -85,6 +87,17 @@ pub fn session_cwd(manager: &WikiEngine) -> PathBuf {
         .space(name)
         .map(|s| s.repo_root.clone())
         .unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Load the cancellation flag for a session. Returns None if session not found.
+pub fn get_cancelled(sessions: &Sessions, session_id: &str) -> Option<Arc<AtomicBool>> {
+    sessions
+        .lock()
+        .ok()?
+        .get(session_id)?
+        .cancelled
+        .clone()
+        .into()
 }
 
 pub fn clear_active_run(sessions: &Sessions, session_id: &str) {

--- a/src/acp/helpers.rs
+++ b/src/acp/helpers.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use agent_client_protocol::Client;
 use agent_client_protocol::ConnectionTo;

--- a/src/acp/ingest.rs
+++ b/src/acp/ingest.rs
@@ -44,11 +44,23 @@ pub fn step_ingest(
                 report.unchanged_count,
                 report.warnings.len(),
             );
-            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, &summary)?;
+            send_tool_result(
+                cx,
+                session_id,
+                &tool_id,
+                ToolCallStatus::Completed,
+                &summary,
+            )?;
             Ok(())
         }
         Err(e) => {
-            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Failed, &format!("{e}"))?;
+            send_tool_result(
+                cx,
+                session_id,
+                &tool_id,
+                ToolCallStatus::Failed,
+                &format!("{e}"),
+            )?;
             Ok(())
         }
     }

--- a/src/acp/ingest.rs
+++ b/src/acp/ingest.rs
@@ -6,7 +6,9 @@ use agent_client_protocol::{Client, ConnectionTo};
 use crate::engine::WikiEngine;
 use crate::ops;
 
-use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result, session_cwd};
+use super::helpers::{
+    clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result, session_cwd,
+};
 use super::{Sessions, StepResult, make_tool_id};
 
 pub fn step_ingest(
@@ -77,7 +79,11 @@ pub fn run_ingest(
     wiki_name: &str,
 ) -> StepResult {
     let cancelled = get_cancelled(sessions, &session_id.to_string());
-    if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+    if cancelled
+        .as_ref()
+        .map(|c| c.load(Ordering::Relaxed))
+        .unwrap_or(false)
+    {
         send_text(cx, session_id, "Cancelled.")?;
         clear_active_run(sessions, &session_id.to_string());
         return Ok(());

--- a/src/acp/ingest.rs
+++ b/src/acp/ingest.rs
@@ -1,0 +1,73 @@
+use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
+use agent_client_protocol::{Client, ConnectionTo};
+
+use crate::engine::WikiEngine;
+use crate::ops;
+
+use super::helpers::{clear_active_run, send_tool_call, send_tool_result, session_cwd};
+use super::{Sessions, StepResult, make_tool_id};
+
+pub fn step_ingest(
+    cx: &ConnectionTo<Client>,
+    manager: &WikiEngine,
+    session_id: &SessionId,
+    path: &str,
+    wiki_name: &str,
+) -> StepResult {
+    let tool_id = make_tool_id("ingest", "ingest");
+    send_tool_call(
+        cx,
+        session_id,
+        &tool_id,
+        &format!("wiki_ingest: {path}"),
+        ToolKind::Other,
+    )?;
+
+    let result = {
+        let engine = manager
+            .state
+            .read()
+            .map_err(|_| agent_client_protocol::schema::Error::internal_error())?;
+        ops::ingest(&engine, manager, path, false, wiki_name)
+    };
+
+    match result {
+        Ok(report) => {
+            let commit_info = if report.commit.is_empty() {
+                "no commit".to_string()
+            } else {
+                format!("commit {}", &report.commit[..8.min(report.commit.len())])
+            };
+            let summary = format!(
+                "{} pages validated, {} unchanged, {} warnings — {commit_info}",
+                report.pages_validated,
+                report.unchanged_count,
+                report.warnings.len(),
+            );
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, &summary)?;
+            Ok(())
+        }
+        Err(e) => {
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Failed, &format!("{e}"))?;
+            Ok(())
+        }
+    }
+}
+
+pub fn run_ingest(
+    cx: &ConnectionTo<Client>,
+    manager: &WikiEngine,
+    sessions: &Sessions,
+    session_id: &SessionId,
+    query: &str,
+    wiki_name: &str,
+) -> StepResult {
+    let path = if query.is_empty() {
+        session_cwd(manager).to_string_lossy().into_owned()
+    } else {
+        query.to_string()
+    };
+    step_ingest(cx, manager, session_id, &path, wiki_name)?;
+    clear_active_run(sessions, &session_id.to_string());
+    Ok(())
+}

--- a/src/acp/ingest.rs
+++ b/src/acp/ingest.rs
@@ -1,10 +1,12 @@
+use std::sync::atomic::Ordering;
+
 use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
 use agent_client_protocol::{Client, ConnectionTo};
 
 use crate::engine::WikiEngine;
 use crate::ops;
 
-use super::helpers::{clear_active_run, send_tool_call, send_tool_result, session_cwd};
+use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result, session_cwd};
 use super::{Sessions, StepResult, make_tool_id};
 
 pub fn step_ingest(
@@ -74,6 +76,12 @@ pub fn run_ingest(
     query: &str,
     wiki_name: &str,
 ) -> StepResult {
+    let cancelled = get_cancelled(sessions, &session_id.to_string());
+    if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+        send_text(cx, session_id, "Cancelled.")?;
+        clear_active_run(sessions, &session_id.to_string());
+        return Ok(());
+    }
     let path = if query.is_empty() {
         session_cwd(manager).to_string_lossy().into_owned()
     } else {

--- a/src/acp/lint.rs
+++ b/src/acp/lint.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
 use agent_client_protocol::{Client, ConnectionTo};
@@ -7,7 +7,9 @@ use agent_client_protocol::{Client, ConnectionTo};
 use crate::engine::WikiEngine;
 use crate::ops;
 
-use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result};
+use super::helpers::{
+    clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result,
+};
 use super::{Sessions, StepResult, make_tool_id};
 
 pub fn step_lint(
@@ -48,7 +50,11 @@ pub fn step_lint(
                 &summary,
             )?;
             for f in &report.findings {
-                if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+                if cancelled
+                    .as_ref()
+                    .map(|c| c.load(Ordering::Relaxed))
+                    .unwrap_or(false)
+                {
                     send_text(cx, session_id, "Cancelled.")?;
                     return Ok(());
                 }

--- a/src/acp/lint.rs
+++ b/src/acp/lint.rs
@@ -36,7 +36,13 @@ pub fn step_lint(
                 "{} findings ({} errors, {} warnings)",
                 report.total, report.errors, report.warnings
             );
-            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, &summary)?;
+            send_tool_result(
+                cx,
+                session_id,
+                &tool_id,
+                ToolCallStatus::Completed,
+                &summary,
+            )?;
             for f in &report.findings {
                 send_text(
                     cx,
@@ -47,7 +53,13 @@ pub fn step_lint(
             Ok(())
         }
         Err(e) => {
-            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Failed, &format!("{e}"))?;
+            send_tool_result(
+                cx,
+                session_id,
+                &tool_id,
+                ToolCallStatus::Failed,
+                &format!("{e}"),
+            )?;
             Ok(())
         }
     }

--- a/src/acp/lint.rs
+++ b/src/acp/lint.rs
@@ -1,0 +1,68 @@
+use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
+use agent_client_protocol::{Client, ConnectionTo};
+
+use crate::engine::WikiEngine;
+use crate::ops;
+
+use super::helpers::{clear_active_run, send_text, send_tool_call, send_tool_result};
+use super::{Sessions, StepResult, make_tool_id};
+
+pub fn step_lint(
+    cx: &ConnectionTo<Client>,
+    manager: &WikiEngine,
+    session_id: &SessionId,
+    wiki_name: &str,
+    rules: Option<&str>,
+) -> StepResult {
+    let tool_id = make_tool_id("lint", "lint");
+    let label = rules
+        .filter(|r| !r.is_empty())
+        .map(|r| format!("wiki_lint rules={r}"))
+        .unwrap_or_else(|| "wiki_lint".to_string());
+
+    send_tool_call(cx, session_id, &tool_id, &label, ToolKind::Other)?;
+
+    let result = {
+        let engine = manager
+            .state
+            .read()
+            .map_err(|_| agent_client_protocol::schema::Error::internal_error())?;
+        ops::run_lint(&engine, wiki_name, rules, None)
+    };
+
+    match result {
+        Ok(report) => {
+            let summary = format!(
+                "{} findings ({} errors, {} warnings)",
+                report.total, report.errors, report.warnings
+            );
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, &summary)?;
+            for f in &report.findings {
+                send_text(
+                    cx,
+                    session_id,
+                    &format!("[{}] {}: {}", f.severity, f.slug, f.message),
+                )?;
+            }
+            Ok(())
+        }
+        Err(e) => {
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Failed, &format!("{e}"))?;
+            Ok(())
+        }
+    }
+}
+
+pub fn run_lint(
+    cx: &ConnectionTo<Client>,
+    manager: &WikiEngine,
+    sessions: &Sessions,
+    session_id: &SessionId,
+    query: &str,
+    wiki_name: &str,
+) -> StepResult {
+    let rules = (!query.is_empty()).then_some(query);
+    step_lint(cx, manager, session_id, wiki_name, rules)?;
+    clear_active_run(sessions, &session_id.to_string());
+    Ok(())
+}

--- a/src/acp/lint.rs
+++ b/src/acp/lint.rs
@@ -1,10 +1,13 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
 use agent_client_protocol::{Client, ConnectionTo};
 
 use crate::engine::WikiEngine;
 use crate::ops;
 
-use super::helpers::{clear_active_run, send_text, send_tool_call, send_tool_result};
+use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result};
 use super::{Sessions, StepResult, make_tool_id};
 
 pub fn step_lint(
@@ -13,6 +16,7 @@ pub fn step_lint(
     session_id: &SessionId,
     wiki_name: &str,
     rules: Option<&str>,
+    cancelled: Option<Arc<AtomicBool>>,
 ) -> StepResult {
     let tool_id = make_tool_id("lint", "lint");
     let label = rules
@@ -44,6 +48,10 @@ pub fn step_lint(
                 &summary,
             )?;
             for f in &report.findings {
+                if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+                    send_text(cx, session_id, "Cancelled.")?;
+                    return Ok(());
+                }
                 send_text(
                     cx,
                     session_id,
@@ -73,8 +81,9 @@ pub fn run_lint(
     query: &str,
     wiki_name: &str,
 ) -> StepResult {
+    let cancelled = get_cancelled(sessions, &session_id.to_string());
     let rules = (!query.is_empty()).then_some(query);
-    step_lint(cx, manager, session_id, wiki_name, rules)?;
+    step_lint(cx, manager, session_id, wiki_name, rules, cancelled)?;
     clear_active_run(sessions, &session_id.to_string());
     Ok(())
 }

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -6,7 +6,7 @@ mod research;
 mod server;
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::{ContentBlock, PromptRequest};

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -31,6 +31,7 @@ pub struct AcpSession {
     pub cancelled: Arc<AtomicBool>,
 }
 
+/// Shared map of active ACP sessions, keyed by session ID.
 pub type Sessions = Arc<Mutex<HashMap<String, AcpSession>>>;
 
 // ── Dispatch ──────────────────────────────────────────────────────────────────

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,3 +1,4 @@
+mod graph;
 mod helpers;
 mod lint;
 mod research;

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -6,6 +6,7 @@ mod research;
 mod server;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::{ContentBlock, PromptRequest};
@@ -26,6 +27,8 @@ pub struct AcpSession {
     pub created_at: u64,
     /// ID of the currently executing tool run, if any.
     pub active_run: Option<String>,
+    /// Cooperative cancellation flag. Set by cancel handler; polled by workflow steps.
+    pub cancelled: Arc<AtomicBool>,
 }
 
 type Sessions = Arc<Mutex<HashMap<String, AcpSession>>>;

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,5 +1,6 @@
 mod graph;
 mod helpers;
+mod ingest;
 mod lint;
 mod research;
 mod server;

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -31,7 +31,7 @@ pub struct AcpSession {
     pub cancelled: Arc<AtomicBool>,
 }
 
-type Sessions = Arc<Mutex<HashMap<String, AcpSession>>>;
+pub type Sessions = Arc<Mutex<HashMap<String, AcpSession>>>;
 
 // ── Dispatch ──────────────────────────────────────────────────────────────────
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -1,4 +1,5 @@
 mod helpers;
+mod lint;
 mod research;
 mod server;
 

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -54,6 +54,9 @@ fn extract_prompt_text(req: &PromptRequest) -> String {
         .join(" ")
 }
 
+/// Convenience alias for ACP step return values.
+pub type StepResult<T = ()> = std::result::Result<T, agent_client_protocol::schema::Error>;
+
 /// Generate a unique tool-run ID from workflow name, step name, and current timestamp.
 pub fn make_tool_id(workflow: &str, step: &str) -> String {
     format!(

--- a/src/acp/research.rs
+++ b/src/acp/research.rs
@@ -77,6 +77,7 @@ pub fn step_read(
     workflow: &str,
     slug: &str,
     wiki_name: &str,
+    stream_content: bool,
 ) -> std::result::Result<(), agent_client_protocol::schema::Error> {
     let tool_id = make_tool_id(workflow, "read");
     send_tool_call(
@@ -96,6 +97,13 @@ pub fn step_read(
     };
 
     match result {
+        Ok(crate::ops::ContentReadResult::Page(body)) => {
+            send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, "")?;
+            if stream_content {
+                send_text(cx, session_id, &body)?;
+            }
+            Ok(())
+        }
         Ok(_) => send_tool_result(cx, session_id, &tool_id, ToolCallStatus::Completed, ""),
         Err(e) => send_tool_result(
             cx,
@@ -160,6 +168,7 @@ pub fn run_research(
             "research",
             &results[0].slug,
             wiki_name,
+            false,
         )?;
         step_report_results(cx, session_id, &results, wiki_name)?;
     }

--- a/src/acp/research.rs
+++ b/src/acp/research.rs
@@ -6,7 +6,9 @@ use agent_client_protocol::{Client, ConnectionTo};
 use crate::engine::WikiEngine;
 use crate::ops;
 
-use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result};
+use super::helpers::{
+    clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result,
+};
 use super::{Sessions, make_tool_id};
 
 // ── Reusable workflow steps ───────────────────────────────────────────────────
@@ -158,7 +160,11 @@ pub fn run_research(
 
     let results = step_search(cx, manager, session_id, "research", query, wiki_name, 5)?;
 
-    if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+    if cancelled
+        .as_ref()
+        .map(|c| c.load(Ordering::Relaxed))
+        .unwrap_or(false)
+    {
         send_text(cx, session_id, "Cancelled.")?;
         clear_active_run(sessions, &session_id.to_string());
         return Ok(());

--- a/src/acp/research.rs
+++ b/src/acp/research.rs
@@ -1,10 +1,12 @@
+use std::sync::atomic::Ordering;
+
 use agent_client_protocol::schema::{SessionId, ToolCallStatus, ToolKind};
 use agent_client_protocol::{Client, ConnectionTo};
 
 use crate::engine::WikiEngine;
 use crate::ops;
 
-use super::helpers::{clear_active_run, send_text, send_tool_call, send_tool_result};
+use super::helpers::{clear_active_run, get_cancelled, send_text, send_tool_call, send_tool_result};
 use super::{Sessions, make_tool_id};
 
 // ── Reusable workflow steps ───────────────────────────────────────────────────
@@ -150,9 +152,17 @@ pub fn run_research(
     query: &str,
     wiki_name: &str,
 ) -> std::result::Result<(), agent_client_protocol::schema::Error> {
+    let cancelled = get_cancelled(sessions, &session_id.to_string());
+
     send_text(cx, session_id, &format!("Searching for: {query}..."))?;
 
     let results = step_search(cx, manager, session_id, "research", query, wiki_name, 5)?;
+
+    if cancelled.as_ref().map(|c| c.load(Ordering::Relaxed)).unwrap_or(false) {
+        send_text(cx, session_id, "Cancelled.")?;
+        clear_active_run(sessions, &session_id.to_string());
+        return Ok(());
+    }
 
     if results.is_empty() {
         send_text(

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::{
     AgentCapabilities, CancelNotification, InitializeRequest, InitializeResponse,
@@ -29,7 +29,32 @@ pub async fn serve_acp(
     manager: Arc<WikiEngine>,
     config: crate::config::ServeConfig,
     sessions: Sessions,
+    mut push_rx: tokio::sync::mpsc::Receiver<(String, String)>,
 ) -> Result<()> {
+    let shared_cx: Arc<Mutex<Option<ConnectionTo<Client>>>> = Arc::new(Mutex::new(None));
+
+    // Push task: receive watcher events and forward to idle sessions
+    {
+        let sessions = sessions.clone();
+        let shared_cx = shared_cx.clone();
+        tokio::spawn(async move {
+            while let Some((wiki_name, msg)) = push_rx.recv().await {
+                let cx_opt = shared_cx.lock().ok().and_then(|g| g.clone());
+                if let Some(cx) = cx_opt {
+                    if let Ok(s) = sessions.lock() {
+                        for (id, sess) in s.iter() {
+                            if sess.wiki.as_deref() == Some(&wiki_name)
+                                && sess.active_run.is_none()
+                            {
+                                let sid = SessionId::new(id.clone());
+                                let _ = send_text(&cx, &sid, &msg);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
 
     Agent
         .builder()
@@ -157,7 +182,11 @@ pub async fn serve_acp(
             {
                 let mgr = manager.clone();
                 let sessions = sessions.clone();
+                let shared_cx = shared_cx.clone();
                 async move |req: PromptRequest, responder, cx: ConnectionTo<Client>| {
+                    if let Ok(mut g) = shared_cx.lock() {
+                        *g = Some(cx.clone());
+                    }
                     let text = extract_prompt_text(&req);
                     let (workflow, query) = dispatch_workflow(&text);
                     let session_id_str = req.session_id.to_string();

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -43,8 +43,7 @@ pub async fn serve_acp(
                 if let Some(cx) = cx_opt {
                     if let Ok(s) = sessions.lock() {
                         for (id, sess) in s.iter() {
-                            if sess.wiki.as_deref() == Some(&wiki_name)
-                                && sess.active_run.is_none()
+                            if sess.wiki.as_deref() == Some(&wiki_name) && sess.active_run.is_none()
                             {
                                 let sid = SessionId::new(id.clone());
                                 let _ = send_text(&cx, &sid, &msg);

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -17,6 +17,9 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use crate::engine::WikiEngine;
 
 use super::helpers::{clear_active_run, resolve_wiki_name, send_text, session_cwd};
+use super::graph::run_graph;
+use super::ingest::run_ingest;
+use super::lint::run_lint;
 use super::research::run_research;
 use super::{AcpSession, Sessions, dispatch_workflow, extract_prompt_text};
 
@@ -155,27 +158,53 @@ pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
 
                     match workflow {
                         "research" => {
-                            run_research(
-                                &cx,
-                                &mgr,
-                                &sessions,
-                                &req.session_id,
-                                query_text,
-                                &wiki_name,
-                            )?;
+                            run_research(&cx, &mgr, &sessions, &req.session_id, query_text, &wiki_name)?;
                         }
-                        other => {
-                            send_text(
-                                &cx,
-                                &req.session_id,
-                                &format!(
-                                    "Unknown workflow \"{other}\". Use `llm-wiki:research <query>` or ask a question directly."
-                                ),
-                            )?;
+                        "lint" => {
+                            run_lint(&cx, &mgr, &sessions, &req.session_id, query_text, &wiki_name)?;
+                        }
+                        "graph" => {
+                            run_graph(&cx, &mgr, &sessions, &req.session_id, query_text, &wiki_name)?;
+                        }
+                        "ingest" => {
+                            run_ingest(&cx, &mgr, &sessions, &req.session_id, query_text, &wiki_name)?;
+                        }
+                        "use" => {
+                            use super::research::step_read;
+                            if query_text.is_empty() {
+                                send_text(&cx, &req.session_id, "Usage: `llm-wiki:use <slug>`")?;
+                            } else {
+                                step_read(&cx, &mgr, &req.session_id, "use", query_text, &wiki_name, true)?;
+                            }
+                            clear_active_run(&sessions, &session_id_str);
+                        }
+                        "help" | _ => {
+                            let msg = if workflow != "help" {
+                                format!(
+                                    "Unknown workflow \"{workflow}\". Available workflows:\n\
+                                     • `llm-wiki:research <query>` — search + read top result\n\
+                                     • `llm-wiki:lint [rules]`      — run lint rules (comma-separated or all)\n\
+                                     • `llm-wiki:graph [root-slug]` — render concept graph\n\
+                                     • `llm-wiki:ingest [path]`     — ingest path (default: cwd)\n\
+                                     • `llm-wiki:use <slug>`        — read full page content\n\
+                                     • `llm-wiki:help`              — this message\n\
+                                     • (bare prompt)                — research workflow"
+                                )
+                            } else {
+                                "Available workflows:\n\
+                                 • `llm-wiki:research <query>` — search + read top result\n\
+                                 • `llm-wiki:lint [rules]`      — run lint rules (comma-separated or all)\n\
+                                 • `llm-wiki:graph [root-slug]` — render concept graph\n\
+                                 • `llm-wiki:ingest [path]`     — ingest path (default: cwd)\n\
+                                 • `llm-wiki:use <slug>`        — read full page content\n\
+                                 • `llm-wiki:help`              — this message\n\
+                                 • (bare prompt)                — research workflow"
+                                    .to_string()
+                            };
+                            send_text(&cx, &req.session_id, &msg)?;
+                            clear_active_run(&sessions, &session_id_str);
                         }
                     }
-
-                    clear_active_run(&sessions, &session_id_str);
                     tracing::debug!(session = %session_id_str, workflow = %workflow, "prompt complete");
                     responder.respond(PromptResponse::new(StopReason::EndTurn))
                 }

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -25,8 +25,11 @@ use super::research::run_research;
 use super::{AcpSession, Sessions, dispatch_workflow, extract_prompt_text};
 
 /// Start the ACP (Agent Client Protocol) server on stdio.
-pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
-    let sessions: Sessions = Arc::new(std::sync::Mutex::new(HashMap::new()));
+pub async fn serve_acp(
+    manager: Arc<WikiEngine>,
+    config: crate::config::ServeConfig,
+    sessions: Sessions,
+) -> Result<()> {
 
     Agent
         .builder()
@@ -56,7 +59,19 @@ pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
         .on_receive_request(
             {
                 let sessions = sessions.clone();
+                let config = config.clone();
                 async move |req: NewSessionRequest, responder, _cx| {
+                    {
+                        let sessions = sessions.lock().unwrap();
+                        if sessions.len() >= config.acp_max_sessions {
+                            return responder.respond_with_error(
+                                agent_client_protocol::schema::Error::new(
+                                    i32::from(agent_client_protocol::schema::ErrorCode::InvalidParams),
+                                    format!("Session limit reached (max: {})", config.acp_max_sessions),
+                                ),
+                            );
+                        }
+                    }
                     let id = format!("session-{}", chrono::Utc::now().timestamp_millis());
                     let _span =
                         tracing::info_span!("acp_new_session", session = %id).entered();

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -235,10 +235,10 @@ pub async fn serve_acp(
                         }
                         "use" => {
                             use super::research::step_read;
-                            if query_text.is_empty() {
+                            if query.is_empty() {
                                 send_text(&cx, &req.session_id, "Usage: `llm-wiki:use <slug>`")?;
                             } else {
-                                step_read(&cx, &mgr, &req.session_id, "use", query_text, &wiki_name, true)?;
+                                step_read(&cx, &mgr, &req.session_id, "use", query, &wiki_name, true)?;
                             }
                             clear_active_run(&sessions, &session_id_str);
                         }

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -148,6 +148,13 @@ pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
 
                     let wiki_name = resolve_wiki_name(&mgr, &sessions, &req.session_id);
 
+                    // Reset cancellation flag for new prompt
+                    if let Ok(mut s) = sessions.lock()
+                        && let Some(sess) = s.get_mut(&session_id_str)
+                    {
+                        sess.cancelled.store(false, Ordering::Relaxed);
+                    }
+
                     // Mark active run
                     if let Ok(mut s) = sessions.lock()
                         && let Some(sess) = s.get_mut(&session_id_str)
@@ -218,7 +225,13 @@ pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
             {
                 let sessions = sessions.clone();
                 async move |notif: CancelNotification, _cx| {
-                    clear_active_run(&sessions, &notif.session_id.to_string());
+                    let id = notif.session_id.to_string();
+                    if let Ok(sessions) = sessions.lock() {
+                        if let Some(sess) = sessions.get(&id) {
+                            sess.cancelled.store(true, Ordering::Relaxed);
+                        }
+                    }
+                    clear_active_run(&sessions, &id);
                     Ok(())
                 }
             },

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -16,8 +16,8 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::engine::WikiEngine;
 
-use super::helpers::{clear_active_run, resolve_wiki_name, send_text, session_cwd};
 use super::graph::run_graph;
+use super::helpers::{clear_active_run, resolve_wiki_name, send_text, session_cwd};
 use super::ingest::run_ingest;
 use super::lint::run_lint;
 use super::research::run_research;

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -31,23 +31,31 @@ pub async fn serve_acp(
     sessions: Sessions,
     mut push_rx: tokio::sync::mpsc::Receiver<(String, String)>,
 ) -> Result<()> {
-    let shared_cx: Arc<Mutex<Option<ConnectionTo<Client>>>> = Arc::new(Mutex::new(None));
+    let (cx_tx, cx_rx) = tokio::sync::watch::channel::<Option<ConnectionTo<Client>>>(None);
+    let cx_tx = Arc::new(cx_tx);
 
-    // Push task: receive watcher events and forward to idle sessions
+    // Push task: block until a cx is available, then forward watcher events to idle sessions
     {
         let sessions = sessions.clone();
-        let shared_cx = shared_cx.clone();
         tokio::spawn(async move {
+            // Wait for the first Prompt to establish the connection handle
+            let mut cx_rx = cx_rx;
+            let cx = loop {
+                if cx_rx.changed().await.is_err() {
+                    return; // channel closed, server shutting down
+                }
+                if let Some(cx) = cx_rx.borrow().clone() {
+                    break cx;
+                }
+            };
             while let Some((wiki_name, msg)) = push_rx.recv().await {
-                let cx_opt = shared_cx.lock().ok().and_then(|g| g.clone());
-                if let Some(cx) = cx_opt {
-                    if let Ok(s) = sessions.lock() {
-                        for (id, sess) in s.iter() {
-                            if sess.wiki.as_deref() == Some(&wiki_name) && sess.active_run.is_none()
-                            {
-                                let sid = SessionId::new(id.clone());
-                                let _ = send_text(&cx, &sid, &msg);
-                            }
+                // Refresh cx in case it was updated
+                let cx = cx_rx.borrow().clone().unwrap_or_else(|| cx.clone());
+                if let Ok(s) = sessions.lock() {
+                    for (id, sess) in s.iter() {
+                        if sess.wiki.as_deref() == Some(&wiki_name) && sess.active_run.is_none() {
+                            let sid = SessionId::new(id.clone());
+                            let _ = send_text(&cx, &sid, &msg);
                         }
                     }
                 }
@@ -181,11 +189,9 @@ pub async fn serve_acp(
             {
                 let mgr = manager.clone();
                 let sessions = sessions.clone();
-                let shared_cx = shared_cx.clone();
+                let cx_tx = cx_tx.clone();
                 async move |req: PromptRequest, responder, cx: ConnectionTo<Client>| {
-                    if let Ok(mut g) = shared_cx.lock() {
-                        *g = Some(cx.clone());
-                    }
+                    let _ = cx_tx.send(Some(cx.clone()));
                     let text = extract_prompt_text(&req);
                     let (workflow, query) = dispatch_workflow(&text);
                     let session_id_str = req.session_id.to_string();

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -178,7 +178,7 @@ pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
                             }
                             clear_active_run(&sessions, &session_id_str);
                         }
-                        "help" | _ => {
+                        _ => {
                             let msg = if workflow != "help" {
                                 format!(
                                     "Unknown workflow \"{workflow}\". Available workflows:\n\

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use agent_client_protocol::schema::{
     AgentCapabilities, CancelNotification, InitializeRequest, InitializeResponse,

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use agent_client_protocol::schema::{
@@ -71,6 +72,7 @@ pub async fn serve_acp(manager: Arc<WikiEngine>) -> Result<()> {
                         wiki,
                         created_at: chrono::Utc::now().timestamp() as u64,
                         active_run: None,
+                        cancelled: Arc::new(AtomicBool::new(false)),
                     };
                     sessions.lock().unwrap().insert(id.clone(), session);
                     tracing::info!(session = %id, "session created");

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use agent_client_protocol::schema::{
     AgentCapabilities, CancelNotification, InitializeRequest, InitializeResponse,
@@ -282,10 +281,10 @@ pub async fn serve_acp(
                 let sessions = sessions.clone();
                 async move |notif: CancelNotification, _cx| {
                     let id = notif.session_id.to_string();
-                    if let Ok(sessions) = sessions.lock() {
-                        if let Some(sess) = sessions.get(&id) {
-                            sess.cancelled.store(true, Ordering::Relaxed);
-                        }
+                    if let Ok(sessions) = sessions.lock()
+                        && let Some(sess) = sessions.get(&id)
+                    {
+                        sess.cancelled.store(true, Ordering::Relaxed);
                     }
                     clear_active_run(&sessions, &id);
                     Ok(())

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -135,7 +135,14 @@ pub async fn serve_acp(
                                         SessionId::new(sess.id.clone()),
                                         cwd.clone(),
                                     )
-                                    .title(sess.label.clone())
+                                    .title(if sess.active_run.is_some() {
+                                        Some(format!(
+                                            "[active] {}",
+                                            sess.label.clone().unwrap_or_default()
+                                        ))
+                                    } else {
+                                        sess.label.clone()
+                                    })
                                 })
                                 .collect()
                         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,6 +148,10 @@ fn default_community_suggestions_limit() -> usize {
     2
 }
 
+fn default_acp_max_sessions() -> usize {
+    20
+}
+
 /// `[serve]` section — HTTP and ACP server configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServeConfig {
@@ -172,6 +176,9 @@ pub struct ServeConfig {
     /// Interval in seconds between ACP heartbeat pings (default: 60).
     #[serde(default = "default_heartbeat_secs")]
     pub heartbeat_secs: u32,
+    /// Maximum number of concurrent ACP sessions (default: 20). Rejects NewSession when reached.
+    #[serde(default = "default_acp_max_sessions")]
+    pub acp_max_sessions: usize,
 }
 
 impl Default for ServeConfig {
@@ -184,6 +191,7 @@ impl Default for ServeConfig {
             max_restarts: 10,
             restart_backoff: 1,
             heartbeat_secs: 60,
+            acp_max_sessions: default_acp_max_sessions(),
         }
     }
 }
@@ -714,6 +722,7 @@ pub fn set_global_config_value(global: &mut GlobalConfig, key: &str, value: &str
         "serve.max_restarts" => global.serve.max_restarts = value.parse()?,
         "serve.restart_backoff" => global.serve.restart_backoff = value.parse()?,
         "serve.heartbeat_secs" => global.serve.heartbeat_secs = value.parse()?,
+        "serve.acp_max_sessions" => global.serve.acp_max_sessions = value.parse()?,
         "ingest.auto_commit" => global.ingest.auto_commit = value.parse()?,
         "history.follow" => global.history.follow = value.parse()?,
         "history.default_limit" => global.history.default_limit = value.parse()?,
@@ -756,6 +765,7 @@ pub fn get_config_value(resolved: &ResolvedConfig, global: &GlobalConfig, key: &
         "serve.max_restarts" => global.serve.max_restarts.to_string(),
         "serve.restart_backoff" => global.serve.restart_backoff.to_string(),
         "serve.heartbeat_secs" => global.serve.heartbeat_secs.to_string(),
+        "serve.acp_max_sessions" => global.serve.acp_max_sessions.to_string(),
         "validation.type_strictness" => resolved.validation.type_strictness.clone(),
         "logging.log_path" => global.logging.log_path.clone(),
         "logging.log_rotation" => global.logging.log_rotation.clone(),
@@ -888,6 +898,7 @@ pub fn set_wiki_config_value(wiki_cfg: &mut WikiConfig, key: &str, value: &str) 
         | "serve.max_restarts"
         | "serve.restart_backoff"
         | "serve.heartbeat_secs"
+        | "serve.acp_max_sessions"
         | "logging.log_path"
         | "logging.log_rotation"
         | "logging.log_max_files"

--- a/src/main.rs
+++ b/src/main.rs
@@ -727,7 +727,8 @@ fn main() -> Result<()> {
                     tokio::signal::ctrl_c().await.ok();
                     cancel_for_signal.cancel();
                 });
-                llm_wiki::watch::run_watcher(manager, debounce, cancel).await
+                let (push_tx, _push_rx) = tokio::sync::mpsc::channel(1);
+                llm_wiki::watch::run_watcher(manager, debounce, cancel, push_tx).await
             })?;
             let _ = wiki; // reserved for future single-wiki watch
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -166,6 +166,10 @@ pub async fn serve(
     }
 
     // 6. Start watcher (if enabled)
+    // Push channel: watcher sends (wiki_name, message) to ACP sessions.
+    // The original sender is dropped after spawning the watcher; only the watcher clone remains.
+    let (push_tx, push_rx) = tokio::sync::mpsc::channel::<(String, String)>(64);
+
     let watch_handle = if watch {
         let watch_manager = manager.clone();
         let cancel_watch = cancel.clone();
@@ -173,12 +177,14 @@ pub async fn serve(
             let engine = manager.state.read().map_err(|_| anyhow::anyhow!("lock"))?;
             engine.config.watch.debounce_ms
         };
+        let push_tx_watch = push_tx;
         Some(tokio::spawn(async move {
-            if let Err(e) = crate::watch::run_watcher(watch_manager, debounce, cancel_watch).await {
+            if let Err(e) = crate::watch::run_watcher(watch_manager, debounce, cancel_watch, push_tx_watch).await {
                 tracing::error!(error = %e, "watcher error");
             }
         }))
     } else {
+        drop(push_tx);
         None
     };
 
@@ -192,7 +198,7 @@ pub async fn serve(
 
         let acp_handle = tokio::spawn(async move {
             tokio::select! {
-                result = crate::acp::serve_acp(acp_manager, acp_serve_cfg, acp_sessions) => {
+                result = crate::acp::serve_acp(acp_manager, acp_serve_cfg, acp_sessions, push_rx) => {
                     if let Err(e) = result {
                         tracing::error!(transport = "acp", error = %e, "ACP transport error");
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use rmcp::ServiceExt;
@@ -185,10 +186,13 @@ pub async fn serve(
     if acp {
         let acp_manager = manager.clone();
         let cancel_acp = cancel.clone();
+        let acp_sessions: crate::acp::Sessions =
+            Arc::new(Mutex::new(HashMap::new()));
+        let acp_serve_cfg = serve_cfg.clone();
 
         let acp_handle = tokio::spawn(async move {
             tokio::select! {
-                result = crate::acp::serve_acp(acp_manager) => {
+                result = crate::acp::serve_acp(acp_manager, acp_serve_cfg, acp_sessions) => {
                     if let Err(e) = result {
                         tracing::error!(transport = "acp", error = %e, "ACP transport error");
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -179,7 +179,10 @@ pub async fn serve(
         };
         let push_tx_watch = push_tx;
         Some(tokio::spawn(async move {
-            if let Err(e) = crate::watch::run_watcher(watch_manager, debounce, cancel_watch, push_tx_watch).await {
+            if let Err(e) =
+                crate::watch::run_watcher(watch_manager, debounce, cancel_watch, push_tx_watch)
+                    .await
+            {
                 tracing::error!(error = %e, "watcher error");
             }
         }))
@@ -192,8 +195,7 @@ pub async fn serve(
     if acp {
         let acp_manager = manager.clone();
         let cancel_acp = cancel.clone();
-        let acp_sessions: crate::acp::Sessions =
-            Arc::new(Mutex::new(HashMap::new()));
+        let acp_sessions: crate::acp::Sessions = Arc::new(Mutex::new(HashMap::new()));
         let acp_serve_cfg = serve_cfg.clone();
 
         let acp_handle = tokio::spawn(async move {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -20,10 +20,12 @@ enum WatchAction {
 // ── run_watcher ───────────────────────────────────────────────────────────────
 
 /// Start watching all mounted wikis. Runs until the cancellation token fires.
+/// `push_tx`: optional channel to notify ACP sessions of watcher-triggered ingests.
 pub async fn run_watcher(
     engine: Arc<WikiEngine>,
     debounce_ms: u32,
     cancel: CancellationToken,
+    push_tx: tokio::sync::mpsc::Sender<(String, String)>,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<(String, PathBuf)>(256);
 
@@ -128,6 +130,11 @@ pub async fn run_watcher(
                                     duration_ms = start.elapsed().as_millis() as u64,
                                     "watch: ingested",
                                 );
+                                let msg = format!(
+                                    "Wiki \"{wiki_name}\" updated: {} page(s) changed.",
+                                    report.updated + report.deleted
+                                );
+                                let _ = push_tx.try_send((wiki_name.clone(), msg));
                             }
                         }
                         Err(e) => {

--- a/tests/acp.rs
+++ b/tests/acp.rs
@@ -87,6 +87,13 @@ fn dispatch_use() {
 }
 
 #[test]
+fn dispatch_use_no_slug() {
+    let (wf, q) = dispatch_workflow("llm-wiki:use");
+    assert_eq!(wf, "use");
+    assert_eq!(q, "");
+}
+
+#[test]
 fn dispatch_help() {
     let (wf, q) = dispatch_workflow("llm-wiki:help");
     assert_eq!(wf, "help");

--- a/tests/acp.rs
+++ b/tests/acp.rs
@@ -44,6 +44,55 @@ fn dispatch_prefix_with_extra_spaces() {
     assert_eq!(t, "spaced query");
 }
 
+#[test]
+fn dispatch_lint_no_args() {
+    let (wf, q) = dispatch_workflow("llm-wiki:lint");
+    assert_eq!(wf, "lint");
+    assert_eq!(q, "");
+}
+
+#[test]
+fn dispatch_lint_with_rules() {
+    let (wf, q) = dispatch_workflow("llm-wiki:lint orphan,stale");
+    assert_eq!(wf, "lint");
+    assert_eq!(q, "orphan,stale");
+}
+
+#[test]
+fn dispatch_graph_no_root() {
+    let (wf, q) = dispatch_workflow("llm-wiki:graph");
+    assert_eq!(wf, "graph");
+    assert_eq!(q, "");
+}
+
+#[test]
+fn dispatch_graph_with_root() {
+    let (wf, q) = dispatch_workflow("llm-wiki:graph concepts/transformer");
+    assert_eq!(wf, "graph");
+    assert_eq!(q, "concepts/transformer");
+}
+
+#[test]
+fn dispatch_ingest_no_path() {
+    let (wf, q) = dispatch_workflow("llm-wiki:ingest");
+    assert_eq!(wf, "ingest");
+    assert_eq!(q, "");
+}
+
+#[test]
+fn dispatch_use() {
+    let (wf, q) = dispatch_workflow("llm-wiki:use concepts/moe");
+    assert_eq!(wf, "use");
+    assert_eq!(q, "concepts/moe");
+}
+
+#[test]
+fn dispatch_help() {
+    let (wf, q) = dispatch_workflow("llm-wiki:help");
+    assert_eq!(wf, "help");
+    assert_eq!(q, "");
+}
+
 // ── Tool ID ───────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Phase 1: wire all workflow dispatch arms (research, lint, graph, ingest, use, help) with `StepResult<T>` type alias
- Phase 2: cooperative cancellation via `Arc<AtomicBool>`, session cap (`acp_max_sessions`, default 20), proactive watcher push via mpsc channel

## Changes

- `src/acp/`: cancel handler, session policy, watcher push task, all workflow modules
- `src/config.rs`: `serve.acp_max_sessions` config key
- `src/watch.rs`: `push_tx` parameter for watcher-to-ACP notifications
- Docs: design doc, manual test matrix, changelog entries

## Test plan

- [x] `cargo clippy -- -D warnings` passes (verified)
- [x] `cargo test` passes
- [x] Manual: `llm-wiki:research`, `llm-wiki:lint`, `llm-wiki:graph`, `llm-wiki:ingest`, `llm-wiki:use`, `llm-wiki:help`
- [x] Manual: cancel mid-workflow → clean stop
- [x] Manual: exceed session cap → error response
- [x] Manual: watcher ingest → push notification reaches idle session