### PR TITLE
Fix Windows slug separator so nested pages use forward slashes

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -148,7 +148,8 @@ fn slug_from_path(abs_path: &Path, wiki_root: &Path) -> String {
         .unwrap_or(abs_path)
         .with_extension("")
         .to_string_lossy()
-        .into_owned()
+        // Slugs are always POSIX-style; normalize the OS path separator to `/`.
+        .replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 fn validate_file(

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -30,6 +30,9 @@ impl Slug {
         } else {
             rel.with_extension("").to_string_lossy().into_owned()
         };
+        // Slugs are always POSIX-style. Replace the OS path separator with `/`
+        // so nested pages get forward-slash slugs on every platform.
+        let raw = raw.replace(std::path::MAIN_SEPARATOR, "/");
         Self::try_from(raw.as_str())
     }
 

--- a/tests/slug.rs
+++ b/tests/slug.rs
@@ -67,6 +67,26 @@ fn from_path_outside_root() {
     assert!(Slug::from_path(path, root).is_err());
 }
 
+#[test]
+fn from_path_nested_uses_forward_slash() {
+    // Build the path with the OS separator (backslash on Windows) via `join`
+    // so the slug always comes out POSIX-style regardless of platform.
+    let root = Path::new("wiki");
+    let path = root.join("components").join("ai-schema-reviewer.md");
+    let s = Slug::from_path(&path, root).unwrap();
+    assert_eq!(s.as_str(), "components/ai-schema-reviewer");
+    assert!(!s.as_str().contains('\\'));
+}
+
+#[test]
+fn from_path_nested_bundle_uses_forward_slash() {
+    let root = Path::new("wiki");
+    let path = root.join("components").join("parser").join("index.md");
+    let s = Slug::from_path(&path, root).unwrap();
+    assert_eq!(s.as_str(), "components/parser");
+    assert!(!s.as_str().contains('\\'));
+}
+
 // ── Slug::title ───────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## The bug

On Windows, pages in subdirectories get slugs built with the backslash path separator. A page at `components/ai-schema-reviewer.md` gets the slug `components\ai-schema-reviewer` instead of `components/ai-schema-reviewer`. Top-level pages and section index pages have no separator, so they look correct, which hides the problem.

## Impact on Windows

- Graph and `wiki_stats`: nested pages show up as orphans. Body links use forward-slash slugs (the documented form), but the graph node keys hold backslashes, so the edge builder finds no match.
- `wiki_lint`: hundreds of false `broken-link` errors for the same reason.
- `wiki_search`: results show each page twice, once with `\` and once with `/`, because separators are not consistent across code paths.

## Root cause

`Slug::from_path` in `src/slug.rs` builds the slug from a relative `PathBuf` with `to_string_lossy()` and never normalizes the separator. On Windows the relative path uses `\`, so the slug keeps backslashes.

The indexed `slug` field comes straight from `Slug::from_path` (`src/index_manager.rs:294`, `src/index_manager.rs:305`). The graph builder uses that slug as the node key (`src/graph.rs:372`) and resolves body links by exact string match against those keys (`src/graph.rs:491`). Body links use `/`, node keys use `\`, so nothing matches. Search and list read the same indexed slug field, so they show the backslash form too.

There is a second copy of the same logic in the ingest redaction-report helper `slug_from_path` (`src/ingest.rs:145-152`) with the same defect.

## The fix

Normalize the OS path separator to `/` at slug construction time. `std::path::MAIN_SEPARATOR` is `/` on Unix, so this is a no-op there and only changes Windows behavior.

- `src/slug.rs`: `Slug::from_path` replaces `MAIN_SEPARATOR` with `/` before building the slug. This is the single source of truth for indexed slugs, so fixing it here corrects the graph, lint, search, and list paths.
- `src/ingest.rs`: `slug_from_path` gets the same one-line normalization for the redaction report label.

## Tests

Added two regression tests in `tests/slug.rs`. They build nested paths with the native separator through `Path::join`, so on Windows they use backslashes. They assert the slug comes out as `components/ai-schema-reviewer` (flat) and `components/parser` (bundle) with no backslash. The existing `from_path` tests use hardcoded forward-slash string literals, so they never exercised the Windows path.

## Verified locally on Windows

Built and tested on Windows (`x86_64-pc-windows-msvc`, Rust 1.95, the toolchain pinned in `rust-toolchain.toml`):

- `cargo test --test slug` passes all 34 tests, including the two new ones.
- To confirm the tests actually catch the bug, I reverted just the fix line and re-ran. The two new tests fail with `left: "components\ai-schema-reviewer"`. With the fix back in, they pass.

Note: the CI workflow (`ci.yml`) runs on `ubuntu-latest` only, where `MAIN_SEPARATOR` is already `/`, so CI will pass the tests but will not exercise the backslash case. The local Windows run above is what verifies the actual fix.
