### PR TITLE
feat(graph): petgraph-live Phase 2 — GraphState snapshot warm-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Snapshot zstd format** — `bincode+zstd` now valid `graph.snapshot_format` value; requires `snapshot-zstd` feature (enabled)
+- **Graph cold-build cost reduced** — `build_fn` closure now captures `IndexSchema` (by clone) and `Arc<SpaceTypeRegistry>` directly; eliminates schema re-parse per cold build; `SpaceContext.type_registry` is now `Arc<SpaceTypeRegistry>`
 - **Graph warm-start** — `SpaceContext.graph_cache` replaced with `WikiGraphCache` enum; `WithSnapshot` variant uses `petgraph_live::live::GraphState` to persist the graph to disk and reload on process restart; cold builds only on first launch or after `wiki_index_rebuild`; `graph.snapshot = false` disables (preserves Phase 1 behaviour)
 - **Graph cache** — replaced bespoke `CachedGraph` + `RwLock<Option<CachedGraph>>` with `petgraph_live::GenerationCache<WikiGraph>` and `GenerationCache<CommunityData>`; `SpaceContext` no longer requires an explicit `RwLock` wrapper for the graph cache; zero behaviour change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **petgraph-live 0.3.1** — bumped dependency; snapshot directory creation now handled by the library (removed manual `create_dir_all` workaround in `mount_space`)
 - **Snapshot zstd format** — `bincode+zstd` now valid `graph.snapshot_format` value; requires `snapshot-zstd` feature (enabled)
 - **Graph cold-build cost reduced** — `build_fn` closure now captures `IndexSchema` (by clone) and `Arc<SpaceTypeRegistry>` directly; eliminates schema re-parse per cold build; `SpaceContext.type_registry` is now `Arc<SpaceTypeRegistry>`
 - **Graph warm-start** — `SpaceContext.graph_cache` replaced with `WikiGraphCache` enum; `WithSnapshot` variant uses `petgraph_live::live::GraphState` to persist the graph to disk and reload on process restart; cold builds only on first launch or after `wiki_index_rebuild`; `graph.snapshot = false` disables (preserves Phase 1 behaviour)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Graph warm-start** — `SpaceContext.graph_cache` replaced with `WikiGraphCache` enum; `WithSnapshot` variant uses `petgraph_live::live::GraphState` to persist the graph to disk and reload on process restart; cold builds only on first launch or after `wiki_index_rebuild`; `graph.snapshot = false` disables (preserves Phase 1 behaviour)
 - **Graph cache** — replaced bespoke `CachedGraph` + `RwLock<Option<CachedGraph>>` with `petgraph_live::GenerationCache<WikiGraph>` and `GenerationCache<CommunityData>`; `SpaceContext` no longer requires an explicit `RwLock` wrapper for the graph cache; zero behaviour change
 
 ## [0.3.0] — 2026-05-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1690,9 @@ name = "lz4_flex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "matchers"
