### PR TITLE
feat(graph): replace CachedGraph with petgraph-live GenerationCache (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Graph cache** — replaced bespoke `CachedGraph` + `RwLock<Option<CachedGraph>>` with `petgraph_live::GenerationCache<WikiGraph>` and `GenerationCache<CommunityData>`; `SpaceContext` no longer requires an explicit `RwLock` wrapper for the graph cache; zero behaviour change
+
 ## [0.3.0] — 2026-05-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-wiki-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1623,6 +1623,7 @@ dependencies = [
  "jsonschema",
  "notify",
  "petgraph",
+ "petgraph-live",
  "regex",
  "rmcp",
  "serde",
@@ -1975,6 +1976,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "serde",
+]
+
+[[package]]
+name = "petgraph-live"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f003b5742d6870d23f8e306b43714de98ea5abf48082f7fd88a044eb8201c2ec"
+dependencies = [
+ "petgraph",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-wiki-engine"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Git-backed wiki engine with MCP server — bring your own LLM"
@@ -57,6 +57,7 @@ tantivy    = "0.26"
 
 # Graph
 petgraph   = "0.8"
+petgraph-live = "0.3"
 
 # Filesystem traversal
 walkdir    = "2"

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -2,7 +2,7 @@
 title: "Graph Cache Implementation"
 summary: "In-memory graph cache keyed on index generation — eliminates redundant build_graph and Louvain calls in serve mode."
 status: ready
-last_updated: "2026-05-01"
+last_updated: "2026-05-03"
 depends_on:
   - engine.md
   - index-manager.md
@@ -26,27 +26,28 @@ compounds the cost — it ran on every `wiki_stats` and `wiki_suggest` call.
 ```rust
 // src/graph.rs
 
-pub struct CachedGraph {
-    pub graph:            Arc<WikiGraph>,
-    pub community_map:    Option<Arc<HashMap<String, usize>>>,
-    pub community_stats:  Option<CommunityStats>,
-    pub index_gen:        u64,
+pub struct CommunityData {
+    pub local_count: usize,
+    pub map:   Arc<HashMap<String, usize>>,
+    pub stats: CommunityStats,
 }
 ```
 
-`community_map` — slug→community_id, used by `wiki_suggest` strategy 4.
-`community_stats` — aggregated stats (`count`, `isolated` list), used by `wiki_stats`.
-`index_gen` — generation value at cache time; compared against current generation to detect staleness.
+`CommunityData` replaces `CachedGraph.community_map` + `CachedGraph.community_stats`.
+`local_count` stores local node count at build time — avoids re-traversal on the hot path.
+Community and graph caches share the same generation key.
 
-`CachedGraph` lives in `SpaceContext`:
+Both caches live in `SpaceContext`:
 
 ```rust
 // src/engine.rs
-pub graph_cache: RwLock<Option<CachedGraph>>,
+pub graph_cache:     GenerationCache<WikiGraph>,
+pub community_cache: GenerationCache<CommunityData>,
 ```
 
-Multiple readers can use the cached graph simultaneously. A single writer
-rebuilds and stores on miss.
+`GenerationCache<T>` is `Send + Sync` — no `RwLock` wrapper needed.
+`GenerationCache::get_or_build(gen, builder)` returns `Arc<T>` on hit,
+calls `builder()` → `Result<T>` on miss, caches and returns `Arc<T>`.
 
 ## Cache key: `AtomicU64` generation counter
 
@@ -88,40 +89,45 @@ pub fn get_or_build_graph(
     index_schema:  &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache:   &RwLock<Option<CachedGraph>>,
+    graph_cache:   &GenerationCache<WikiGraph>,
     searcher:      &Searcher,
     filter:        &GraphFilter,
 ) -> Result<Arc<WikiGraph>>
 ```
 
 - Filtered requests (`!filter.is_default()`) bypass cache, build and return fresh.
-- Cache hit: `cached.index_gen == current_gen` → return `Arc::clone`.
-- Cache miss: build graph, compute `community_map` + `community_stats`, store, return.
+- Cache hit: generation matches → return `Arc::clone`.
+- Cache miss: call `build_graph` inside `get_or_build`, cache result, return.
 
 ### `get_cached_community_map`
 
 ```rust
 pub fn get_cached_community_map(
     ...,
-    min_nodes: usize,
+    graph_cache:     &GenerationCache<WikiGraph>,
+    community_cache: &GenerationCache<CommunityData>,
+    searcher:        &Searcher,
+    min_nodes:       usize,
 ) -> Result<Option<Arc<HashMap<String, usize>>>>
 ```
 
-Returns cached `community_map` if local node count ≥ `min_nodes`, otherwise
-`None`. Triggers graph build as side effect on miss.
+Uses nested closure pattern: `community_cache.get_or_build` wraps `graph_cache.get_or_build` inside.
+Hot path (both warm): community_cache hits immediately — graph_cache never touched.
+Returns `None` when `community.local_count < min_nodes`.
 
 ### `get_cached_community_stats`
 
 ```rust
 pub fn get_cached_community_stats(
     ...,
-    min_nodes: usize,
+    graph_cache:     &GenerationCache<WikiGraph>,
+    community_cache: &GenerationCache<CommunityData>,
+    searcher:        &Searcher,
+    min_nodes:       usize,
 ) -> Result<Option<CommunityStats>>
 ```
 
-Same pattern as `get_cached_community_map` but returns `CommunityStats`. Used
-by `ops/stats.rs` to skip Louvain on cache hit. Returns `None` when local node
-count < `min_nodes`.
+Same nested closure pattern. Returns `None` when `community.local_count < min_nodes`.
 
 ## Cache population
 
@@ -178,10 +184,6 @@ accepts pre-built graphs rather than raw index handles.
 ## Limitations
 
 - Cache lives only for process lifetime. Cold start always rebuilds.
-  See [imp-graph-snapshot.md](../improvements/imp-graph-snapshot.md) for
-  the planned persistent snapshot feature.
-- Community data is always computed (Louvain runs at threshold 0). The
-  caller-supplied `min_nodes` is applied at read time — no recompute needed
-  for different thresholds, cached graph and community data are always reused.
-- Only unfiltered full graphs are cached. Each distinct filter combination
-  builds fresh.
+  Phase 2 (`feat/petgraph-live-snapshot`) adds `GraphState` warm-start.
+- Only unfiltered full graphs are cached. Each distinct filter combination builds fresh.
+- Community data is always computed at threshold 0. `min_nodes` is applied at read time — no recompute for different thresholds.

--- a/docs/improvements/2026-05-03-petgraph-live-algorithms.md
+++ b/docs/improvements/2026-05-03-petgraph-live-algorithms.md
@@ -1,0 +1,181 @@
+---
+title: "petgraph-live Phase 3 — Algorithm suite"
+summary: "Expose petgraph-live structural algorithms (articulation points, bridges, diameter, radius, center, periphery) via wiki_stats and a new wiki_health MCP tool."
+status: proposed
+target_version: "0.4.0"
+branch: feat/petgraph-live-algorithms
+pr_target: dev/v0.4.0
+depends_on:
+  - 2026-05-03-petgraph-live-cache.md
+last_updated: "2026-05-03"
+read_when:
+  - Implementing Phase 3 of petgraph-live integration
+  - Working on ops/stats.rs, ops/health.rs, mcp/tools.rs, mcp/handlers.rs
+  - Designing the wiki_health MCP tool
+---
+
+# petgraph-live Phase 3 — Algorithm suite
+
+## Problem
+
+`wiki_stats` reports basic metrics: orphan count, density, average connections, community count. Structural health questions — "which pages are critical connectors?", "which links are load-bearing?", "how far apart are the most isolated concepts?" — are unanswerable today.
+
+`petgraph-live` default features include `connect` and `metrics` modules that answer exactly these questions on any `DiGraph`.
+
+## Solution
+
+Add `ops/health.rs` with a `wiki_health` function. Register a `wiki_health` MCP tool. Extend `WikiStats` with optional structural fields populated from the same algorithms.
+
+Phase 3 is **independent of Phase 2** (snapshot). It requires only Phase 1 (`GenerationCache<WikiGraph>` in `SpaceContext`).
+
+## Algorithms
+
+All operate on `Arc<WikiGraph>` from `space.graph_cache.get_or_build(...)`.
+
+| Field | Module | Call | Meaning |
+|-------|--------|------|---------|
+| `articulation_points` | `connect` | `articulation_points(&g)` | Slugs whose removal disconnects the graph |
+| `bridges` | `connect` | `find_bridges(&g)` | Edges whose removal disconnects the graph |
+| `diameter` | `metrics` | `diameter(&g)` | Maximum shortest-path length (O(n²)) |
+| `radius` | `metrics` | `radius(&g)` | Minimum eccentricity |
+| `center` | `metrics` | `center(&g)` | Nodes with eccentricity = radius (hub pages) |
+| `periphery` | `metrics` | `periphery(&g)` | Nodes with eccentricity = diameter (isolated pages) |
+
+`articulation_points` and `find_bridges` are O(n+e) — always computed.
+
+`diameter`, `radius`, `center`, `periphery` are O(n²) — skipped for large graphs. Threshold configurable via `graph.max_nodes_for_diameter` (default 2000). When skipped, fields return `null` with a `note` field explaining why.
+
+## `wiki_health` MCP tool
+
+New tool: `wiki_health`. Input: `wiki` (optional). Output:
+
+```json
+{
+  "wiki": "my-wiki",
+  "node_count": 312,
+  "articulation_points": ["slug-a", "slug-b"],
+  "bridges": [
+    { "from": "slug-a", "to": "slug-b" },
+    { "from": "slug-c", "to": "slug-d" }
+  ],
+  "diameter": 12,
+  "radius": 4,
+  "center": ["slug-hub"],
+  "periphery": ["slug-isolated"],
+  "note": null
+}
+```
+
+When `diameter` skipped:
+
+```json
+{
+  "diameter": null,
+  "radius": null,
+  "center": null,
+  "periphery": null,
+  "note": "graph too large for diameter computation (312 nodes > max_nodes_for_diameter=2000 threshold — set graph.max_nodes_for_diameter to override)"
+}
+```
+
+## `wiki_stats` additions
+
+`WikiStats` gains optional structural fields — populated only when `include_health: bool` is passed (default `false`, avoids O(n²) cost on every `wiki_stats` call):
+
+```rust
+pub struct WikiStats {
+    // ... existing fields ...
+    pub articulation_points: Option<Vec<String>>,
+    pub bridges:             Option<Vec<(String, String)>>,
+    pub diameter:            Option<u32>,
+    pub radius:              Option<u32>,
+    pub center:              Option<Vec<String>>,
+    pub periphery:           Option<Vec<String>>,
+    pub health_note:         Option<String>,
+}
+```
+
+MCP tool `wiki_stats` gains optional `include_health` boolean parameter.
+
+## Config addition
+
+New field in `GraphConfig`:
+
+```toml
+[graph]
+max_nodes_for_diameter = 2000   # skip O(n²) algorithms above this threshold
+```
+
+New arm in `set_global_config_value` / `get_config_value`: `graph.max_nodes_for_diameter`.
+
+## `ops/health.rs`
+
+New module. Single public function:
+
+```rust
+pub fn wiki_health(
+    engine:    &EngineState,
+    wiki_name: &str,
+) -> Result<WikiHealthReport>
+```
+
+Acquires `Arc<WikiGraph>` from `space.graph_cache`, runs algorithms, applies size threshold, returns `WikiHealthReport`.
+
+`WikiHealthReport` is the typed backing for the JSON above.
+
+## Affected files
+
+| File | Change |
+|------|--------|
+| `src/ops/health.rs` | New — `wiki_health` function + `WikiHealthReport` struct |
+| `src/ops/mod.rs` | Add `pub mod health` |
+| `src/ops/stats.rs` | Add optional structural fields to `WikiStats`; call `ops/health` when `include_health` |
+| `src/mcp/tools.rs` | Register `wiki_health` tool; add `include_health` param to `wiki_stats` |
+| `src/mcp/handlers.rs` | Add `wiki_health` handler; update `wiki_stats` handler |
+| `src/config.rs` | Add `graph.max_nodes_for_diameter` to `GraphConfig`; add match arms |
+| `CHANGELOG.md` | Add `[Unreleased]` entry |
+
+## Breaking changes
+
+None. `wiki_stats` JSON gains new nullable fields — additive only. `wiki_health` is a new tool.
+
+## Out of scope
+
+| Item | Reason |
+|------|--------|
+| `wiki_suggest` articulation reranking | Too speculative; boost-on-articulation-point is a Phase 4+ idea |
+| Community detection via petgraph-live | Louvain is intentionally out of scope for petgraph-live; keep existing implementation |
+| Async algorithm execution | Not needed; algorithms run in <1s for wikis below threshold |
+
+## Constraints
+
+- `gen` is reserved in Rust 2024 — never use as variable name
+- `anyhow::Result` throughout
+- `graph.max_nodes_for_diameter` check must apply to **local** node count (non-external), same as `min_nodes_for_communities`
+- `wiki_health` must return a well-formed JSON response even when all O(n²) fields are null
+
+## Validation
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test --doc
+# Manual: wiki_health on a real wiki returns non-empty articulation_points
+# Manual: wiki_stats with include_health=true returns same data
+```
+
+## Definition of done
+
+- [ ] `ops/health.rs` with `wiki_health` function
+- [ ] `wiki_health` MCP tool registered and returns correct JSON
+- [ ] `wiki_stats` accepts `include_health` and populates structural fields when true
+- [ ] `graph.max_nodes_for_diameter` config key wired up
+- [ ] `note` field populated correctly when O(n²) skipped
+- [ ] All tests pass, clippy clean, fmt clean, doc tests pass
+- [ ] `CHANGELOG.md` `[Unreleased]` updated
+
+## See also
+
+- [Phase 1 — GenerationCache](2026-05-03-petgraph-live-cache.md) (required prerequisite)
+- [Phase 2 — Snapshot warm-start](2026-05-03-petgraph-live-snapshot.md) (independent)

--- a/docs/improvements/2026-05-03-petgraph-live-cache.md
+++ b/docs/improvements/2026-05-03-petgraph-live-cache.md
@@ -1,7 +1,7 @@
 ---
 title: "petgraph-live Phase 1 — GenerationCache"
 summary: "Replace bespoke CachedGraph + RwLock<Option<CachedGraph>> with petgraph_live::cache::GenerationCache<WikiGraph> and a separate GenerationCache<CommunityData>. Zero behaviour change."
-status: proposed
+status: in-progress
 target_version: "0.4.0"
 branch: feat/petgraph-live-cache
 pr_target: dev/v0.4.0

--- a/docs/improvements/2026-05-03-petgraph-live-cache.md
+++ b/docs/improvements/2026-05-03-petgraph-live-cache.md
@@ -1,0 +1,154 @@
+---
+title: "petgraph-live Phase 1 — GenerationCache"
+summary: "Replace bespoke CachedGraph + RwLock<Option<CachedGraph>> with petgraph_live::cache::GenerationCache<WikiGraph> and a separate GenerationCache<CommunityData>. Zero behaviour change."
+status: proposed
+target_version: "0.4.0"
+branch: feat/petgraph-live-cache
+pr_target: dev/v0.4.0
+depends_on: []
+last_updated: "2026-05-03"
+read_when:
+  - Implementing Phase 1 of petgraph-live integration
+  - Reviewing SpaceContext graph cache design
+  - Working on graph.rs, engine.rs, ops/stats.rs, ops/suggest.rs, ops/graph.rs
+---
+
+# petgraph-live Phase 1 — GenerationCache
+
+## Problem
+
+`SpaceContext` carries a bespoke generation-keyed graph cache:
+
+```rust
+pub graph_cache: RwLock<Option<CachedGraph>>,
+
+pub struct CachedGraph {
+    pub graph:           Arc<WikiGraph>,
+    pub community_map:   Option<Arc<HashMap<String, usize>>>,
+    pub community_stats: Option<CommunityStats>,
+    pub index_gen:       u64,
+}
+```
+
+`get_or_build_graph()` in `src/graph.rs` manually manages read/write locks, compares `index_gen`, rebuilds on miss. Community data is co-located in `CachedGraph` — graph and community share one lock, one invalidation event.
+
+Pain points:
+- Manual lock/invalidation logic not covered beyond integration smoke tests
+- Community threshold check requires re-traversing the graph on every hot call
+- No warm-start (Phase 2 concern, but Phase 1 must lay the foundation)
+- `CachedGraph` is a private bespoke type — `petgraph-live` solves this generically
+
+## Solution
+
+Replace with `petgraph_live::cache::GenerationCache<T>` — a production-quality generation-keyed cache that is `Send + Sync` with no external `RwLock` wrapper.
+
+Two caches on `SpaceContext`:
+
+```rust
+pub graph_cache:     GenerationCache<WikiGraph>,
+pub community_cache: GenerationCache<CommunityData>,
+```
+
+`CommunityData` replaces the community fields of `CachedGraph` and stores `local_count` to avoid re-traversal on the hot path:
+
+```rust
+pub struct CommunityData {
+    pub local_count: usize,                        // local node count at build time
+    pub map:         Arc<HashMap<String, usize>>,  // slug → community id
+    pub stats:       CommunityStats,
+}
+```
+
+## Hot-path design
+
+`get_cached_community_map` and `get_cached_community_stats` use a **nested closure pattern**:
+
+```rust
+let community = community_cache.get_or_build(current_gen, || {
+    let graph = graph_cache.get_or_build(current_gen, || {
+        build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+    })?;
+    let local_count = graph.node_indices().filter(|&i| !graph[i].external).count();
+    let (stats_opt, map_opt) = build_community_data(&graph, 0);
+    Ok(CommunityData { local_count, map: Arc::new(map_opt.unwrap_or_default()), stats: ... })
+})?;
+```
+
+On cache hit: `community_cache.get_or_build` returns immediately after one read lock — `graph_cache` never touched. This avoids 3 atomic ops + 1 lock acquisition vs. the naive "fetch graph first, then community" approach.
+
+`community.local_count` makes the `min_nodes` threshold check a field read — no graph traversal.
+
+## Import path
+
+`GenerationCache` lives at `petgraph_live::cache::GenerationCache`, not `petgraph_live::GenerationCache`.
+
+```rust
+use petgraph_live::cache::GenerationCache;
+```
+
+## `LabeledEdge` serde
+
+Phase 2 snapshot requires `LabeledEdge: Serialize + Deserialize`. Add derives now to keep Phase 1 and Phase 2 diffs clean:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabeledEdge { pub relation: String }
+```
+
+## Cargo.toml
+
+```toml
+petgraph-live = "0.3"   # default features only — no snapshot feature needed for Phase 1
+```
+
+No diamond conflict: `petgraph-live` depends on `petgraph = "0.8"`, same as llm-wiki.
+
+## Affected files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Add `petgraph-live = "0.3"`; bump version `0.3.0` → `0.4.0` |
+| `src/graph.rs` | Add `Serialize + Deserialize` to `LabeledEdge`; add `CommunityData`; rewrite `get_or_build_graph`, `get_cached_community_map`, `get_cached_community_stats`; delete `CachedGraph` |
+| `src/engine.rs` | Replace `RwLock<Option<CachedGraph>>` with two `GenerationCache` fields; keep `RwLock` import (`WikiEngine.state` still uses it) |
+| `src/ops/graph.rs` | Call sites compile automatically — `graph_cache` type change is transparent |
+| `src/ops/stats.rs` | Add `&space.community_cache` parameter to `get_cached_community_stats` call |
+| `src/ops/suggest.rs` | Add `&space.community_cache` parameter to `get_cached_community_map` call |
+| `tests/graph_cache.rs` | Add `&space.community_cache` to community function calls; `get_or_build_graph` calls unchanged |
+| `docs/implementation/graph-cache.md` | Update core structs and accessor signatures |
+| `CHANGELOG.md` | Add `[Unreleased]` entry |
+
+## Breaking changes
+
+None public.
+
+## Constraints
+
+- `gen` is reserved in Rust 2024 — never use as variable name
+- `anyhow::Result` throughout — `GenerationCache::get_or_build` builder returns `Result<T, E>` where `E: From<anyhow::Error>`; passes cleanly with `?`
+- Keep `use std::sync::RwLock` in `engine.rs` — `WikiEngine.state: Arc<RwLock<EngineState>>` still needs it
+- `docs/roadmap.md` already has v0.4.0 section — update in place, do not duplicate
+
+## Validation
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test --doc
+```
+
+## Definition of done
+
+- [ ] `CachedGraph` struct deleted
+- [ ] `SpaceContext` has `graph_cache: GenerationCache<WikiGraph>` and `community_cache: GenerationCache<CommunityData>`, no `RwLock` wrapper
+- [ ] `get_or_build_graph` uses `GenerationCache::get_or_build`
+- [ ] Community accessors use nested closure pattern
+- [ ] `graph_cache_hit_returns_same_arc` test passes — `Arc::ptr_eq` on generation hit
+- [ ] All tests pass, clippy clean, fmt clean, doc tests pass
+- [ ] `CHANGELOG.md` `[Unreleased]` updated
+
+## See also
+
+- [Phase 2 — Snapshot warm-start](2026-05-03-petgraph-live-snapshot.md)
+- [Phase 3 — Algorithm suite](2026-05-03-petgraph-live-algorithms.md)
+- Implementation plan: `docs/brainstorm/plan/2026-05-02-petgraph-live-phase1.md`

--- a/docs/improvements/2026-05-03-petgraph-live-cache.md
+++ b/docs/improvements/2026-05-03-petgraph-live-cache.md
@@ -1,7 +1,7 @@
 ---
 title: "petgraph-live Phase 1 — GenerationCache"
 summary: "Replace bespoke CachedGraph + RwLock<Option<CachedGraph>> with petgraph_live::cache::GenerationCache<WikiGraph> and a separate GenerationCache<CommunityData>. Zero behaviour change."
-status: in-progress
+status: phase1-implemented
 target_version: "0.4.0"
 branch: feat/petgraph-live-cache
 pr_target: dev/v0.4.0
@@ -139,13 +139,13 @@ cargo test --doc
 
 ## Definition of done
 
-- [ ] `CachedGraph` struct deleted
-- [ ] `SpaceContext` has `graph_cache: GenerationCache<WikiGraph>` and `community_cache: GenerationCache<CommunityData>`, no `RwLock` wrapper
-- [ ] `get_or_build_graph` uses `GenerationCache::get_or_build`
-- [ ] Community accessors use nested closure pattern
-- [ ] `graph_cache_hit_returns_same_arc` test passes — `Arc::ptr_eq` on generation hit
-- [ ] All tests pass, clippy clean, fmt clean, doc tests pass
-- [ ] `CHANGELOG.md` `[Unreleased]` updated
+- [x] `CachedGraph` struct deleted
+- [x] `SpaceContext` has `graph_cache: GenerationCache<WikiGraph>` and `community_cache: GenerationCache<CommunityData>`, no `RwLock` wrapper
+- [x] `get_or_build_graph` uses `GenerationCache::get_or_build`
+- [x] Community accessors use nested closure pattern
+- [x] `graph_cache_hit_returns_same_arc` test passes — `Arc::ptr_eq` on generation hit
+- [x] All tests pass, clippy clean, fmt clean, doc tests pass
+- [x] `CHANGELOG.md` `[Unreleased]` updated
 
 ## See also
 

--- a/docs/improvements/2026-05-03-petgraph-live-snapshot.md
+++ b/docs/improvements/2026-05-03-petgraph-live-snapshot.md
@@ -1,0 +1,161 @@
+---
+title: "petgraph-live Phase 2 — Snapshot warm-start"
+summary: "Replace GenerationCache<WikiGraph> with GraphState<WikiGraph> so the graph survives process restarts. Cold builds only on first launch or after wiki_index_rebuild."
+status: proposed
+target_version: "0.4.0"
+branch: feat/petgraph-live-snapshot
+pr_target: dev/v0.4.0
+depends_on:
+  - 2026-05-03-petgraph-live-cache.md
+last_updated: "2026-05-03"
+read_when:
+  - Implementing Phase 2 of petgraph-live integration
+  - Working on engine.rs, space_builder.rs, mcp/handlers.rs, config.rs
+  - Reviewing graph snapshot lifecycle
+---
+
+# petgraph-live Phase 2 — Snapshot warm-start
+
+## Problem
+
+Phase 1 replaces `RwLock<Option<CachedGraph>>` with `GenerationCache<WikiGraph>`. The cache is in-memory only — every process restart rebuilds the graph from the Tantivy index. For large wikis this is a measurable cold-start penalty on every `llm-wiki serve` restart.
+
+## Solution
+
+Replace `GenerationCache<WikiGraph>` with `petgraph_live::live::GraphState<WikiGraph>`.
+
+`GraphState` composes generation-keyed cache + snapshot lifecycle:
+- On startup: attempt to load snapshot for the current generation key
+- Hit: return cached graph (warm start — no Tantivy traversal)
+- Miss (stale key, missing file, corrupt): cold build → save snapshot → return graph
+- On `wiki_index_rebuild`: explicit invalidation writes a new snapshot for the new generation
+
+`community_cache: GenerationCache<CommunityData>` stays unchanged — community data is fast to rebuild from the graph, not worth snapshotting.
+
+## Cargo.toml change
+
+```toml
+petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
+```
+
+`snapshot-lz4` implies `snapshot`. LZ4 chosen over zstd: faster decompression, adequate compression ratio for graph data (struct-heavy, repetitive strings).
+
+## SpaceContext change
+
+```rust
+// Phase 1
+pub graph_cache: GenerationCache<WikiGraph>,
+
+// Phase 2
+pub graph_state: GraphState<WikiGraph>,
+```
+
+`community_cache: GenerationCache<CommunityData>` unchanged.
+
+`GraphState` is `Send + Sync`. No `RwLock` wrapper needed.
+
+## Snapshot configuration
+
+`GraphState` requires a `SnapshotConfig` at construction time:
+
+```rust
+SnapshotConfig {
+    dir:         state_dir.join("snapshots").join(&space.name),
+    name:        "wiki-graph".into(),
+    format:      SnapshotFormat::Bincode,
+    compression: Compression::Lz4,
+    keep:        config.graph.snapshot_keep,
+}
+```
+
+Generation key passed per call: `graph_state.get_or_build(current_gen, builder)`.
+
+Key mismatch on load → stale snapshot → cold build → new snapshot saved automatically.
+
+`state_dir` must come from `EngineState::state_dir` — never hardcode.
+
+Snapshot directory created lazily by petgraph-live `save()` — no `mkdir` needed.
+
+## Config additions
+
+New fields in `GraphConfig` (`src/config.rs`):
+
+```toml
+[graph]
+snapshot         = true         # default: true; false disables snapshot (CI, tests)
+snapshot_keep    = 3            # snapshot rotation count (keep N most recent)
+snapshot_format  = "bincode+lz4"  # or "bincode" / "bincode+zstd"
+```
+
+`snapshot = false` preserves Phase 1 behaviour — `GraphState` falls back to in-memory only. Useful in CI and integration tests where snapshot files are unwanted.
+
+New arms in `set_global_config_value` / `get_config_value` / `set_wiki_config_value`: `graph.snapshot`, `graph.snapshot_keep`, `graph.snapshot_format`.
+
+## `wiki_index_rebuild` invalidation
+
+After rebuild, the old snapshot is stale. Explicit invalidation required:
+
+```rust
+space.graph_state.invalidate();
+// Optionally pre-warm synchronously:
+space.graph_state.get_or_build(new_gen, builder)?;
+```
+
+Without explicit invalidation, the next call detects generation mismatch and cold-builds automatically — but leaving a stale snapshot on disk is wasteful. `invalidate()` deletes it.
+
+## `LabeledEdge` serde requirement
+
+`GraphState` snapshot requires `WikiGraph` nodes and edges to implement `Serialize + Deserialize`. Phase 1 adds these derives to `LabeledEdge`. Phase 2 depends on that being in place.
+
+`PageNode` already derives serde. No change needed.
+
+## Affected files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Change `petgraph-live = "0.3"` → `petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }` |
+| `src/engine.rs` | Replace `GenerationCache<WikiGraph>` with `GraphState<WikiGraph>`; add `SnapshotConfig` construction |
+| `src/space_builder.rs` | Pass `state_dir` and `SnapshotConfig` when constructing `SpaceContext` |
+| `src/ops/graph.rs` | Update graph access from `graph_cache.get_or_build` → `graph_state.get_or_build` |
+| `src/ops/stats.rs` | Same — `graph_state.get_or_build` |
+| `src/mcp/handlers.rs` | `wiki_index_rebuild` handler calls `space.graph_state.invalidate()` after rebuild |
+| `src/config.rs` | Add `graph.snapshot`, `graph.snapshot_keep`, `graph.snapshot_format` to `GraphConfig`; add match arms |
+| `docs/implementation/graph-cache.md` | Document snapshot lifecycle |
+| `CHANGELOG.md` | Add `[Unreleased]` entry |
+
+## Breaking changes
+
+None public. Snapshot files appear under `state_dir/snapshots/<wiki-name>/`.
+
+## Constraints
+
+- `gen` is reserved in Rust 2024 — never use as variable name
+- `state_dir` never hardcoded — always from `EngineState::state_dir`
+- `snapshot = false` must fully bypass `GraphState` snapshot logic (pass via config at construction)
+- Community cache stays `GenerationCache<CommunityData>` — not snapshotted
+- Integration tests must set `graph.snapshot = false` to avoid snapshot files in `tempfile::TempDir`
+
+## Validation
+
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test --doc
+# Manual: start server, kill, restart — first tool call must not log "building graph from index"
+```
+
+## Definition of done
+
+- [ ] `GenerationCache<WikiGraph>` replaced with `GraphState<WikiGraph>` in `SpaceContext`
+- [ ] `SnapshotConfig` constructed from `state_dir` + `GraphConfig`
+- [ ] `wiki_index_rebuild` calls `graph_state.invalidate()` after rebuild
+- [ ] `graph.snapshot = false` disables snapshot in tests and CI
+- [ ] Warm-start verified: process restart skips cold build log
+- [ ] All tests pass, clippy clean, fmt clean, doc tests pass
+- [ ] `CHANGELOG.md` `[Unreleased]` updated
+
+## See also
+
+- [Phase 1 — GenerationCache](2026-05-03-petgraph-live-cache.md) (required prerequisite)
+- [Phase 3 — Algorithm suite](2026-05-03-petgraph-live-algorithms.md) (independent)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,9 +11,9 @@ last_updated: "2026-05-03"
 
 | Area  | What |
 |-------|------|
-| Graph | petgraph-live Phase 1: replace bespoke `CachedGraph` with `GenerationCache` (`feat/petgraph-live-cache`) |
-| Graph | petgraph-live Phase 2: snapshot warm-start via `GraphState` (`feat/petgraph-live-snapshot`) |
-| Graph | petgraph-live Phase 3: `wiki_health` MCP tool + structural algorithms (`feat/petgraph-live-algorithms`) |
+| Graph | petgraph-live Phase 1: replace bespoke `CachedGraph` with `GenerationCache` — see [docs/improvements/2026-05-03-petgraph-live-cache.md](improvements/2026-05-03-petgraph-live-cache.md) |
+| Graph | petgraph-live Phase 2: snapshot warm-start via `GraphState` — see [docs/improvements/2026-05-03-petgraph-live-snapshot.md](improvements/2026-05-03-petgraph-live-snapshot.md) |
+| Graph | petgraph-live Phase 3: `wiki_health` MCP tool + structural algorithms — see [docs/improvements/2026-05-03-petgraph-live-algorithms.md](improvements/2026-05-03-petgraph-live-algorithms.md) |
 
 ## Future
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,7 +5,8 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 
 use crate::config::{self, GlobalConfig, ResolvedConfig, WikiEntry};
-use crate::graph::CachedGraph;
+use petgraph_live::cache::GenerationCache;
+use crate::graph::{CommunityData, WikiGraph};
 use crate::index_manager::{IndexReport, SpaceIndexManager, StalenessKind, UpdateReport};
 use crate::index_schema::IndexSchema;
 use crate::space_builder;
@@ -27,8 +28,10 @@ pub struct SpaceContext {
     pub index_schema: IndexSchema,
     /// Lifecycle manager for the Tantivy search index.
     pub index_manager: SpaceIndexManager,
-    /// In-memory graph cache. Invalidated when `index_manager.generation()` changes.
-    pub graph_cache: RwLock<Option<CachedGraph>>,
+    /// Generation-keyed graph cache. Invalidated automatically when index generation advances.
+    pub graph_cache: GenerationCache<WikiGraph>,
+    /// Generation-keyed community cache. Shares the same generation key as graph_cache.
+    pub community_cache: GenerationCache<CommunityData>,
 }
 
 impl SpaceContext {
@@ -370,6 +373,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         type_registry,
         index_schema,
         index_manager,
-        graph_cache: RwLock::new(None),
+        graph_cache: GenerationCache::new(),
+        community_cache: GenerationCache::new(),
     })
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,12 +5,12 @@ use std::sync::{Arc, RwLock};
 use anyhow::Result;
 
 use crate::config::{self, GlobalConfig, ResolvedConfig, WikiEntry};
-use petgraph_live::cache::GenerationCache;
 use crate::graph::{CommunityData, WikiGraph};
 use crate::index_manager::{IndexReport, SpaceIndexManager, StalenessKind, UpdateReport};
 use crate::index_schema::IndexSchema;
 use crate::space_builder;
 use crate::type_registry::SpaceTypeRegistry;
+use petgraph_live::cache::GenerationCache;
 
 // ── SpaceContext ──────────────────────────────────────────────────────────────
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -151,6 +151,16 @@ pub struct CommunityStats {
     pub isolated: Vec<String>,
 }
 
+/// Cached community detection results for a space.
+pub struct CommunityData {
+    /// Number of local (non-external) nodes in the graph at cache time.
+    pub local_count: usize,
+    /// Slug → community id map.
+    pub map: Arc<HashMap<String, usize>>,
+    /// Aggregated Louvain stats.
+    pub stats: CommunityStats,
+}
+
 /// Build undirected adjacency by symmetrizing the directed graph. External nodes excluded.
 fn build_adjacency(graph: &WikiGraph) -> HashMap<NodeIndex, HashSet<NodeIndex>> {
     let mut adj: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::new();
@@ -1207,5 +1217,18 @@ mod tests {
         let json = serde_json::to_string(&e).unwrap();
         let back: LabeledEdge = serde_json::from_str(&json).unwrap();
         assert_eq!(back.relation, "links-to");
+    }
+
+    #[test]
+    fn community_data_constructs() {
+        use std::collections::HashMap;
+        let data = CommunityData {
+            local_count: 3,
+            map: std::sync::Arc::new(HashMap::from([("slug-a".to_string(), 0usize)])),
+            stats: CommunityStats { count: 1, largest: 1, smallest: 1, isolated: vec![] },
+        };
+        assert_eq!(data.local_count, 3);
+        assert_eq!(data.map.get("slug-a"), Some(&0));
+        assert_eq!(data.stats.count, 1);
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,6 @@
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::Utc;
@@ -43,17 +43,6 @@ pub struct LabeledEdge {
 /// Directed graph type used for the wiki concept graph.
 pub type WikiGraph = DiGraph<PageNode, LabeledEdge>;
 
-/// Cached result of a full (unfiltered) graph build, keyed by index generation.
-pub struct CachedGraph {
-    /// The full unfiltered wiki graph.
-    pub graph: Arc<WikiGraph>,
-    /// Precomputed community map (slug → community_id). Some for any non-empty graph.
-    pub community_map: Option<Arc<HashMap<String, usize>>>,
-    /// Precomputed community stats. Some for any non-empty graph.
-    pub community_stats: Option<CommunityStats>,
-    /// Generation value from SpaceIndexManager at cache time.
-    pub index_gen: u64,
-}
 
 /// Filtering parameters for graph construction and subgraph extraction.
 #[derive(Debug, Clone, Default)]
@@ -1050,12 +1039,12 @@ fn build_community_data(
 /// Return cached full graph, or build and cache on miss.
 /// Filtered (non-default) requests bypass cache entirely.
 pub fn get_or_build_graph(
-    index_schema: &IndexSchema,
+    index_schema:  &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache: &RwLock<Option<CachedGraph>>,
-    searcher: &Searcher,
-    filter: &GraphFilter,
+    graph_cache:   &petgraph_live::cache::GenerationCache<WikiGraph>,
+    searcher:      &Searcher,
+    filter:        &GraphFilter,
 ) -> Result<Arc<WikiGraph>> {
     if !filter.is_default() {
         let g = build_graph(searcher, index_schema, filter, type_registry)?;
@@ -1063,148 +1052,72 @@ pub fn get_or_build_graph(
     }
 
     let current_gen = index_manager.generation();
-
-    // Check cache hit
-    {
-        let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref()
-            && cached.index_gen == current_gen
-        {
-            return Ok(Arc::clone(&cached.graph));
-        }
-    }
-
-    // Cache miss — build
-    let graph = Arc::new(build_graph(searcher, index_schema, filter, type_registry)?);
-    let (community_stats, community_map_raw) = build_community_data(&graph, 0);
-    let community_map = community_map_raw.map(Arc::new);
-
-    *graph_cache.write().unwrap() = Some(CachedGraph {
-        graph: Arc::clone(&graph),
-        community_map,
-        community_stats,
-        index_gen: current_gen,
-    });
-
-    Ok(graph)
+    graph_cache.get_or_build(current_gen, || {
+        build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+    })
 }
 
 /// Return cached community map, or None if graph is below `min_nodes` threshold.
-/// Builds and caches the full graph as a side effect if not already cached.
+///
+/// Hot path (both caches warm): community_cache hits immediately — graph_cache not touched.
+/// Cold path (miss): graph built and cached first, community built and cached inside closure.
 pub fn get_cached_community_map(
-    index_schema: &IndexSchema,
-    type_registry: &SpaceTypeRegistry,
-    index_manager: &SpaceIndexManager,
-    graph_cache: &RwLock<Option<CachedGraph>>,
-    searcher: &Searcher,
-    min_nodes: usize,
+    index_schema:    &IndexSchema,
+    type_registry:   &SpaceTypeRegistry,
+    index_manager:   &SpaceIndexManager,
+    graph_cache:     &petgraph_live::cache::GenerationCache<WikiGraph>,
+    community_cache: &petgraph_live::cache::GenerationCache<CommunityData>,
+    searcher:        &Searcher,
+    min_nodes:       usize,
 ) -> Result<Option<Arc<HashMap<String, usize>>>> {
     let current_gen = index_manager.generation();
 
-    // Check cache hit
-    {
-        let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref()
-            && cached.index_gen == current_gen
-        {
-            let local_count = cached
-                .graph
-                .node_indices()
-                .filter(|&i| !cached.graph[i].external)
-                .count();
-            if local_count < min_nodes {
-                return Ok(None);
-            }
-            return Ok(cached.community_map.clone());
-        }
+    let community = community_cache.get_or_build(current_gen, || -> Result<CommunityData> {
+        let graph = graph_cache.get_or_build(current_gen, || {
+            build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+        })?;
+        let local_count = graph.node_indices().filter(|&i| !graph[i].external).count();
+        let (stats_opt, map_opt) = build_community_data(&graph, 0);
+        let stats = stats_opt.unwrap_or(CommunityStats { count: 0, largest: 0, smallest: 0, isolated: vec![] });
+        let map   = map_opt.unwrap_or_default();
+        Ok(CommunityData { local_count, map: Arc::new(map), stats })
+    })?;
+
+    if community.local_count < min_nodes {
+        return Ok(None);
     }
-
-    // Cache miss — build graph and community data
-    get_or_build_graph(
-        index_schema,
-        type_registry,
-        index_manager,
-        graph_cache,
-        searcher,
-        &GraphFilter::default(),
-    )?;
-
-    // Re-read (no gen check — cache is valid at whatever generation get_or_build_graph wrote)
-    {
-        let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() {
-            let local_count = cached
-                .graph
-                .node_indices()
-                .filter(|&i| !cached.graph[i].external)
-                .count();
-            if local_count < min_nodes {
-                return Ok(None);
-            }
-            return Ok(cached.community_map.clone());
-        }
-    }
-
-    Ok(None)
+    Ok(Some(Arc::clone(&community.map)))
 }
 
-/// Return cached `CommunityStats` for `space`, or `None` if graph is below threshold.
-/// Builds and caches the full graph as a side effect if not already cached.
+/// Return cached CommunityStats, or None if graph is below threshold.
+///
+/// Hot path: community_cache hits immediately — graph_cache not touched.
 pub fn get_cached_community_stats(
-    index_schema: &IndexSchema,
-    type_registry: &SpaceTypeRegistry,
-    index_manager: &SpaceIndexManager,
-    graph_cache: &RwLock<Option<CachedGraph>>,
-    searcher: &Searcher,
-    min_nodes: usize,
+    index_schema:    &IndexSchema,
+    type_registry:   &SpaceTypeRegistry,
+    index_manager:   &SpaceIndexManager,
+    graph_cache:     &petgraph_live::cache::GenerationCache<WikiGraph>,
+    community_cache: &petgraph_live::cache::GenerationCache<CommunityData>,
+    searcher:        &Searcher,
+    min_nodes:       usize,
 ) -> Result<Option<CommunityStats>> {
     let current_gen = index_manager.generation();
 
-    // Check cache hit
-    {
-        let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref()
-            && cached.index_gen == current_gen
-        {
-            let local_count = cached
-                .graph
-                .node_indices()
-                .filter(|&i| !cached.graph[i].external)
-                .count();
-            if local_count < min_nodes {
-                return Ok(None);
-            }
-            return Ok(cached.community_stats.clone());
-        }
+    let community = community_cache.get_or_build(current_gen, || -> Result<CommunityData> {
+        let graph = graph_cache.get_or_build(current_gen, || {
+            build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+        })?;
+        let local_count = graph.node_indices().filter(|&i| !graph[i].external).count();
+        let (stats_opt, map_opt) = build_community_data(&graph, 0);
+        let stats = stats_opt.unwrap_or(CommunityStats { count: 0, largest: 0, smallest: 0, isolated: vec![] });
+        let map   = map_opt.unwrap_or_default();
+        Ok(CommunityData { local_count, map: Arc::new(map), stats })
+    })?;
+
+    if community.local_count < min_nodes {
+        return Ok(None);
     }
-
-    // Cache miss — build graph and community data
-    get_or_build_graph(
-        index_schema,
-        type_registry,
-        index_manager,
-        graph_cache,
-        searcher,
-        &GraphFilter::default(),
-    )?;
-
-    // Re-read (no gen check — cache is valid at whatever generation get_or_build_graph wrote)
-    {
-        let cache = graph_cache.read().unwrap();
-        if let Some(cached) = cache.as_ref() {
-            let local_count = cached
-                .graph
-                .node_indices()
-                .filter(|&i| !cached.graph[i].external)
-                .count();
-            if local_count < min_nodes {
-                return Ok(None);
-            }
-            return Ok(cached.community_stats.clone());
-        }
-    }
-
-    Ok(None)
+    Ok(Some(community.stats.clone()))
 }
 
 #[cfg(test)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -34,7 +34,7 @@ pub struct PageNode {
 }
 
 /// A directed edge in the wiki concept graph with a relation label.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LabeledEdge {
     /// Relation label (e.g. `"links-to"`, `"cites"`, `"supersedes"`).
     pub relation: String,
@@ -1195,4 +1195,17 @@ pub fn get_cached_community_stats(
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labeled_edge_serializes() {
+        let e = LabeledEdge { relation: "links-to".to_string() };
+        let json = serde_json::to_string(&e).unwrap();
+        let back: LabeledEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.relation, "links-to");
+    }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -43,7 +43,6 @@ pub struct LabeledEdge {
 /// Directed graph type used for the wiki concept graph.
 pub type WikiGraph = DiGraph<PageNode, LabeledEdge>;
 
-
 /// Filtering parameters for graph construction and subgraph extraction.
 #[derive(Debug, Clone, Default)]
 pub struct GraphFilter {
@@ -1039,12 +1038,12 @@ fn build_community_data(
 /// Return cached full graph, or build and cache on miss.
 /// Filtered (non-default) requests bypass cache entirely.
 pub fn get_or_build_graph(
-    index_schema:  &IndexSchema,
+    index_schema: &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache:   &petgraph_live::cache::GenerationCache<WikiGraph>,
-    searcher:      &Searcher,
-    filter:        &GraphFilter,
+    graph_cache: &petgraph_live::cache::GenerationCache<WikiGraph>,
+    searcher: &Searcher,
+    filter: &GraphFilter,
 ) -> Result<Arc<WikiGraph>> {
     if !filter.is_default() {
         let g = build_graph(searcher, index_schema, filter, type_registry)?;
@@ -1053,7 +1052,12 @@ pub fn get_or_build_graph(
 
     let current_gen = index_manager.generation();
     graph_cache.get_or_build(current_gen, || {
-        build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+        build_graph(
+            searcher,
+            index_schema,
+            &GraphFilter::default(),
+            type_registry,
+        )
     })
 }
 
@@ -1062,25 +1066,39 @@ pub fn get_or_build_graph(
 /// Hot path (both caches warm): community_cache hits immediately — graph_cache not touched.
 /// Cold path (miss): graph built and cached first, community built and cached inside closure.
 pub fn get_cached_community_map(
-    index_schema:    &IndexSchema,
-    type_registry:   &SpaceTypeRegistry,
-    index_manager:   &SpaceIndexManager,
-    graph_cache:     &petgraph_live::cache::GenerationCache<WikiGraph>,
+    index_schema: &IndexSchema,
+    type_registry: &SpaceTypeRegistry,
+    index_manager: &SpaceIndexManager,
+    graph_cache: &petgraph_live::cache::GenerationCache<WikiGraph>,
     community_cache: &petgraph_live::cache::GenerationCache<CommunityData>,
-    searcher:        &Searcher,
-    min_nodes:       usize,
+    searcher: &Searcher,
+    min_nodes: usize,
 ) -> Result<Option<Arc<HashMap<String, usize>>>> {
     let current_gen = index_manager.generation();
 
     let community = community_cache.get_or_build(current_gen, || -> Result<CommunityData> {
         let graph = graph_cache.get_or_build(current_gen, || {
-            build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+            build_graph(
+                searcher,
+                index_schema,
+                &GraphFilter::default(),
+                type_registry,
+            )
         })?;
         let local_count = graph.node_indices().filter(|&i| !graph[i].external).count();
         let (stats_opt, map_opt) = build_community_data(&graph, 0);
-        let stats = stats_opt.unwrap_or(CommunityStats { count: 0, largest: 0, smallest: 0, isolated: vec![] });
-        let map   = map_opt.unwrap_or_default();
-        Ok(CommunityData { local_count, map: Arc::new(map), stats })
+        let stats = stats_opt.unwrap_or(CommunityStats {
+            count: 0,
+            largest: 0,
+            smallest: 0,
+            isolated: vec![],
+        });
+        let map = map_opt.unwrap_or_default();
+        Ok(CommunityData {
+            local_count,
+            map: Arc::new(map),
+            stats,
+        })
     })?;
 
     if community.local_count < min_nodes {
@@ -1093,25 +1111,39 @@ pub fn get_cached_community_map(
 ///
 /// Hot path: community_cache hits immediately — graph_cache not touched.
 pub fn get_cached_community_stats(
-    index_schema:    &IndexSchema,
-    type_registry:   &SpaceTypeRegistry,
-    index_manager:   &SpaceIndexManager,
-    graph_cache:     &petgraph_live::cache::GenerationCache<WikiGraph>,
+    index_schema: &IndexSchema,
+    type_registry: &SpaceTypeRegistry,
+    index_manager: &SpaceIndexManager,
+    graph_cache: &petgraph_live::cache::GenerationCache<WikiGraph>,
     community_cache: &petgraph_live::cache::GenerationCache<CommunityData>,
-    searcher:        &Searcher,
-    min_nodes:       usize,
+    searcher: &Searcher,
+    min_nodes: usize,
 ) -> Result<Option<CommunityStats>> {
     let current_gen = index_manager.generation();
 
     let community = community_cache.get_or_build(current_gen, || -> Result<CommunityData> {
         let graph = graph_cache.get_or_build(current_gen, || {
-            build_graph(searcher, index_schema, &GraphFilter::default(), type_registry)
+            build_graph(
+                searcher,
+                index_schema,
+                &GraphFilter::default(),
+                type_registry,
+            )
         })?;
         let local_count = graph.node_indices().filter(|&i| !graph[i].external).count();
         let (stats_opt, map_opt) = build_community_data(&graph, 0);
-        let stats = stats_opt.unwrap_or(CommunityStats { count: 0, largest: 0, smallest: 0, isolated: vec![] });
-        let map   = map_opt.unwrap_or_default();
-        Ok(CommunityData { local_count, map: Arc::new(map), stats })
+        let stats = stats_opt.unwrap_or(CommunityStats {
+            count: 0,
+            largest: 0,
+            smallest: 0,
+            isolated: vec![],
+        });
+        let map = map_opt.unwrap_or_default();
+        Ok(CommunityData {
+            local_count,
+            map: Arc::new(map),
+            stats,
+        })
     })?;
 
     if community.local_count < min_nodes {
@@ -1126,7 +1158,9 @@ mod tests {
 
     #[test]
     fn labeled_edge_serializes() {
-        let e = LabeledEdge { relation: "links-to".to_string() };
+        let e = LabeledEdge {
+            relation: "links-to".to_string(),
+        };
         let json = serde_json::to_string(&e).unwrap();
         let back: LabeledEdge = serde_json::from_str(&json).unwrap();
         assert_eq!(back.relation, "links-to");
@@ -1138,7 +1172,12 @@ mod tests {
         let data = CommunityData {
             local_count: 3,
             map: std::sync::Arc::new(HashMap::from([("slug-a".to_string(), 0usize)])),
-            stats: CommunityStats { count: 1, largest: 1, smallest: 1, isolated: vec![] },
+            stats: CommunityStats {
+                count: 1,
+                largest: 1,
+                smallest: 1,
+                isolated: vec![],
+            },
         };
         assert_eq!(data.local_count, 3);
         assert_eq!(data.map.get("slug-a"), Some(&0));

--- a/src/ops/stats.rs
+++ b/src/ops/stats.rs
@@ -95,6 +95,7 @@ pub fn stats(engine: &EngineState, wiki_name: &str) -> Result<WikiStats> {
         &space.type_registry,
         &space.index_manager,
         &space.graph_cache,
+        &space.community_cache,
         &searcher,
         resolved.graph.min_nodes_for_communities,
     )?;

--- a/src/ops/suggest.rs
+++ b/src/ops/suggest.rs
@@ -213,6 +213,7 @@ pub fn suggest(
         &space.type_registry,
         &space.index_manager,
         &space.graph_cache,
+        &space.community_cache,
         &searcher,
         resolved.graph.min_nodes_for_communities,
     )? && let Some(&my_community) = community_map.get(slug.as_str())

--- a/tests/graph_cache.rs
+++ b/tests/graph_cache.rs
@@ -176,6 +176,7 @@ fn get_cached_community_map_returns_none_for_small_graph() {
         &space.type_registry,
         &space.index_manager,
         &space.graph_cache,
+        &space.community_cache,
         &searcher,
         30,
     )
@@ -199,6 +200,7 @@ fn get_cached_community_stats_returns_none_for_small_graph() {
         &space.type_registry,
         &space.index_manager,
         &space.graph_cache,
+        &space.community_cache,
         &searcher,
         30,
     )
@@ -511,6 +513,7 @@ fn get_cached_community_stats_returns_some_for_graph_above_min_nodes_threshold()
         &space.type_registry,
         &space.index_manager,
         &space.graph_cache,
+        &space.community_cache,
         &searcher,
         5,
     )
@@ -526,6 +529,7 @@ fn get_cached_community_stats_returns_some_for_graph_above_min_nodes_threshold()
         &space.type_registry,
         &space.index_manager,
         &space.graph_cache,
+        &space.community_cache,
         &searcher,
         5,
     )

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -55,7 +55,8 @@ fn build_engine(dir: &Path, wiki_root: &Path) -> EngineState {
         type_registry: registry(),
         index_schema: schema(),
         index_manager: mgr,
-        graph_cache: std::sync::RwLock::new(None),
+        graph_cache: petgraph_live::cache::GenerationCache::new(),
+        community_cache: petgraph_live::cache::GenerationCache::new(),
     });
 
     let mut spaces = HashMap::new();
@@ -387,7 +388,8 @@ fn build_engine_with_name(dir: &Path, wiki_root: &Path, name: &str) -> EngineSta
         type_registry: registry(),
         index_schema: schema(),
         index_manager: mgr,
-        graph_cache: std::sync::RwLock::new(None),
+        graph_cache: petgraph_live::cache::GenerationCache::new(),
+        community_cache: petgraph_live::cache::GenerationCache::new(),
     });
 
     let mut spaces = HashMap::new();


### PR DESCRIPTION
## Summary

- Replace bespoke `CachedGraph` + `RwLock<Option<CachedGraph>>` with `petgraph_live::GenerationCache<WikiGraph>`
- Add separate `GenerationCache<CommunityData>` for community detection results
- Rewrite cache accessor functions with nested closure pattern for hot-path efficiency
- Zero public behaviour change; all existing tests pass

## Test plan

- [x] `cargo test` — 259 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --doc` — clean
- [x] `graph_cache_hit_returns_same_arc` — verifies `GenerationCache` returns same `Arc` on hit
- [x] `graph_cache_invalidated_after_rebuild` — verifies invalidation on index rebuild