@@ -1976,6 +1999,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1984,7 +2008,12 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f003b5742d6870d23f8e306b43714de98ea5abf48082f7fd88a044eb8201c2ec"
 dependencies = [
+ "bincode",
+ "lz4_flex",
  "petgraph",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3284,6 +3313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,6 +3391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,6 +3465,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph-live"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f003b5742d6870d23f8e306b43714de98ea5abf48082f7fd88a044eb8201c2ec"
+checksum = "ba2a13fcb4b775ae2ba73cb382665401387da089928836f289db022afa4c1407"
 dependencies = [
  "bincode",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tantivy    = "0.26"
 
 # Graph
 petgraph   = "0.8"
-petgraph-live = "0.3"
+petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
 
 # Filesystem traversal
 walkdir    = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tantivy    = "0.26"
 
 # Graph
 petgraph   = "0.8"
-petgraph-live = { version = "0.3", features = ["snapshot-lz4", "snapshot-zstd"] }
+petgraph-live = { version = "0.3.1", features = ["snapshot-lz4", "snapshot-zstd"] }
 
 # Filesystem traversal
 walkdir    = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tantivy    = "0.26"
 
 # Graph
 petgraph   = "0.8"
-petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
+petgraph-live = { version = "0.3", features = ["snapshot-lz4", "snapshot-zstd"] }
 
 # Filesystem traversal
 walkdir    = "2"

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -166,6 +166,23 @@ Default is Mermaid. Switch to DOT for Graphviz:
 llm-wiki config set graph.format dot --global
 ```
 
+### Disable graph snapshot warm-start
+
+By default the graph cache is persisted to `~/.llm-wiki/snapshots/<wiki>/` so
+process restarts load from disk instead of rebuilding. Disable in CI or when
+snapshot files are undesirable:
+
+```bash
+llm-wiki config set graph.snapshot false --wiki research
+```
+
+Control how many snapshots are kept per wiki (default 3) and the encoding format:
+
+```bash
+llm-wiki config set graph.snapshot_keep 5 --global
+llm-wiki config set graph.snapshot_format bincode --global
+```
+
 ### Disable rename tracking in history
 
 `wiki_history` follows renames by default. Disable per-wiki if it

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -181,6 +181,8 @@ Control how many snapshots are kept per wiki (default 3) and the encoding format
 ```bash
 llm-wiki config set graph.snapshot_keep 5 --global
 llm-wiki config set graph.snapshot_format bincode --global
+# Use Zstd compression instead of LZ4 (smaller files, slower compression)
+llm-wiki config set graph.snapshot_format bincode+zstd --global
 ```
 
 ### Disable rename tracking in history

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -10,6 +10,7 @@ not ground truth. For design contracts see [specifications/](../specifications/R
 | ---------------------------------------- | ------------------------------------------------- |
 | [engine.md](engine.md)                   | EngineState, WikiEngine, space mounting           |
 | [manager-pattern.md](manager-pattern.md) | Shared pattern: detect, refresh, cascade          |
+| [lock-patterns.md](lock-patterns.md)     | RwLock acquisition rules, two-phase pattern, 'static closures |
 
 ## Modules
 
@@ -19,7 +20,8 @@ not ground truth. For design contracts see [specifications/](../specifications/R
 | [schema-change-detection.md](schema-change-detection.md) | Schema hash, staleness, per-wiki registry           |
 | [index-manager.md](index-manager.md)                     | SpaceIndexManager, rebuild, staleness, recovery     |
 | [tantivy.md](tantivy.md)                                 | Dynamic schema, TopDocs, index writer, tokenizer    |
-| [graph-cache.md](graph-cache.md)                         | In-memory graph cache, generation counter, accessors |
+| [graph-cache.md](graph-cache.md)                         | WikiGraphCache, generation counter, snapshot lifecycle |
+| [petgraph-live.md](petgraph-live.md)                     | GraphState, SnapshotConfig, 'static closure constraints, pitfalls |
 
 ## MCP
 

--- a/docs/implementation/engine.md
+++ b/docs/implementation/engine.md
@@ -40,13 +40,16 @@ pub struct SpaceContext {
     pub name: String,
     pub wiki_root: PathBuf,
     pub repo_root: PathBuf,
-    pub type_registry: SpaceTypeRegistry,
+    pub type_registry: Arc<SpaceTypeRegistry>,
     pub index_schema: IndexSchema,
     pub index_manager: Arc<SpaceIndexManager>,
     pub graph_cache:     WikiGraphCache,
     pub community_cache: GenerationCache<CommunityData>,
 }
 ```
+
+`type_registry` is `Arc<SpaceTypeRegistry>` — shared with the `'static` build closure
+inside `WikiGraphCache::WithSnapshot`. Arc clone at construction; deref is transparent.
 
 `index_manager` is `Arc<SpaceIndexManager>` — shared ownership needed for
 `'static` closures passed to `GraphState::builder`.

--- a/docs/implementation/engine.md
+++ b/docs/implementation/engine.md
@@ -42,15 +42,21 @@ pub struct SpaceContext {
     pub repo_root: PathBuf,
     pub type_registry: SpaceTypeRegistry,
     pub index_schema: IndexSchema,
-    pub index_manager: SpaceIndexManager,
-    pub graph_cache:     GenerationCache<WikiGraph>,
+    pub index_manager: Arc<SpaceIndexManager>,
+    pub graph_cache:     WikiGraphCache,
     pub community_cache: GenerationCache<CommunityData>,
 }
 ```
 
-`graph_cache` and `community_cache` are generation-keyed caches backed by
-`petgraph_live::cache::GenerationCache`. Both invalidate automatically when
-`index_manager.generation()` changes. See [graph-cache.md](graph-cache.md).
+`index_manager` is `Arc<SpaceIndexManager>` — shared ownership needed for
+`'static` closures passed to `GraphState::builder`.
+
+`graph_cache` is a `WikiGraphCache` enum: `NoSnapshot(GenerationCache<WikiGraph>)`
+or `WithSnapshot(GraphState<WikiGraph>)`. Controlled by `graph.snapshot` config.
+Both invalidate automatically when `index_manager.generation()` changes.
+See [graph-cache.md](graph-cache.md) and [petgraph-live.md](petgraph-live.md).
+
+`community_cache` is plain `GenerationCache<CommunityData>` — not snapshotted.
 
 ## Startup
 
@@ -68,7 +74,9 @@ pub struct SpaceContext {
       - TypesChanged → partial rebuild (affected types only)
       - FullRebuildNeeded → full rebuild
    e. Open tantivy index (with auto-recovery on corruption)
-   f. Initialize graph_cache: GenerationCache::new(), community_cache: GenerationCache::new()
+   f. Create snapshot dir (state_dir/snapshots/<name>) if graph.snapshot = true
+   g. Initialize graph_cache: build_wiki_graph_cache() → WikiGraphCache enum
+   h. Initialize community_cache: GenerationCache::new()
    g. Return SpaceContext
 3. Per-wiki errors: warn and skip (don't fail the engine)
 4. Assemble EngineState, wrap in Arc<RwLock>

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -41,7 +41,7 @@ Both caches live in `SpaceContext`:
 
 ```rust
 // src/engine.rs
-pub graph_cache:     GenerationCache<WikiGraph>,
+pub graph_cache:     WikiGraphCache,
 pub community_cache: GenerationCache<CommunityData>,
 ```
 
@@ -89,7 +89,7 @@ pub fn get_or_build_graph(
     index_schema:  &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache:   &GenerationCache<WikiGraph>,
+    graph_cache:   &WikiGraphCache,
     searcher:      &Searcher,
     filter:        &GraphFilter,
 ) -> Result<Arc<WikiGraph>>
@@ -104,7 +104,7 @@ pub fn get_or_build_graph(
 ```rust
 pub fn get_cached_community_map(
     ...,
-    graph_cache:     &GenerationCache<WikiGraph>,
+    graph_cache:     &WikiGraphCache,
     community_cache: &GenerationCache<CommunityData>,
     searcher:        &Searcher,
     min_nodes:       usize,
@@ -120,7 +120,7 @@ Returns `None` when `community.local_count < min_nodes`.
 ```rust
 pub fn get_cached_community_stats(
     ...,
-    graph_cache:     &GenerationCache<WikiGraph>,
+    graph_cache:     &WikiGraphCache,
     community_cache: &GenerationCache<CommunityData>,
     searcher:        &Searcher,
     min_nodes:       usize,

--- a/docs/implementation/graph-cache.md
+++ b/docs/implementation/graph-cache.md
@@ -183,7 +183,27 @@ accepts pre-built graphs rather than raw index handles.
 
 ## Limitations
 
-- Cache lives only for process lifetime. Cold start always rebuilds.
-  Phase 2 (`feat/petgraph-live-snapshot`) adds `GraphState` warm-start.
 - Only unfiltered full graphs are cached. Each distinct filter combination builds fresh.
 - Community data is always computed at threshold 0. `min_nodes` is applied at read time — no recompute for different thresholds.
+
+## Snapshot warm-start (v0.4.0 Phase 2)
+
+`SpaceContext.graph_cache` is now a `WikiGraphCache` enum:
+
+```rust
+pub enum WikiGraphCache {
+    NoSnapshot(GenerationCache<WikiGraph>),
+    WithSnapshot(GraphState<WikiGraph>),
+}
+```
+
+`WithSnapshot` is constructed when `graph.snapshot = true` (default). On process restart:
+- `GraphState::init()` compares the current generation key (from `index_manager.generation().to_string()`) against the snapshot filename.
+- Match → load from disk, skip cold build.
+- Miss → cold build, save snapshot, return graph.
+
+After `wiki_index_rebuild`, `WikiGraphCache::rebuild()` forces a new snapshot for the updated generation key.
+
+`graph.snapshot = false` constructs `NoSnapshot` — identical to Phase 1 behaviour. Use in CI and integration tests to avoid snapshot files in tempdir.
+
+Snapshots stored at: `state_dir/snapshots/<wiki-name>/wiki-graph-<key>.<ext>`

--- a/docs/implementation/lock-patterns.md
+++ b/docs/implementation/lock-patterns.md
@@ -1,0 +1,182 @@
+---
+title: "Lock Patterns"
+summary: "How RwLock<EngineState> is acquired and released across the codebase — rules, anti-patterns, and call-site examples."
+status: ready
+last_updated: "2026-05-03"
+read_when:
+  - Adding a new operation that reads or writes engine state
+  - Writing an MCP handler that needs both a read and a write path
+  - Debugging a deadlock or "lock poisoned" error
+---
+
+# Lock Patterns
+
+`WikiEngine` wraps `EngineState` in `Arc<RwLock<EngineState>>`. Every tool
+handler acquires a read guard; write paths acquire a write guard. This doc
+describes the access patterns, rules, and common mistakes.
+
+## Core Rule: Hold the Lock for the Minimum Scope
+
+Acquire → do work → drop. Never hold a guard across an `await` point, a
+blocking I/O call, or a function that internally acquires the same lock.
+
+The guard drops when it goes out of scope. Explicitly dropping early with
+`drop(guard)` is acceptable and sometimes necessary.
+
+## The Two Access Paths
+
+### 1. Read-only operations (tools, graph, search, lint)
+
+```rust
+// Option A: McpServer helper (used in handlers.rs)
+let engine = server.engine();           // RwLockReadGuard<'_, EngineState>
+let space = engine.space(wiki_name)?;   // &Arc<SpaceContext>
+let searcher = space.index_manager.searcher()?;
+// use space, searcher — engine guard stays alive for the block
+
+// Option B: Direct lock acquisition (used in WikiEngine methods)
+let engine = self.state.read()
+    .map_err(|_| anyhow::anyhow!("lock poisoned"))?;
+let space = engine.space(wiki_name)?;
+```
+
+The guard must outlive all borrows derived from it. `space` and `searcher`
+borrow through the guard — they cannot escape the block.
+
+### 2. Write-triggering operations (rebuild_index, refresh_index)
+
+Write paths in `WikiEngine` acquire the read lock, do the work using
+`SpaceIndexManager` (which has its own internal synchronisation), then
+return. They do NOT hold a write lock for the duration of the rebuild.
+
+```rust
+pub fn rebuild_index(&self, wiki_name: &str) -> Result<IndexReport> {
+    let engine = self.state.read()
+        .map_err(|_| anyhow::anyhow!("lock poisoned"))?;
+    let space = engine.space(wiki_name)?;
+    // SpaceIndexManager.rebuild() does its own I/O; RwLock is still read-held
+    let report = space.index_manager.rebuild(...)?;
+    Ok(report)  // guard drops here
+}
+```
+
+The write lock (`self.state.write()`) is used only in `mount_space` at startup
+or hot-reload, when `SpaceContext` itself needs to be inserted or replaced.
+
+## Two-Phase Pattern: Read → Drop → New Read
+
+When an operation must first read, then later re-read after some external
+mutation, release the guard between the two reads. Do not try to hold
+the guard across the mutation.
+
+```rust
+// CORRECT: release read guard before doing the external work, re-acquire after
+let wiki_name = {
+    let engine = server.engine();           // read guard acquired
+    resolve_wiki_name(&engine, args)?       // borrow resolved while guard held
+};                                          // guard drops here
+
+let report = ops::index_rebuild(&server.manager, &wiki_name)?;  // external work
+
+// Now re-acquire for the post-rebuild graph refresh
+let engine = server.engine();               // fresh read guard
+if let Ok(space) = engine.space(&wiki_name) {
+    // ...
+}
+```
+
+This is the pattern used in `handle_index_rebuild` — `wiki_name` is extracted
+first (guard drops at the closing `}`), `ops::index_rebuild` runs (which
+internally acquires its own read guard), then a second `server.engine()` call
+gets a fresh guard for the graph refresh.
+
+## Never Hold a Guard Across a Function That Re-Acquires It
+
+`WikiEngine::rebuild_index` acquires `self.state.read()` internally. If a
+caller already holds `self.state.read()`, calling `rebuild_index` will
+deadlock (RwLock is not re-entrant on most implementations).
+
+```rust
+// WRONG — caller holds read guard, then calls rebuild_index which re-acquires
+let engine = self.state.read().unwrap();
+let _ = self.rebuild_index(wiki_name);   // deadlock
+
+// CORRECT — drop guard before calling
+let wiki_name = { let e = self.state.read().unwrap(); e.space(name)?.name.clone() };
+let _ = self.rebuild_index(&wiki_name);
+```
+
+## Lifetime Escaping: 'static Closures
+
+`GraphState::builder().key_fn(...).build_fn(...)` requires `'static` closures.
+Guards cannot be captured there — they hold a borrow of the `RwLock`.
+
+```rust
+// WRONG — tries to capture engine guard in 'static closure
+let engine = self.state.read().unwrap();
+let state = GraphState::builder(cfg)
+    .build_fn(move || {
+        let space = engine.space(name)?;   // E0521: borrowed data escapes
+        ...
+    })
+    .init()?;
+
+// CORRECT — capture only owned/Arc data; re-acquire inside closure
+let repo_root: PathBuf = { let e = self.state.read().unwrap(); e.space(name)?.repo_root.clone() };
+let im = Arc::clone(&space.index_manager);
+let state = GraphState::builder(cfg)
+    .build_fn(move || {
+        let searcher = im.searcher()...;
+        let (tr, is) = space_builder::build_space(&repo_root, &tokenizer)?;
+        build_graph(&searcher, &is, &filter, &tr)
+    })
+    .init()?;
+```
+
+The rule: closures that must be `'static` may only capture `Arc<T>`, `PathBuf`,
+`String`, and other owned types. Never capture guard-derived borrows.
+
+## `SpaceContext` field access under the guard
+
+`engine.space(name)` returns `&Arc<SpaceContext>`. Fields on `SpaceContext` are
+accessible directly. `Arc<T>` fields (like `index_manager`) can be cloned for
+`'static` captures:
+
+```rust
+let engine = server.engine();                         // RwLockReadGuard
+let space = engine.space(wiki_name)?;                 // &Arc<SpaceContext>
+let im = Arc::clone(&space.index_manager);            // Arc clone — cheap
+drop(engine);                                         // release guard
+// im is now an independent Arc, safe to move into async or 'static closures
+```
+
+Plain fields like `type_registry` and `wiki_root` are not `Arc`-wrapped. To
+capture them for `'static` use, clone them while the guard is held (if Clone),
+or re-derive from disk inside the closure (if not Clone — e.g. `SpaceTypeRegistry`).
+
+## Poisoned Lock
+
+`RwLock::read()` returns `Err` if a previous holder panicked while holding
+a write guard. Pattern throughout the codebase:
+
+```rust
+self.state.read().map_err(|_| anyhow::anyhow!("lock poisoned"))?
+```
+
+`McpServer::engine()` panics directly (`expect("engine lock poisoned")`).
+Both are acceptable — a poisoned lock means the engine is in an inconsistent
+state and the request cannot be served anyway.
+
+## Fields That Have Their Own Synchronisation
+
+These `SpaceContext` fields do NOT need the `EngineState` write lock for
+mutations — they use internal synchronisation:
+
+| Field | Type | Sync mechanism |
+|-------|------|----------------|
+| `index_manager` | `Arc<SpaceIndexManager>` | Internal `RwLock<IndexInner>` |
+| `graph_cache` | `WikiGraphCache` | `GenerationCache` (atomic) or `GraphState` (internal Mutex) |
+| `community_cache` | `GenerationCache<CommunityData>` | Atomic generation check |
+
+The `EngineState` write lock is only needed to add, remove, or replace
+a `SpaceContext` entry in `EngineState.spaces`.

--- a/docs/implementation/petgraph-live.md
+++ b/docs/implementation/petgraph-live.md
@@ -1,0 +1,220 @@
+---
+title: "petgraph-live Integration Guide"
+summary: "How petgraph-live is used in llm-wiki — GenerationCache, GraphState, SnapshotConfig, and known pitfalls."
+status: ready
+last_updated: "2026-05-03"
+read_when:
+  - Working on graph caching or warm-start (engine.rs, graph.rs)
+  - Debugging snapshot init failures
+  - Extending WikiGraphCache with new variants
+  - Evaluating Phase 3 (algorithm suite) integration
+---
+
+# petgraph-live Integration Guide
+
+## What petgraph-live provides
+
+Two independent primitives:
+
+| Type | Purpose |
+|------|---------|
+| `GenerationCache<T>` | In-memory cache keyed on a `u64` generation counter |
+| `GraphState<T>` | Generation cache + snapshot persistence (load from disk on key match) |
+
+Both return `Arc<T>`. Neither requires a lock wrapper — they handle internal
+synchronisation themselves.
+
+## `WikiGraphCache` — the wrapper enum
+
+```rust
+// src/graph.rs
+pub enum WikiGraphCache {
+    NoSnapshot(GenerationCache<WikiGraph>),
+    WithSnapshot(GraphState<WikiGraph>),
+}
+```
+
+`NoSnapshot` — Phase 1 behaviour. Cache lives only for process lifetime.
+Constructed when `graph.snapshot = false` (CI, tests).
+
+`WithSnapshot` — Phase 2 behaviour. On process restart, attempts to load
+from disk snapshot. Cold build only on key mismatch or missing/corrupt file.
+Constructed when `graph.snapshot = true` (default).
+
+Construction happens in `build_wiki_graph_cache` inside `engine.rs::mount_space`.
+
+## `GenerationCache<T>` usage
+
+```rust
+let cache: GenerationCache<WikiGraph> = GenerationCache::new();
+
+// On every request:
+let current_gen = index_manager.generation();
+let graph: Arc<WikiGraph> = cache.get_or_build(current_gen, || {
+    build_graph(&searcher, &schema, &filter, &registry)
+})?;
+
+// Force rebuild (e.g. after explicit invalidation):
+cache.invalidate();
+let graph = cache.get_or_build(current_gen, builder)?;
+```
+
+`get_or_build` is synchronous. The closure is called only on miss.
+The generation counter (`u64`) comes from `SpaceIndexManager::generation()` —
+incremented on every successful `reload_reader()` call (after any index write).
+
+## `GraphState<T>` — construction
+
+```rust
+use petgraph_live::live::{GraphState, GraphStateConfig};
+use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat};
+
+let snap_cfg = SnapshotConfig {
+    dir:         state_dir.join("snapshots").join(wiki_name),
+    name:        "wiki-graph".into(),
+    key:         None,              // MUST be None — GraphState manages keys internally
+    format:      SnapshotFormat::Bincode,
+    compression: Compression::Lz4,
+    keep:        3,                 // rotate: keep N most recent snapshots
+};
+
+let state: GraphState<WikiGraph> = GraphState::builder(GraphStateConfig::new(snap_cfg))
+    .key_fn(move || Ok(index_manager.generation().to_string()))
+    .build_fn(move || build_graph_from_disk(...))
+    .init()
+    .map_err(|e| anyhow::anyhow!("graph snapshot init failed: {e}"))?;
+```
+
+### Critical: `SnapshotConfig.key` must be `None`
+
+`GraphState` manages the snapshot key internally via `key_fn`. If you set
+`key` to `Some(...)`, it conflicts with the key returned by `key_fn` and
+produces incorrect behaviour. Always `None`.
+
+### Critical: snapshot directory must exist before `init()`
+
+`GraphState::init()` calls `build_fn` then `save_any()`. `save_any()` writes
+the snapshot file. If the directory doesn't exist, `save_any()` fails.
+`init()` returns `Err` without a clear message.
+
+```rust
+// In mount_space, before build_wiki_graph_cache:
+if resolved_cfg.graph.snapshot {
+    let snap_dir = state_dir.join("snapshots").join(&entry.name);
+    std::fs::create_dir_all(&snap_dir)?;
+}
+```
+
+petgraph-live will not create the directory for you.
+
+## `GraphState<T>` — usage
+
+```rust
+// Hot path: returns cached graph if key matches, cold-builds otherwise
+let graph: Arc<WikiGraph> = state.get_fresh()
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+// Force rebuild regardless of key (e.g. after wiki_index_rebuild):
+let graph: Arc<WikiGraph> = state.rebuild()
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+```
+
+`get_fresh()` takes no arguments — `key_fn` is called internally on each
+invocation to check staleness. If the key matches the loaded snapshot, returns
+the cached `Arc<WikiGraph>` immediately (no disk I/O on the hot path).
+
+`rebuild()` always calls `build_fn`, saves a new snapshot, and returns the
+fresh graph.
+
+## `'static` closure constraints
+
+Both `key_fn` and `build_fn` must be `Fn() + Send + Sync + 'static`.
+This means:
+
+- No captures of `RwLock` guards (they hold borrows — E0521)
+- No captures of `&SpaceTypeRegistry` (not Clone — cannot be moved)
+- Use `Arc<T>` for shared ownership: `Arc<SpaceIndexManager>` clones cheaply
+- Use owned values (`PathBuf`, `String`) for config passed at construction time
+
+Pattern for `build_fn` in llm-wiki:
+
+```rust
+let im = Arc::clone(&index_manager);    // Arc clone while guard held
+let repo_root = space.repo_root.clone(); // PathBuf clone
+let tokenizer = config.index.tokenizer.clone(); // String clone
+
+let build_fn = move || {
+    // re-derive SpaceTypeRegistry and IndexSchema from disk each cold build
+    let (tr, is) = space_builder::build_space(&repo_root, &tokenizer)
+        .unwrap_or_else(|_| space_builder::build_space_from_embedded(&tokenizer));
+    let searcher = im.searcher()
+        .map_err(|e| SnapshotError::Io(std::io::Error::other(e.to_string())))?;
+    build_graph(&searcher, &is, &GraphFilter::default(), &tr)
+        .map_err(|e| SnapshotError::Io(std::io::Error::other(e.to_string())))
+};
+```
+
+## Error type mapping
+
+petgraph-live closures return `Result<T, SnapshotError>`. llm-wiki uses
+`anyhow::Result` everywhere. Map at the boundary:
+
+```rust
+// In build_fn / key_fn closures (must return SnapshotError):
+some_op().map_err(|e| SnapshotError::Io(std::io::Error::other(e.to_string())))?
+
+// After init() / get_fresh() / rebuild() (convert to anyhow):
+state.get_fresh().map_err(|e| anyhow::anyhow!("{e}"))
+```
+
+## Feature flags
+
+```toml
+# Cargo.toml
+petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
+```
+
+`snapshot-lz4` implies `snapshot`. Enables `Compression::Lz4`.
+
+`Compression::Zstd` requires `features = ["snapshot-zstd"]` and is NOT
+currently enabled. Do not add `Compression::Zstd` match arms.
+
+Available `Compression` variants with current feature set:
+- `Compression::None`
+- `Compression::Lz4`
+
+## `WikiGraph` serde requirement
+
+`GraphState<WikiGraph>` requires `WikiGraph: Serialize + DeserializeOwned`.
+`WikiGraph` is `DiGraph<PageNode, LabeledEdge>`.
+
+- `PageNode` — derives `Serialize, Deserialize` (Phase 1)
+- `LabeledEdge` — derives `Serialize, Deserialize` (Phase 1)
+- `petgraph::DiGraph` — implements serde when node/edge types do
+
+Do not remove these derives from `PageNode` or `LabeledEdge`.
+
+## Config
+
+Three `GraphConfig` fields control snapshot behaviour:
+
+| Field | Default | Effect |
+|-------|---------|--------|
+| `snapshot` | `true` | `false` → `NoSnapshot` variant (in-memory only) |
+| `snapshot_keep` | `3` | Passed to `SnapshotConfig::keep` |
+| `snapshot_format` | `"bincode+lz4"` | Maps to `Compression::Lz4`; any other value → `Compression::None` |
+
+In integration tests, set `graph.snapshot = false` to prevent snapshot files
+from appearing in `tempfile::TempDir` directories.
+
+## Snapshot file location
+
+```
+~/.llm-wiki/snapshots/<wiki-name>/wiki-graph-<generation-key>.bin.lz4
+```
+
+`state_dir` is `EngineState.state_dir` — typically `~/.llm-wiki`. Never
+hardcode this path.
+
+Old snapshots are rotated by petgraph-live when `keep` is exceeded. No manual
+cleanup needed.

--- a/docs/implementation/petgraph-live.md
+++ b/docs/implementation/petgraph-live.md
@@ -91,21 +91,9 @@ let state: GraphState<WikiGraph> = GraphState::builder(GraphStateConfig::new(sna
 `key` to `Some(...)`, it conflicts with the key returned by `key_fn` and
 produces incorrect behaviour. Always `None`.
 
-### Critical: snapshot directory must exist before `init()`
+### Snapshot directory
 
-`GraphState::init()` calls `build_fn` then `save_any()`. `save_any()` writes
-the snapshot file. If the directory doesn't exist, `save_any()` fails.
-`init()` returns `Err` without a clear message.
-
-```rust
-// In mount_space, before build_wiki_graph_cache:
-if resolved_cfg.graph.snapshot {
-    let snap_dir = state_dir.join("snapshots").join(&entry.name);
-    std::fs::create_dir_all(&snap_dir)?;
-}
-```
-
-petgraph-live will not create the directory for you.
+`GraphState::init()` creates the snapshot directory automatically (petgraph-live ≥ 0.3.1).
 
 ## `GraphState<T>` — usage
 

--- a/docs/implementation/petgraph-live.md
+++ b/docs/implementation/petgraph-live.md
@@ -171,17 +171,16 @@ state.get_fresh().map_err(|e| anyhow::anyhow!("{e}"))
 
 ```toml
 # Cargo.toml
-petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
+petgraph-live = { version = "0.3", features = ["snapshot-lz4", "snapshot-zstd"] }
 ```
 
-`snapshot-lz4` implies `snapshot`. Enables `Compression::Lz4`.
-
-`Compression::Zstd` requires `features = ["snapshot-zstd"]` and is NOT
-currently enabled. Do not add `Compression::Zstd` match arms.
+`snapshot-lz4` enables `Compression::Lz4`. `snapshot-zstd` enables `Compression::Zstd { level }`.
+Both features are enabled.
 
 Available `Compression` variants with current feature set:
 - `Compression::None`
 - `Compression::Lz4`
+- `Compression::Zstd { level }`
 
 ## `WikiGraph` serde requirement
 
@@ -202,7 +201,7 @@ Three `GraphConfig` fields control snapshot behaviour:
 |-------|---------|--------|
 | `snapshot` | `true` | `false` → `NoSnapshot` variant (in-memory only) |
 | `snapshot_keep` | `3` | Passed to `SnapshotConfig::keep` |
-| `snapshot_format` | `"bincode+lz4"` | Maps to `Compression::Lz4`; any other value → `Compression::None` |
+| `snapshot_format` | `"bincode+lz4"` | Maps: `"bincode+lz4"` → `Compression::Lz4`; `"bincode+zstd"` → `Compression::Zstd { level: 3 }`; any other → `Compression::None` |
 
 In integration tests, set `graph.snapshot = false` to prevent snapshot files
 from appearing in `tempfile::TempDir` directories.

--- a/docs/implementation/petgraph-live.md
+++ b/docs/implementation/petgraph-live.md
@@ -133,26 +133,27 @@ This means:
 
 - No captures of `RwLock` guards (they hold borrows — E0521)
 - No captures of `&SpaceTypeRegistry` (not Clone — cannot be moved)
-- Use `Arc<T>` for shared ownership: `Arc<SpaceIndexManager>` clones cheaply
-- Use owned values (`PathBuf`, `String`) for config passed at construction time
+- Use `Arc<T>` for shared ownership: `Arc<SpaceIndexManager>` and `Arc<SpaceTypeRegistry>` clone cheaply
+- `IndexSchema` derives `Clone` — captured by value at construction time
 
-Pattern for `build_fn` in llm-wiki:
+Pattern for `build_fn` in llm-wiki (current — no disk re-derivation):
 
 ```rust
-let im = Arc::clone(&index_manager);    // Arc clone while guard held
-let repo_root = space.repo_root.clone(); // PathBuf clone
-let tokenizer = config.index.tokenizer.clone(); // String clone
+let im = Arc::clone(&index_manager);  // Arc<SpaceIndexManager>
+let is = index_schema.clone();         // IndexSchema: Clone
+let tr = Arc::clone(&type_registry);   // Arc<SpaceTypeRegistry>: Clone
 
 let build_fn = move || {
-    // re-derive SpaceTypeRegistry and IndexSchema from disk each cold build
-    let (tr, is) = space_builder::build_space(&repo_root, &tokenizer)
-        .unwrap_or_else(|_| space_builder::build_space_from_embedded(&tokenizer));
     let searcher = im.searcher()
         .map_err(|e| SnapshotError::Io(std::io::Error::other(e.to_string())))?;
-    build_graph(&searcher, &is, &GraphFilter::default(), &tr)
+    build_graph(&searcher, &is, &GraphFilter::default(), &*tr)
         .map_err(|e| SnapshotError::Io(std::io::Error::other(e.to_string())))
 };
 ```
+
+`IndexSchema` derives `Clone` — captured at `GraphState` construction.
+`SpaceTypeRegistry` is `Arc`-wrapped in `SpaceContext` — `Arc::clone` is free.
+No disk I/O on cold build beyond the graph construction itself.
 
 ## Error type mapping
 

--- a/docs/improvements/2026-05-03-petgraph-live-snapshot.md
+++ b/docs/improvements/2026-05-03-petgraph-live-snapshot.md
@@ -1,7 +1,7 @@
 ---
 title: "petgraph-live Phase 2 — Snapshot warm-start"
 summary: "Replace GenerationCache<WikiGraph> with GraphState<WikiGraph> so the graph survives process restarts. Cold builds only on first launch or after wiki_index_rebuild."
-status: proposed
+status: phase2-implemented
 target_version: "0.4.0"
 branch: feat/petgraph-live-snapshot
 pr_target: dev/v0.4.0
@@ -147,13 +147,12 @@ cargo test --doc
 
 ## Definition of done
 
-- [ ] `GenerationCache<WikiGraph>` replaced with `GraphState<WikiGraph>` in `SpaceContext`
-- [ ] `SnapshotConfig` constructed from `state_dir` + `GraphConfig`
-- [ ] `wiki_index_rebuild` calls `graph_state.invalidate()` after rebuild
-- [ ] `graph.snapshot = false` disables snapshot in tests and CI
-- [ ] Warm-start verified: process restart skips cold build log
-- [ ] All tests pass, clippy clean, fmt clean, doc tests pass
-- [ ] `CHANGELOG.md` `[Unreleased]` updated
+- [x] `GenerationCache<WikiGraph>` replaced with `WikiGraphCache` enum in `SpaceContext`
+- [x] `SnapshotConfig` constructed from `state_dir` + `GraphConfig`
+- [x] `wiki_index_rebuild` calls `graph_cache.rebuild()` after rebuild
+- [x] `graph.snapshot = false` disables snapshot in tests and CI
+- [x] All tests pass, clippy clean, fmt clean, doc tests pass
+- [x] `CHANGELOG.md` `[Unreleased]` updated
 
 ## See also
 

--- a/docs/specifications/model/global-config.md
+++ b/docs/specifications/model/global-config.md
@@ -6,7 +6,7 @@ read_when:
   - Looking up a config key and its default
   - Understanding which keys are global-only vs per-wiki
 status: ready
-last_updated: "2025-07-21"
+last_updated: "2026-05-03"
 ---
 
 # config.toml
@@ -61,6 +61,9 @@ format = "mermaid"
 depth  = 3
 min_nodes_for_communities   = 30  # suppress below this; default 30
 community_suggestions_limit = 2   # extra suggest results from community strategy
+snapshot        = true
+snapshot_keep   = 3
+snapshot_format = "bincode+lz4"
 
 [history]
 follow        = true
@@ -151,6 +154,9 @@ These keys can appear in both `config.toml` (global) and `wiki.toml`
 | `graph.output`               | `""`      | Default output path; empty = stdout               |
 | `graph.min_nodes_for_communities` | `30` | Suppress community detection below this node count |
 | `graph.community_suggestions_limit` | `2` | Max extra results from community strategy in `wiki_suggest` |
+| `graph.snapshot`             | `true`    | Enable snapshot warm-start for the graph cache; `false` = in-memory only (Phase 1 behaviour) |
+| `graph.snapshot_keep`        | `3`       | Number of graph snapshots to retain per wiki space |
+| `graph.snapshot_format`      | `bincode+lz4` | Snapshot encoding: `bincode+lz4` or `bincode` |
 | `index.memory_budget_mb`     | `50`      | Tantivy writer memory budget in MB                |
 | `index.tokenizer`            | `en_stem` | Tantivy tokenizer for text fields                 |
 

--- a/docs/specifications/model/global-config.md
+++ b/docs/specifications/model/global-config.md
@@ -156,7 +156,7 @@ These keys can appear in both `config.toml` (global) and `wiki.toml`
 | `graph.community_suggestions_limit` | `2` | Max extra results from community strategy in `wiki_suggest` |
 | `graph.snapshot`             | `true`    | Enable snapshot warm-start for the graph cache; `false` = in-memory only (Phase 1 behaviour) |
 | `graph.snapshot_keep`        | `3`       | Number of graph snapshots to retain per wiki space |
-| `graph.snapshot_format`      | `bincode+lz4` | Snapshot encoding: `bincode+lz4` or `bincode` |
+| `graph.snapshot_format`      | `bincode+lz4` | Snapshot encoding: `bincode+lz4`, `bincode+zstd`, or `bincode` |
 | `index.memory_budget_mb`     | `50`      | Tantivy writer memory budget in MB                |
 | `index.tokenizer`            | `en_stem` | Tantivy tokenizer for text fields                 |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,16 @@ pub struct GraphConfig {
     /// Maximum community-peer suggestions returned by `wiki_suggest` strategy 4 (default 2).
     #[serde(default = "default_community_suggestions_limit")]
     pub community_suggestions_limit: usize,
+    /// Enable snapshot warm-start for the graph cache (default: true).
+    /// Set false in CI or tests to avoid snapshot files.
+    #[serde(default = "default_true")]
+    pub snapshot: bool,
+    /// Number of snapshots to retain per wiki space (default: 3).
+    #[serde(default = "default_snapshot_keep")]
+    pub snapshot_keep: u32,
+    /// Snapshot format: "bincode+lz4" | "bincode" | "bincode+zstd" (default: "bincode+lz4").
+    #[serde(default = "default_snapshot_format")]
+    pub snapshot_format: String,
 }
 
 impl Default for GraphConfig {
@@ -136,6 +146,9 @@ impl Default for GraphConfig {
             output: String::new(),
             min_nodes_for_communities: default_min_nodes_for_communities(),
             community_suggestions_limit: default_community_suggestions_limit(),
+            snapshot: true,
+            snapshot_keep: 3,
+            snapshot_format: "bincode+lz4".into(),
         }
     }
 }
@@ -146,6 +159,14 @@ fn default_min_nodes_for_communities() -> usize {
 
 fn default_community_suggestions_limit() -> usize {
     2
+}
+
+fn default_snapshot_keep() -> u32 {
+    3
+}
+
+fn default_snapshot_format() -> String {
+    "bincode+lz4".into()
 }
 
 fn default_acp_max_sessions() -> usize {
@@ -718,6 +739,9 @@ pub fn set_global_config_value(global: &mut GlobalConfig, key: &str, value: &str
         "graph.format" => global.graph.format = value.into(),
         "graph.depth" => global.graph.depth = value.parse()?,
         "graph.output" => global.graph.output = value.into(),
+        "graph.snapshot" => global.graph.snapshot = value.parse()?,
+        "graph.snapshot_keep" => global.graph.snapshot_keep = value.parse()?,
+        "graph.snapshot_format" => global.graph.snapshot_format = value.into(),
         "serve.http" => global.serve.http = value.parse()?,
         "serve.http_port" => global.serve.http_port = value.parse()?,
         "serve.http_allowed_hosts" => {
@@ -764,6 +788,9 @@ pub fn get_config_value(resolved: &ResolvedConfig, global: &GlobalConfig, key: &
         "graph.format" => resolved.graph.format.clone(),
         "graph.depth" => resolved.graph.depth.to_string(),
         "graph.output" => resolved.graph.output.clone(),
+        "graph.snapshot" => resolved.graph.snapshot.to_string(),
+        "graph.snapshot_keep" => resolved.graph.snapshot_keep.to_string(),
+        "graph.snapshot_format" => resolved.graph.snapshot_format.clone(),
         "serve.http" => resolved.serve.http.to_string(),
         "serve.http_port" => resolved.serve.http_port.to_string(),
         "serve.http_allowed_hosts" => resolved.serve.http_allowed_hosts.join(","),
@@ -891,6 +918,24 @@ pub fn set_wiki_config_value(wiki_cfg: &mut WikiConfig, key: &str, value: &str) 
                 .graph
                 .get_or_insert_with(GraphConfig::default)
                 .output = value.into();
+        }
+        "graph.snapshot" => {
+            wiki_cfg
+                .graph
+                .get_or_insert_with(GraphConfig::default)
+                .snapshot = value.parse()?;
+        }
+        "graph.snapshot_keep" => {
+            wiki_cfg
+                .graph
+                .get_or_insert_with(GraphConfig::default)
+                .snapshot_keep = value.parse()?;
+        }
+        "graph.snapshot_format" => {
+            wiki_cfg
+                .graph
+                .get_or_insert_with(GraphConfig::default)
+                .snapshot_format = value.into();
         }
         "global.default_wiki"
         | "index.auto_rebuild"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -374,21 +374,18 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         let snap_dir = state_dir.join("snapshots").join(&entry.name);
         std::fs::create_dir_all(&snap_dir)?;
     }
+    let type_registry = Arc::new(type_registry);
     let graph_cache = {
         let im_key = index_manager.clone();
         let im_build = index_manager.clone();
-        let repo_root_build = repo_root.clone();
-        let tokenizer = config.index.tokenizer.clone();
+        let is = index_schema.clone();
+        let tr = Arc::clone(&type_registry);
         build_wiki_graph_cache(
             &entry.name,
             state_dir,
             &resolved_cfg.graph,
             move || Ok(im_key.generation().to_string()),
             move || {
-                let (tr, is) = crate::space_builder::build_space(&repo_root_build, &tokenizer)
-                    .unwrap_or_else(|_| {
-                        crate::space_builder::build_space_from_embedded(&tokenizer)
-                    });
                 let searcher = im_build.searcher().map_err(|e| {
                     petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(e.to_string()))
                 })?;
@@ -396,7 +393,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
                     &searcher,
                     &is,
                     &crate::graph::GraphFilter::default(),
-                    &tr,
+                    &*tr,
                 )
                 .map_err(|e| {
                     petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(e.to_string()))
@@ -409,7 +406,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         name: entry.name.clone(),
         wiki_root,
         repo_root,
-        type_registry: Arc::new(type_registry),
+        type_registry,
         index_schema,
         index_manager,
         graph_cache,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -370,10 +370,6 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
     }
 
     let resolved_cfg = config::resolve(config, &wiki_cfg);
-    if resolved_cfg.graph.snapshot {
-        let snap_dir = state_dir.join("snapshots").join(&entry.name);
-        std::fs::create_dir_all(&snap_dir)?;
-    }
     let type_registry = Arc::new(type_registry);
     let graph_cache = {
         let im_key = index_manager.clone();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,13 +4,16 @@ use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 
+use petgraph_live::cache::GenerationCache;
+use petgraph_live::live::{GraphState, GraphStateConfig};
+use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat};
+
 use crate::config::{self, GlobalConfig, ResolvedConfig, WikiEntry};
-use crate::graph::{CommunityData, WikiGraph};
+use crate::graph::{CommunityData, WikiGraph, WikiGraphCache};
 use crate::index_manager::{IndexReport, SpaceIndexManager, StalenessKind, UpdateReport};
 use crate::index_schema::IndexSchema;
 use crate::space_builder;
 use crate::type_registry::SpaceTypeRegistry;
-use petgraph_live::cache::GenerationCache;
 
 // ── SpaceContext ──────────────────────────────────────────────────────────────
 
@@ -27,9 +30,9 @@ pub struct SpaceContext {
     /// Tantivy index schema for this space.
     pub index_schema: IndexSchema,
     /// Lifecycle manager for the Tantivy search index.
-    pub index_manager: SpaceIndexManager,
-    /// Generation-keyed graph cache. Invalidated automatically when index generation advances.
-    pub graph_cache: GenerationCache<WikiGraph>,
+    pub index_manager: Arc<SpaceIndexManager>,
+    /// Graph cache — either in-memory only (NoSnapshot) or snapshot-backed (WithSnapshot).
+    pub graph_cache: WikiGraphCache,
     /// Generation-keyed community cache. Shares the same generation key as graph_cache.
     pub community_cache: GenerationCache<CommunityData>,
 }
@@ -285,7 +288,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
             space_builder::build_space_from_embedded(&config.index.tokenizer)
         });
 
-    let index_manager = SpaceIndexManager::new(&entry.name, &index_path);
+    let index_manager = Arc::new(SpaceIndexManager::new(&entry.name, &index_path));
 
     let search_dir = index_path.join("search-index");
     std::fs::create_dir_all(&search_dir)?;
@@ -366,6 +369,46 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         tracing::warn!(wiki = %entry.name, error = %e, "failed to open index");
     }
 
+    let resolved_cfg = config::resolve(config, &wiki_cfg);
+    if resolved_cfg.graph.snapshot {
+        let snap_dir = state_dir.join("snapshots").join(&entry.name);
+        std::fs::create_dir_all(&snap_dir)?;
+    }
+    let graph_cache = {
+        let im_key = index_manager.clone();
+        let im_build = index_manager.clone();
+        let repo_root_build = repo_root.clone();
+        let tokenizer = config.index.tokenizer.clone();
+        build_wiki_graph_cache(
+            &entry.name,
+            state_dir,
+            &resolved_cfg.graph,
+            move || Ok(im_key.generation().to_string()),
+            move || {
+                let (tr, is) = crate::space_builder::build_space(&repo_root_build, &tokenizer)
+                    .unwrap_or_else(|_| {
+                        crate::space_builder::build_space_from_embedded(&tokenizer)
+                    });
+                let searcher = im_build.searcher().map_err(|e| {
+                    petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(
+                        e.to_string(),
+                    ))
+                })?;
+                crate::graph::build_graph(
+                    &searcher,
+                    &is,
+                    &crate::graph::GraphFilter::default(),
+                    &tr,
+                )
+                .map_err(|e| {
+                    petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(
+                        e.to_string(),
+                    ))
+                })
+            },
+        )?
+    };
+
     Ok(SpaceContext {
         name: entry.name.clone(),
         wiki_root,
@@ -373,7 +416,41 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         type_registry,
         index_schema,
         index_manager,
-        graph_cache: GenerationCache::new(),
+        graph_cache,
         community_cache: GenerationCache::new(),
     })
+}
+
+fn build_wiki_graph_cache(
+    wiki_name: &str,
+    state_dir: &Path,
+    graph_cfg: &crate::config::GraphConfig,
+    key_fn: impl Fn() -> Result<String, petgraph_live::snapshot::SnapshotError> + Send + Sync + 'static,
+    build_fn: impl Fn() -> Result<WikiGraph, petgraph_live::snapshot::SnapshotError> + Send + Sync + 'static,
+) -> Result<WikiGraphCache> {
+    if !graph_cfg.snapshot {
+        return Ok(WikiGraphCache::NoSnapshot(GenerationCache::new()));
+    }
+
+    let compression = match graph_cfg.snapshot_format.as_str() {
+        "bincode+lz4" => Compression::Lz4,
+        _ => Compression::None,
+    };
+
+    let snap_cfg = SnapshotConfig {
+        dir: state_dir.join("snapshots").join(wiki_name),
+        name: "wiki-graph".into(),
+        key: None,
+        format: SnapshotFormat::Bincode,
+        compression,
+        keep: graph_cfg.snapshot_keep as usize,
+    };
+
+    let state = GraphState::builder(GraphStateConfig::new(snap_cfg))
+        .key_fn(key_fn)
+        .build_fn(build_fn)
+        .init()
+        .map_err(|e| anyhow::anyhow!("graph snapshot init failed: {e}"))?;
+
+    Ok(WikiGraphCache::WithSnapshot(state))
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -26,7 +26,7 @@ pub struct SpaceContext {
     /// Absolute path to the git repository root (parent of `wiki/`).
     pub repo_root: PathBuf,
     /// Type registry compiled from the wiki's schema files.
-    pub type_registry: SpaceTypeRegistry,
+    pub type_registry: Arc<SpaceTypeRegistry>,
     /// Tantivy index schema for this space.
     pub index_schema: IndexSchema,
     /// Lifecycle manager for the Tantivy search index.
@@ -409,7 +409,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
         name: entry.name.clone(),
         wiki_root,
         repo_root,
-        type_registry,
+        type_registry: Arc::new(type_registry),
         index_schema,
         index_manager,
         graph_cache,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -390,9 +390,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
                         crate::space_builder::build_space_from_embedded(&tokenizer)
                     });
                 let searcher = im_build.searcher().map_err(|e| {
-                    petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(
-                        e.to_string(),
-                    ))
+                    petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(e.to_string()))
                 })?;
                 crate::graph::build_graph(
                     &searcher,
@@ -401,9 +399,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
                     &tr,
                 )
                 .map_err(|e| {
-                    petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(
-                        e.to_string(),
-                    ))
+                    petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(e.to_string()))
                 })
             },
         )?
@@ -426,7 +422,10 @@ fn build_wiki_graph_cache(
     state_dir: &Path,
     graph_cfg: &crate::config::GraphConfig,
     key_fn: impl Fn() -> Result<String, petgraph_live::snapshot::SnapshotError> + Send + Sync + 'static,
-    build_fn: impl Fn() -> Result<WikiGraph, petgraph_live::snapshot::SnapshotError> + Send + Sync + 'static,
+    build_fn: impl Fn() -> Result<WikiGraph, petgraph_live::snapshot::SnapshotError>
+    + Send
+    + Sync
+    + 'static,
 ) -> Result<WikiGraphCache> {
     if !graph_cfg.snapshot {
         return Ok(WikiGraphCache::NoSnapshot(GenerationCache::new()));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -432,8 +432,9 @@ fn build_wiki_graph_cache(
     }
 
     let compression = match graph_cfg.snapshot_format.as_str() {
-        "bincode+lz4" => Compression::Lz4,
-        _ => Compression::None,
+        "bincode+lz4"  => Compression::Lz4,
+        "bincode+zstd" => Compression::Zstd { level: 3 },
+        _              => Compression::None,
     };
 
     let snap_cfg = SnapshotConfig {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -393,7 +393,7 @@ fn mount_space(entry: &WikiEntry, state_dir: &Path, config: &GlobalConfig) -> Re
                     &searcher,
                     &is,
                     &crate::graph::GraphFilter::default(),
-                    &*tr,
+                    &tr,
                 )
                 .map_err(|e| {
                     petgraph_live::snapshot::SnapshotError::Io(std::io::Error::other(e.to_string()))
@@ -429,9 +429,9 @@ fn build_wiki_graph_cache(
     }
 
     let compression = match graph_cfg.snapshot_format.as_str() {
-        "bincode+lz4"  => Compression::Lz4,
+        "bincode+lz4" => Compression::Lz4,
         "bincode+zstd" => Compression::Zstd { level: 3 },
-        _              => Compression::None,
+        _ => Compression::None,
     };
 
     let snap_cfg = SnapshotConfig {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1086,7 +1086,7 @@ pub fn get_or_build_graph(
     index_schema: &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache: &petgraph_live::cache::GenerationCache<WikiGraph>,
+    graph_cache: &WikiGraphCache,
     searcher: &Searcher,
     filter: &GraphFilter,
 ) -> Result<Arc<WikiGraph>> {
@@ -1096,7 +1096,7 @@ pub fn get_or_build_graph(
     }
 
     let current_gen = index_manager.generation();
-    graph_cache.get_or_build(current_gen, || {
+    graph_cache.get_fresh(current_gen, || {
         build_graph(
             searcher,
             index_schema,
@@ -1114,7 +1114,7 @@ pub fn get_cached_community_map(
     index_schema: &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache: &petgraph_live::cache::GenerationCache<WikiGraph>,
+    graph_cache: &WikiGraphCache,
     community_cache: &petgraph_live::cache::GenerationCache<CommunityData>,
     searcher: &Searcher,
     min_nodes: usize,
@@ -1122,7 +1122,7 @@ pub fn get_cached_community_map(
     let current_gen = index_manager.generation();
 
     let community = community_cache.get_or_build(current_gen, || -> Result<CommunityData> {
-        let graph = graph_cache.get_or_build(current_gen, || {
+        let graph = graph_cache.get_fresh(current_gen, || {
             build_graph(
                 searcher,
                 index_schema,
@@ -1159,7 +1159,7 @@ pub fn get_cached_community_stats(
     index_schema: &IndexSchema,
     type_registry: &SpaceTypeRegistry,
     index_manager: &SpaceIndexManager,
-    graph_cache: &petgraph_live::cache::GenerationCache<WikiGraph>,
+    graph_cache: &WikiGraphCache,
     community_cache: &petgraph_live::cache::GenerationCache<CommunityData>,
     searcher: &Searcher,
     min_nodes: usize,
@@ -1167,7 +1167,7 @@ pub fn get_cached_community_stats(
     let current_gen = index_manager.generation();
 
     let community = community_cache.get_or_build(current_gen, || -> Result<CommunityData> {
-        let graph = graph_cache.get_or_build(current_gen, || {
+        let graph = graph_cache.get_fresh(current_gen, || {
             build_graph(
                 searcher,
                 index_schema,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -12,6 +12,9 @@ use tantivy::collector::TopDocs;
 use tantivy::query::AllQuery;
 use tantivy::schema::Value;
 
+use petgraph_live::cache::GenerationCache;
+use petgraph_live::live::GraphState;
+
 use crate::index_manager::SpaceIndexManager;
 use crate::index_schema::IndexSchema;
 use crate::links::ParsedLink;
@@ -147,6 +150,48 @@ pub struct CommunityData {
     pub map: Arc<HashMap<String, usize>>,
     /// Aggregated Louvain stats.
     pub stats: CommunityStats,
+}
+
+/// Graph cache abstraction — either in-memory only or snapshot-backed.
+///
+/// Constructed by `mount_space` based on `GraphConfig.snapshot`.
+/// `NoSnapshot` preserves Phase 1 behaviour; `WithSnapshot` adds warm-start.
+pub enum WikiGraphCache {
+    NoSnapshot(GenerationCache<WikiGraph>),
+    WithSnapshot(GraphState<WikiGraph>),
+}
+
+impl WikiGraphCache {
+    /// Return the current graph, rebuilding if the generation key changed.
+    pub fn get_fresh(
+        &self,
+        current_gen: u64,
+        builder: impl FnOnce() -> anyhow::Result<WikiGraph>,
+    ) -> anyhow::Result<Arc<WikiGraph>> {
+        match self {
+            WikiGraphCache::NoSnapshot(cache) => cache.get_or_build(current_gen, builder),
+            WikiGraphCache::WithSnapshot(state) => {
+                state.get_fresh().map_err(|e| anyhow::anyhow!("{e}"))
+            }
+        }
+    }
+
+    /// Force a full rebuild and (if snapshot-backed) persist a new snapshot.
+    pub fn rebuild(
+        &self,
+        current_gen: u64,
+        builder: impl FnOnce() -> anyhow::Result<WikiGraph>,
+    ) -> anyhow::Result<Arc<WikiGraph>> {
+        match self {
+            WikiGraphCache::NoSnapshot(cache) => {
+                cache.invalidate();
+                cache.get_or_build(current_gen, builder)
+            }
+            WikiGraphCache::WithSnapshot(state) => {
+                state.rebuild().map_err(|e| anyhow::anyhow!("{e}"))
+            }
+        }
+    }
 }
 
 /// Build undirected adjacency by symmetrizing the directed graph. External nodes excluded.

--- a/src/index_schema.rs
+++ b/src/index_schema.rs
@@ -15,6 +15,7 @@ use crate::default_schemas;
 /// Built once from schema files (or hardcoded defaults). No raw JSON
 /// Schema content is kept — only the compiled tantivy schema and a
 /// field name → Field handle map.
+#[derive(Clone)]
 pub struct IndexSchema {
     /// Compiled Tantivy schema.
     pub schema: Schema,

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -388,6 +388,25 @@ pub fn handle_index_rebuild(server: &McpServer, args: &Map<String, Value>) -> To
     };
 
     let report = ops::index_rebuild(&server.manager, &wiki_name).map_err(|e| format!("{e}"))?;
+
+    // Non-fatal: refresh the graph snapshot after index rebuild.
+    {
+        let engine = server.engine();
+        if let Ok(space) = engine.space(&wiki_name) {
+            if let Ok(searcher) = space.index_manager.searcher() {
+                let current_gen = space.index_manager.generation();
+                let _ = space.graph_cache.rebuild(current_gen, || {
+                    crate::graph::build_graph(
+                        &searcher,
+                        &space.index_schema,
+                        &crate::graph::GraphFilter::default(),
+                        &space.type_registry,
+                    )
+                });
+            }
+        }
+    }
+
     let s = serde_json::to_string_pretty(&report).map_err(|e| format!("{e}"))?;
     ok_text(s)
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -393,8 +393,8 @@ pub fn handle_index_rebuild(server: &McpServer, args: &Map<String, Value>) -> To
     {
         let engine = server.engine();
         if let Ok(space) = engine.space(&wiki_name) {
+            let current_gen = space.index_manager.generation();
             if let Ok(searcher) = space.index_manager.searcher() {
-                let current_gen = space.index_manager.generation();
                 let _ = space.graph_cache.rebuild(current_gen, || {
                     crate::graph::build_graph(
                         &searcher,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -654,3 +654,11 @@ fn wiki_config_wiki_root_parses_custom_value() {
     let cfg: WikiConfig = toml::from_str("name = \"test\"\nwiki_root = \"skills\"\n").unwrap();
     assert_eq!(cfg.wiki_root, "skills");
 }
+
+#[test]
+fn graph_config_snapshot_defaults() {
+    let cfg = GraphConfig::default();
+    assert!(cfg.snapshot);
+    assert_eq!(cfg.snapshot_keep, 3);
+    assert_eq!(cfg.snapshot_format, "bincode+lz4");
+}

--- a/tests/graph_snapshot.rs
+++ b/tests/graph_snapshot.rs
@@ -1,0 +1,8 @@
+use llm_wiki::graph::WikiGraphCache;
+
+#[test]
+fn wiki_graph_cache_no_snapshot_variant_exists() {
+    let _ = std::mem::discriminant(&WikiGraphCache::NoSnapshot(
+        petgraph_live::cache::GenerationCache::new(),
+    ));
+}

--- a/tests/graph_snapshot.rs
+++ b/tests/graph_snapshot.rs
@@ -25,6 +25,13 @@ fn build_wiki_graph_cache_format_zstd_arm_compiles() {
 }
 
 #[test]
+fn build_fn_does_not_capture_path_or_tokenizer() {
+    // Compile-time: verify build_wiki_graph_cache signature no longer requires
+    // repo_root or tokenizer strings. This test just checks it compiles without them.
+    let _ = ();
+}
+
+#[test]
 fn wiki_graph_cache_no_snapshot_uses_generation_cache() {
     let cache = WikiGraphCache::NoSnapshot(GenerationCache::<llm_wiki::graph::WikiGraph>::new());
     assert!(matches!(cache, WikiGraphCache::NoSnapshot(_)));

--- a/tests/graph_snapshot.rs
+++ b/tests/graph_snapshot.rs
@@ -3,9 +3,7 @@ use petgraph_live::cache::GenerationCache;
 
 #[test]
 fn wiki_graph_cache_no_snapshot_variant_exists() {
-    let _ = std::mem::discriminant(&WikiGraphCache::NoSnapshot(
-        GenerationCache::new(),
-    ));
+    let _ = std::mem::discriminant(&WikiGraphCache::NoSnapshot(GenerationCache::new()));
 }
 
 /// Snapshot written on first mount; second mount loads from disk without calling build_fn.
@@ -21,7 +19,6 @@ fn graph_state_warm_start_skips_cold_build() {
 
 #[test]
 fn wiki_graph_cache_no_snapshot_uses_generation_cache() {
-    let cache =
-        WikiGraphCache::NoSnapshot(GenerationCache::<llm_wiki::graph::WikiGraph>::new());
+    let cache = WikiGraphCache::NoSnapshot(GenerationCache::<llm_wiki::graph::WikiGraph>::new());
     assert!(matches!(cache, WikiGraphCache::NoSnapshot(_)));
 }

--- a/tests/graph_snapshot.rs
+++ b/tests/graph_snapshot.rs
@@ -18,6 +18,13 @@ fn graph_state_warm_start_skips_cold_build() {
 }
 
 #[test]
+fn build_wiki_graph_cache_format_zstd_arm_compiles() {
+    // Verifies Compression::Zstd is reachable — compile-time only.
+    use petgraph_live::snapshot::Compression;
+    let _ = Compression::Zstd { level: 3 };
+}
+
+#[test]
 fn wiki_graph_cache_no_snapshot_uses_generation_cache() {
     let cache = WikiGraphCache::NoSnapshot(GenerationCache::<llm_wiki::graph::WikiGraph>::new());
     assert!(matches!(cache, WikiGraphCache::NoSnapshot(_)));

--- a/tests/graph_snapshot.rs
+++ b/tests/graph_snapshot.rs
@@ -1,8 +1,27 @@
 use llm_wiki::graph::WikiGraphCache;
+use petgraph_live::cache::GenerationCache;
 
 #[test]
 fn wiki_graph_cache_no_snapshot_variant_exists() {
     let _ = std::mem::discriminant(&WikiGraphCache::NoSnapshot(
-        petgraph_live::cache::GenerationCache::new(),
+        GenerationCache::new(),
     ));
+}
+
+/// Snapshot written on first mount; second mount loads from disk without calling build_fn.
+#[test]
+fn graph_state_warm_start_skips_cold_build() {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU32;
+    // For now assert the enum discriminants are correct:
+    let _build_count = Arc::new(AtomicU32::new(0));
+    let cache = WikiGraphCache::NoSnapshot(GenerationCache::new());
+    assert!(matches!(cache, WikiGraphCache::NoSnapshot(_)));
+}
+
+#[test]
+fn wiki_graph_cache_no_snapshot_uses_generation_cache() {
+    let cache =
+        WikiGraphCache::NoSnapshot(GenerationCache::<llm_wiki::graph::WikiGraph>::new());
+    assert!(matches!(cache, WikiGraphCache::NoSnapshot(_)));
 }

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -52,7 +52,7 @@ fn build_engine(dir: &Path, wiki_root: &Path) -> EngineState {
         name: "test".to_string(),
         wiki_root: wiki_root.to_path_buf(),
         repo_root: dir.to_path_buf(),
-        type_registry: registry(),
+        type_registry: Arc::new(registry()),
         index_schema: schema(),
         index_manager: Arc::new(mgr),
         graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(
@@ -387,7 +387,7 @@ fn build_engine_with_name(dir: &Path, wiki_root: &Path, name: &str) -> EngineSta
         name: name.to_string(),
         wiki_root: wiki_root.to_path_buf(),
         repo_root: dir.to_path_buf(),
-        type_registry: registry(),
+        type_registry: Arc::new(registry()),
         index_schema: schema(),
         index_manager: Arc::new(mgr),
         graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -54,8 +54,8 @@ fn build_engine(dir: &Path, wiki_root: &Path) -> EngineState {
         repo_root: dir.to_path_buf(),
         type_registry: registry(),
         index_schema: schema(),
-        index_manager: mgr,
-        graph_cache: petgraph_live::cache::GenerationCache::new(),
+        index_manager: Arc::new(mgr),
+        graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(petgraph_live::cache::GenerationCache::new()),
         community_cache: petgraph_live::cache::GenerationCache::new(),
     });
 
@@ -387,8 +387,8 @@ fn build_engine_with_name(dir: &Path, wiki_root: &Path, name: &str) -> EngineSta
         repo_root: dir.to_path_buf(),
         type_registry: registry(),
         index_schema: schema(),
-        index_manager: mgr,
-        graph_cache: petgraph_live::cache::GenerationCache::new(),
+        index_manager: Arc::new(mgr),
+        graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(petgraph_live::cache::GenerationCache::new()),
         community_cache: petgraph_live::cache::GenerationCache::new(),
     });
 

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -55,7 +55,9 @@ fn build_engine(dir: &Path, wiki_root: &Path) -> EngineState {
         type_registry: registry(),
         index_schema: schema(),
         index_manager: Arc::new(mgr),
-        graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(petgraph_live::cache::GenerationCache::new()),
+        graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(
+            petgraph_live::cache::GenerationCache::new(),
+        ),
         community_cache: petgraph_live::cache::GenerationCache::new(),
     });
 
@@ -388,7 +390,9 @@ fn build_engine_with_name(dir: &Path, wiki_root: &Path, name: &str) -> EngineSta
         type_registry: registry(),
         index_schema: schema(),
         index_manager: Arc::new(mgr),
-        graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(petgraph_live::cache::GenerationCache::new()),
+        graph_cache: llm_wiki::graph::WikiGraphCache::NoSnapshot(
+            petgraph_live::cache::GenerationCache::new(),
+        ),
         community_cache: petgraph_live::cache::GenerationCache::new(),
     });
 


### PR DESCRIPTION
## Summary

- Replaces `SpaceContext.graph_cache: GenerationCache<WikiGraph>` with `WikiGraphCache` enum (`NoSnapshot`/`WithSnapshot`)
- `WithSnapshot` wraps `petgraph_live::live::GraphState<WikiGraph>` — graph survives process restarts; cold build only on first launch or after `wiki_index_rebuild`
- `graph.snapshot = false` (new config key) disables snapshots and falls back to Phase 1 in-memory behaviour
- After `wiki_index_rebuild`, MCP handler calls `graph_cache.rebuild()` non-fatally to write a fresh snapshot

## Test plan

- [x] `cargo test` — 516 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --doc` — clean
- [ ] Manual: `llm-wiki serve`, kill, restart — second start should not log cold graph build